### PR TITLE
Allows to build the custom brands

### DIFF
--- a/iOSClient/Brand/NCBridgeSwift.h
+++ b/iOSClient/Brand/NCBridgeSwift.h
@@ -24,11 +24,7 @@
 // Nextcloud App
 #if !defined(EXTENSION)
 
-    #if defined(CUSTOM_BUILD)
-        #import "CustomSwift.h"
-    #else
-        #import "Nextcloud-Swift.h"
-    #endif
+    #import "Nextcloud-Swift.h"
 
 #endif
 


### PR DESCRIPTION
With this custom builds are possible. Otherwise they fail with this:

```
...
In file included from /Users/morrisjobke/Projects/nextcloud/ios-test/iOSClient/UploadFromOtherUpp/CCUploadFromOtherUpp.m:26:
In file included from /Users/morrisjobke/Projects/nextcloud/ios-test/iOSClient/Brand/NCBridgeSwift.h:28:
/Users/morrisjobke/Projects/nextcloud/ios-test/iOSClient/Brand/CustomSwift.h:2:9: fatal error: 'Custom-Swift.h' file not found
#import "Custom-Swift.h"
        ^~~~~~~~~~~~~~~~
1 error generated.
```

Found together with @mario 