### PR TITLE
Insert permission request for camera roll access in context

### DIFF
--- a/iOSClient/AppDelegate.m
+++ b/iOSClient/AppDelegate.m
@@ -188,19 +188,6 @@
     //[[AVAudioSession sharedInstance] setActive:YES error:nil];
     [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
     
-    // permission request camera roll
-    ALAssetsLibrary *lib = [[ALAssetsLibrary alloc] init];
-    
-    [lib enumerateGroupsWithTypes:ALAssetsGroupSavedPhotos usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
-        //NSLog(@"[LOG] %li",(long)[group numberOfAssets]);
-    } failureBlock:^(NSError *error) {
-        if (error.code == ALAssetsLibraryAccessUserDeniedError) {
-            NSLog(@"[LOG] user denied access, code: %li",(long)error.code);
-        }else{
-            NSLog(@"[LOG] Other error code: %li",(long)error.code);
-        }
-    }];
-    
     // permission request notification
     if ([application respondsToSelector:@selector(registerUserNotificationSettings:)]) {
         

--- a/iOSClient/Login/CCLogin.storyboard
+++ b/iOSClient/Login/CCLogin.storyboard
@@ -94,173 +94,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="sK9-Ew-RED" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4268" y="-955"/>
-        </scene>
-        <!--LoginNCOC-->
-        <scene sceneID="hY6-r4-8Lk">
-            <objects>
-                <viewController storyboardIdentifier="CCLoginOwnCloud" id="R0z-L3-spN" customClass="CCLoginNCOC" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="eMh-ck-Znl"/>
-                        <viewControllerLayoutGuide type="bottom" id="2RL-Xp-LTT"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="pn7-Hc-BAf">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="User" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="H0b-5A-vRO">
-                                <rect key="frame" x="50" y="196" width="319" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="j74-kN-LHM"/>
-                                </constraints>
-                                <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done"/>
-                            </textField>
-                            <textField opaque="NO" clipsSubviews="YES" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qsY-HN-NTO">
-                                <rect key="frame" x="50" y="234" width="273" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="QVB-Au-F7J"/>
-                                </constraints>
-                                <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <textInputTraits key="textInputTraits" returnKeyType="done" secureTextEntry="YES"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="i3A-7y-R1E">
-                                <rect key="frame" x="-4" y="275" width="383" height="50"/>
-                                <color key="backgroundColor" red="0.91764705879999997" green="0.26274509800000001" blue="0.1058823529" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="50" id="mNO-KB-37L"/>
-                                </constraints>
-                                <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <state key="normal" title="Accedi">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="handleButtonLogin:" destination="R0z-L3-spN" eventType="touchUpInside" id="sO2-a3-Dsu"/>
-                                </connections>
-                            </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="baseurl" translatesAutoresizingMaskIntoConstraints="NO" id="nzJ-WD-LS3">
-                                <rect key="frame" x="7" y="160" width="25" height="25"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="25" id="VGh-jJ-CU2"/>
-                                    <constraint firstAttribute="height" constant="25" id="lyd-V5-5Dd"/>
-                                </constraints>
-                            </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user" translatesAutoresizingMaskIntoConstraints="NO" id="Epv-G7-WxY">
-                                <rect key="frame" x="7" y="198" width="25" height="25"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="25" id="CI9-u8-Q4w"/>
-                                    <constraint firstAttribute="height" constant="25" id="wJz-Kg-ysv"/>
-                                </constraints>
-                            </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password" translatesAutoresizingMaskIntoConstraints="NO" id="dHJ-as-sqM">
-                                <rect key="frame" x="7" y="236" width="25" height="25"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="25" id="ZvH-2J-kIR"/>
-                                    <constraint firstAttribute="width" constant="25" id="rCR-hj-Zey"/>
-                                </constraints>
-                            </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ImageLoginOwncloud" translatesAutoresizingMaskIntoConstraints="NO" id="4hl-hN-WBB">
-                                <rect key="frame" x="112" y="30" width="167" height="120"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="167" id="8QJ-g2-FIN"/>
-                                    <constraint firstAttribute="height" constant="120" id="Cbz-Gc-3R9"/>
-                                </constraints>
-                            </imageView>
-                            <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="https://owncloud.yourdomain.com" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="D0R-AM-DFg">
-                                <rect key="frame" x="50" y="158" width="273" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="cvn-kn-gsR"/>
-                                </constraints>
-                                <color key="textColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done"/>
-                                <connections>
-                                    <action selector="handlebaseUrlchange:" destination="R0z-L3-spN" eventType="editingDidEnd" id="gMK-Ol-O4T"/>
-                                </connections>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BOk-cz-Mdy">
-                                <rect key="frame" x="309" y="28" width="54" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="54" id="RRe-BZ-9jz"/>
-                                </constraints>
-                                <state key="normal" title="Annulla">
-                                    <color key="titleColor" red="0.91764705879999997" green="0.26274509800000001" blue="0.1058823529" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="handleAnnulla:" destination="R0z-L3-spN" eventType="touchUpInside" id="6gV-dM-lnu"/>
-                                </connections>
-                            </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jA7-8D-Nih" userLabel="loadingBaseUrl">
-                                <rect key="frame" x="338" y="160" width="25" height="25"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="25" id="npn-xp-twa"/>
-                                    <constraint firstAttribute="width" constant="25" id="yfj-WE-ntb"/>
-                                </constraints>
-                            </imageView>
-                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qgh-Ys-Egc">
-                                <rect key="frame" x="338" y="236" width="25" height="25"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="25" id="Qzi-BS-FCX"/>
-                                    <constraint firstAttribute="height" constant="25" id="glI-8o-5GA"/>
-                                </constraints>
-                                <state key="normal" image="visiblePassword" backgroundImage="visiblePassword"/>
-                                <connections>
-                                    <action selector="handleToggleVisiblePassword:" destination="R0z-L3-spN" eventType="touchUpInside" id="lJI-TN-1Jd"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="H0b-5A-vRO" firstAttribute="top" secondItem="D0R-AM-DFg" secondAttribute="bottom" constant="8" id="0xN-d5-XKi"/>
-                            <constraint firstItem="qgh-Ys-Egc" firstAttribute="leading" secondItem="jA7-8D-Nih" secondAttribute="leading" id="59J-e8-0qV"/>
-                            <constraint firstItem="qsY-HN-NTO" firstAttribute="leading" secondItem="pn7-Hc-BAf" secondAttribute="leadingMargin" constant="34" id="6EI-yF-ALf"/>
-                            <constraint firstItem="H0b-5A-vRO" firstAttribute="leading" secondItem="pn7-Hc-BAf" secondAttribute="leadingMargin" constant="34" id="8e7-8s-mrP"/>
-                            <constraint firstItem="i3A-7y-R1E" firstAttribute="trailing" secondItem="pn7-Hc-BAf" secondAttribute="trailingMargin" constant="20" id="9lr-wd-Q8L"/>
-                            <constraint firstItem="dHJ-as-sqM" firstAttribute="leading" secondItem="pn7-Hc-BAf" secondAttribute="leadingMargin" constant="-9" id="AdM-FI-hC2"/>
-                            <constraint firstItem="i3A-7y-R1E" firstAttribute="leading" secondItem="pn7-Hc-BAf" secondAttribute="leadingMargin" constant="-20" id="BTR-w5-eOG"/>
-                            <constraint firstItem="dHJ-as-sqM" firstAttribute="top" secondItem="Epv-G7-WxY" secondAttribute="bottom" constant="13" id="Ccj-cl-l2J"/>
-                            <constraint firstItem="D0R-AM-DFg" firstAttribute="top" secondItem="eMh-ck-Znl" secondAttribute="bottom" constant="138" id="EvP-HX-gHx"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="H0b-5A-vRO" secondAttribute="trailing" constant="-10" id="Foo-yy-eNF"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="jA7-8D-Nih" secondAttribute="trailing" constant="-4" id="Gxd-wW-ySt"/>
-                            <constraint firstItem="D0R-AM-DFg" firstAttribute="leading" secondItem="pn7-Hc-BAf" secondAttribute="leadingMargin" constant="34" id="Jjk-CD-Mlf"/>
-                            <constraint firstItem="H0b-5A-vRO" firstAttribute="centerY" secondItem="Epv-G7-WxY" secondAttribute="centerY" constant="0.5" id="L3U-uQ-1YM"/>
-                            <constraint firstItem="Epv-G7-WxY" firstAttribute="leading" secondItem="pn7-Hc-BAf" secondAttribute="leadingMargin" constant="-9" id="NBj-8r-VIT"/>
-                            <constraint firstItem="D0R-AM-DFg" firstAttribute="centerY" secondItem="nzJ-WD-LS3" secondAttribute="centerY" constant="0.5" id="Ogq-tq-210"/>
-                            <constraint firstItem="jA7-8D-Nih" firstAttribute="leading" secondItem="D0R-AM-DFg" secondAttribute="trailing" constant="15" id="PtF-fc-2hL"/>
-                            <constraint firstAttribute="centerX" secondItem="4hl-hN-WBB" secondAttribute="centerX" constant="-8" id="Q6m-6L-yBG"/>
-                            <constraint firstItem="BOk-cz-Mdy" firstAttribute="trailing" secondItem="pn7-Hc-BAf" secondAttribute="trailingMargin" constant="4" id="S2o-f9-JcL"/>
-                            <constraint firstItem="nzJ-WD-LS3" firstAttribute="leading" secondItem="pn7-Hc-BAf" secondAttribute="leadingMargin" constant="-9" id="WOD-MQ-z8M"/>
-                            <constraint firstItem="qgh-Ys-Egc" firstAttribute="top" secondItem="dHJ-as-sqM" secondAttribute="top" id="YAy-wa-eMi"/>
-                            <constraint firstItem="qsY-HN-NTO" firstAttribute="top" secondItem="H0b-5A-vRO" secondAttribute="bottom" constant="8" id="aPe-nJ-kFS"/>
-                            <constraint firstItem="4hl-hN-WBB" firstAttribute="leading" secondItem="pn7-Hc-BAf" secondAttribute="leadingMargin" constant="209" id="bqp-Bb-Kq4"/>
-                            <constraint firstItem="4hl-hN-WBB" firstAttribute="top" secondItem="pn7-Hc-BAf" secondAttribute="top" constant="30" id="cb1-I0-dm2"/>
-                            <constraint firstItem="BOk-cz-Mdy" firstAttribute="top" secondItem="eMh-ck-Znl" secondAttribute="bottom" constant="8" id="jzI-r0-o1u"/>
-                            <constraint firstItem="i3A-7y-R1E" firstAttribute="top" secondItem="qsY-HN-NTO" secondAttribute="bottom" constant="11" id="pA3-WH-rBI"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="qsY-HN-NTO" secondAttribute="trailing" constant="36" id="qsk-wS-ykP"/>
-                            <constraint firstItem="jA7-8D-Nih" firstAttribute="top" secondItem="eMh-ck-Znl" secondAttribute="bottom" constant="140" id="zLF-Pj-AF0"/>
-                        </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="bqp-Bb-Kq4"/>
-                            </mask>
-                        </variation>
-                    </view>
-                    <connections>
-                        <outlet property="annulla" destination="BOk-cz-Mdy" id="wzh-D9-0J1"/>
-                        <outlet property="baseUrl" destination="D0R-AM-DFg" id="92H-lh-vQS"/>
-                        <outlet property="loadingBaseUrl" destination="jA7-8D-Nih" id="7Wg-jz-Oy0"/>
-                        <outlet property="login" destination="i3A-7y-R1E" id="Twm-R4-Oa0"/>
-                        <outlet property="password" destination="qsY-HN-NTO" id="iBK-JM-qpJ"/>
-                        <outlet property="toggleVisiblePassword" destination="qgh-Ys-Egc" id="dua-Tg-yl5"/>
-                        <outlet property="user" destination="H0b-5A-vRO" id="n8R-Sa-g8o"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="UpX-iO-TqU" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="3622" y="-955"/>
+            <point key="canvasLocation" x="3726" y="-956"/>
         </scene>
         <!--LoginNCOC-->
         <scene sceneID="fVe-zF-WhZ">
@@ -428,16 +262,12 @@
     </scenes>
     <resources>
         <image name="ImageLoginNextcloud" width="300" height="200"/>
-        <image name="ImageLoginOwncloud" width="300" height="200"/>
-        <image name="baseurl" width="25" height="25"/>
         <image name="baseurlNextcloud" width="25" height="25"/>
         <image name="cryptocloudlaunchscreen" width="125" height="170"/>
         <image name="newAccountDropBox" width="50" height="50"/>
         <image name="newAccountNextcloud" width="50" height="50"/>
         <image name="newAccountOwnCloud" width="50" height="50"/>
-        <image name="password" width="25" height="25"/>
         <image name="passwordNextcloud" width="25" height="25"/>
-        <image name="user" width="25" height="25"/>
         <image name="userNextcloud" width="25" height="25"/>
         <image name="visiblePassword" width="25" height="25"/>
     </resources>

--- a/iOSClient/PhotosCameraUpload/CCPhotosCameraUpload.m
+++ b/iOSClient/PhotosCameraUpload/CCPhotosCameraUpload.m
@@ -307,15 +307,11 @@
 
 - (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView
 {    
-    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
-        
-        // If the user has previously granted or denied photo library access permission, it executes the handler block when called; otherwise, it displays an alert and executes the block only after the user has responded to the alert.
-        CCManageCameraUpload *viewController = [[CCManageCameraUpload alloc] initWithNibName:nil bundle:nil];
+    CCManageCameraUpload *viewController = [[CCManageCameraUpload alloc] initWithNibName:nil bundle:nil];
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
         
         [navigationController setModalPresentationStyle:UIModalPresentationFullScreen];
         [self presentViewController:navigationController animated:YES completion:nil];
-    }];
 }
 
 #pragma --------------------------------------------------------------------------------------------

