### PR TITLE
Remove old logic for ownCloud < 8

### DIFF
--- a/iOSClient/CCGlobal.h
+++ b/iOSClient/CCGlobal.h
@@ -93,9 +93,7 @@ extern NSString *const BKPasscodeKeychainServiceName;
 // Picker select image
 #define k_pickerControllerMax                           100.0
 
-// define ownCloud IOS
-#define server_version_with_new_shared_schema 8
-#define k_share_link_middle_part_url_before_version_8   @"public.php?service=files&t="
+// define Nextcloud IOS
 #define k_share_link_middle_part_url_after_version_8    @"index.php/s/"
 
 // Constants to identify the different permissions of a file

--- a/iOSClient/Share/CCShareOC.m
+++ b/iOSClient/Share/CCShareOC.m
@@ -262,20 +262,9 @@
         url = sharedLink;
         
     } else {
-        
-        //Token
-        NSString *firstNumber = [[CCNetworking sharedNetworking].sharedOCCommunication.getCurrentServerVersion substringToIndex:1];
-        
-        if (firstNumber.integerValue >= server_version_with_new_shared_schema) {
-            
-            // From ownCloud server version 8 on, a different share link scheme is used.
-            
-            url = [NSString stringWithFormat:@"%@/%@%@", app.activeUrl, k_share_link_middle_part_url_after_version_8, sharedLink];
-            
-        }else{
-            
-            url = [NSString stringWithFormat:@"%@/%@%@", app.activeUrl, k_share_link_middle_part_url_before_version_8, sharedLink];
-        }
+
+        url = [NSString stringWithFormat:@"%@/%@%@", app.activeUrl, k_share_link_middle_part_url_after_version_8, sharedLink];
+
     }
 
     NSArray *activityItems = @[[NSString stringWithFormat:@""], [NSURL URLWithString:url]];


### PR DESCRIPTION
The old logic isn't required anymore and also seems to be buggy. If the version is "11.0.0" then `firstNumber` would be "1" which later in the comparison would fall into the else block and thus generate a link to the old invalid endpoint.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>