### PR TITLE
Show toolbar for external sites

### DIFF
--- a/iOSClient/Library/SwiftWebVC/SwiftModalWebVC.swift
+++ b/iOSClient/Library/SwiftWebVC/SwiftModalWebVC.swift
@@ -46,12 +46,15 @@ public class SwiftModalWebVC: UINavigationController {
         self.init(request: URLRequest(url: pageURL), theme: theme, color: color, colorText: colorText, doneButtonVisible: doneButtonVisible, hideToolbar: hideToolbar)
     }
    
-    public init(request: URLRequest, theme: SwiftModalWebVCTheme = .dark, color: UIColor = UIColor.clear, colorText: UIColor = UIColor.black, doneButtonVisible: Bool = false, hideToolbar: Bool = false) {
+    public init(request: URLRequest, theme: SwiftModalWebVCTheme = .dark, color: UIColor = UIColor.clear, colorText: UIColor = UIColor.black, doneButtonVisible: Bool = true, hideToolbar: Bool = true) {
         
         let webViewController = SwiftWebVC(aRequest: request, hideToolbar: hideToolbar)
         webViewController.storedStatusColor = UINavigationBar.appearance().barStyle
         
         super.init(rootViewController: webViewController)
+
+        webViewController.navigationController?.navigationBar.isTranslucent = false
+        webViewController.navigationController?.navigationBar.barTintColor = NCBrandColor.sharedInstance.brand
 
         let doneButton = UIBarButtonItem(image: SwiftWebVC.bundledImage(named: "SwiftWebVCDismiss"),
                                          style: UIBarButtonItemStyle.plain,


### PR DESCRIPTION
@marinofaggiana I got this as patch to solve the issue, when you have an external site configured and you want to close the web view there was no close or back button. With this change there is one.

Does that make sense?