--- a/iOSClient/PhotosCameraUpload/CCPhotosCameraUpload.m
+++ b/iOSClient/PhotosCameraUpload/CCPhotosCameraUpload.m
@@ -307,11 +307,15 @@
 
 - (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView
 {    
-    CCManageCameraUpload *viewController = [[CCManageCameraUpload alloc] initWithNibName:nil bundle:nil];
-    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
-    
-    [navigationController setModalPresentationStyle:UIModalPresentationFullScreen];
-    [self presentViewController:navigationController animated:YES completion:nil];
+    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+        
+        // If the user has previously granted or denied photo library access permission, it executes the handler block when called; otherwise, it displays an alert and executes the block only after the user has responded to the alert.
+        CCManageCameraUpload *viewController = [[CCManageCameraUpload alloc] initWithNibName:nil bundle:nil];
+        UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+        
+        [navigationController setModalPresentationStyle:UIModalPresentationFullScreen];
+        [self presentViewController:navigationController animated:YES completion:nil];
+    }];
 }
 
 #pragma --------------------------------------------------------------------------------------------

--- a/iOSClient/PhotosCameraUpload/CCPhotosCameraUpload.m
+++ b/iOSClient/PhotosCameraUpload/CCPhotosCameraUpload.m
@@ -308,10 +308,10 @@
 - (void)emptyDataSetDidTapButton:(UIScrollView *)scrollView
 {    
     CCManageCameraUpload *viewController = [[CCManageCameraUpload alloc] initWithNibName:nil bundle:nil];
-        UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
         
-        [navigationController setModalPresentationStyle:UIModalPresentationFullScreen];
-        [self presentViewController:navigationController animated:YES completion:nil];
+    [navigationController setModalPresentationStyle:UIModalPresentationFullScreen];
+    [self presentViewController:navigationController animated:YES completion:nil];
 }
 
 #pragma --------------------------------------------------------------------------------------------

--- a/iOSClient/Settings/CCManageCameraUpload.m
+++ b/iOSClient/Settings/CCManageCameraUpload.m
@@ -62,6 +62,9 @@
 
     form = [XLFormDescriptor formDescriptorWithTitle:NSLocalizedString(@"_uploading_from_camera_", nil)];
     
+    // Request permission for camera roll access
+    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status){}];
+    
     // Camera Upload
     
     section = [XLFormSectionDescriptor formSection];


### PR DESCRIPTION
A permission request for camera roll access is happening on app launch - together with notifications request - causing two alerts straight after each other, possibly leading to confusion. This commit removes it.
The permission is already being requested when access is really needed in CCMain.m (`PHPhotoLibrary requestAuthorization`), using the up-to-date iOS 8+ Photos framework, therefore making the call in AppDelegate.m unnecessary.