### PR TITLE
Fixes System Share menu not consistently presenting from CCMain

### DIFF
--- a/iOSClient/Favorites/CCFavorites.m
+++ b/iOSClient/Favorites/CCFavorites.m
@@ -392,7 +392,7 @@
         _docController = [UIDocumentInteractionController interactionControllerWithURL:url];
         _docController.delegate = self;
         
-        [_docController presentOptionsMenuFromRect:self.view.frame inView:self.view animated:YES];
+        [_docController presentOptionsMenuFromRect:self.view.frame inView:self.view.superview animated:YES];
     }
 }
 

--- a/iOSClient/Main/CCMain.m
+++ b/iOSClient/Main/CCMain.m
@@ -1481,7 +1481,7 @@
         _docController = [UIDocumentInteractionController interactionControllerWithURL:url];
         _docController.delegate = self;
         
-        [_docController presentOptionsMenuFromRect:self.view.frame inView:self.view animated:YES];
+        [_docController presentOptionsMenuFromRect:self.view.frame inView:self.view.superview animated:YES];
     }
     
     // Save to Photo Album


### PR DESCRIPTION
Background:
I first noticed this when I reported Issue #293. Further testing revealed that this affects sharing of all files from the Main File menu, not just files without previews - it's just more obvious with files that can't be previewed because it should open the Share menu automatically.

This affects both iOS 10 and 11.

Fix:
When showing System Options Menu from CCFavorites and CCMain, now passes the superview as the view the menu should be shown in. It looks like there's a system issue with trying to present the options menu from a view's frame within that view.
