### PR TITLE
Removing endless spaces at the end of lines in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
-### Expected behaviour                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+### Expected behaviour
 
-### Actual behaviour                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
+### Actual behaviour
 
-### Steps to reproduce                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+### Steps to reproduce
 
 ### iOS version
 


### PR DESCRIPTION
The template for new issues had a huge amount of spaces at the end of the top three lines. As they are unnecessary and just confuse editors, I removed them.