### PR TITLE
Show modification date for files older than 30 days

### DIFF
--- a/iOSClient/Main/NCMainCommon.swift
+++ b/iOSClient/Main/NCMainCommon.swift
@@ -283,7 +283,7 @@ class NCMainCommon: NSObject {
             } else {
                 
                 cell.imageItem.image = image
-                cell.labelInfo.text = CCUtility.dateDiff(metadata.date as Date) + " " + CCUtility.transformedSize(metadata.size)
+                cell.labelInfo.text = CCUtility.dateDiff(metadata.date as Date) + ", " + CCUtility.transformedSize(metadata.size)
                 
                 // image Local
                 let tableLocalFile = NCManageDatabase.sharedInstance.getTableLocalFile(predicate: NSPredicate(format: "fileID == %@", metadata.fileID))
@@ -537,7 +537,7 @@ class NCMainCommon: NSObject {
                 let iconFileExists = FileManager.default.fileExists(atPath: CCUtility.getDirectoryProviderStorageIconFileID(metadata.fileID, fileNameView: metadata.fileNameView))
                 
                 // Lable Info
-                cell.labelInfoFile.text = CCUtility.dateDiff(metadata.date as Date) + " " + CCUtility.transformedSize(metadata.size)
+                cell.labelInfoFile.text = CCUtility.dateDiff(metadata.date as Date) + ", " + CCUtility.transformedSize(metadata.size)
                 
                 // File Image
                 if iconFileExists {

--- a/iOSClient/Trash/NCTrash.swift
+++ b/iOSClient/Trash/NCTrash.swift
@@ -654,7 +654,7 @@ class NCTrash: UIViewController ,UICollectionViewDataSource, UICollectionViewDel
                 cell.labelInfo.text = CCUtility.dateDiff(tableTrash.date as Date)
             } else {
                 cell.imageItem.image = image
-                cell.labelInfo.text = CCUtility.dateDiff(tableTrash.date as Date) + " " + CCUtility.transformedSize(tableTrash.size)
+                cell.labelInfo.text = CCUtility.dateDiff(tableTrash.date as Date) + ", " + CCUtility.transformedSize(tableTrash.size)
             }
             
             if isEditMode {

--- a/iOSClient/Utility/CCUtility.m
+++ b/iOSClient/Utility/CCUtility.m
@@ -557,7 +557,7 @@
 }
 
 #pragma --------------------------------------------------------------------------------------------
-#pragma mark ===== Varius =====
+#pragma mark ===== Various =====
 #pragma --------------------------------------------------------------------------------------------
 
 + (NSString *)getUserAgent
@@ -569,27 +569,30 @@
 
 + (NSString *)dateDiff:(NSDate *) convertedDate
 {
-    NSDateFormatter *df = [[NSDateFormatter alloc] init];
-    [df setFormatterBehavior:NSDateFormatterBehavior10_4];
-    [df setDateFormat:@"EEE, dd MMM yy HH:mm:ss VVVV"];
-    //NSDate *convertedDate = [df dateFromString:origDate];
-    //NSDate *convertedDate = [NSDate dateWithTimeIntervalSince1970:origDate];
     NSDate *todayDate = [NSDate date];
     double ti = [convertedDate timeIntervalSinceDate:todayDate];
     ti = ti * -1;
     if (ti < 60) {
+        // This minute
         return NSLocalizedString(@"_less_a_minute_", nil);
     } else if (ti < 3600) {
+        // This hour
         int diff = round(ti / 60);
         return [NSString stringWithFormat:NSLocalizedString(@"_minutes_ago_", nil), diff];
     } else if (ti < 86400) {
+        // This day
         int diff = round(ti / 60 / 60);
         return[NSString stringWithFormat:NSLocalizedString(@"_hours_ago_", nil), diff];
-    } else if (ti < 2629743) {
+    } else if (ti < 86400 * 30) {
+        // This month
         int diff = round(ti / 60 / 60 / 24);
         return[NSString stringWithFormat:NSLocalizedString(@"_days_ago_", nil), diff];
     } else {
-        return NSLocalizedString(@"_over_30_days_", nil);
+        // Older than one month
+        NSDateFormatter *df = [[NSDateFormatter alloc] init];
+        [df setFormatterBehavior:NSDateFormatterBehavior10_4];
+        [df setDateStyle:NSDateFormatterMediumStyle];
+        return [df stringFromDate:convertedDate];
     }
 }
 


### PR DESCRIPTION
As mentioned in #636, for files older than 30 days the iOS client now displays the file modification date rather than the "over 30 days" message (in human-readable, locale-specific format).

![bildschirmfoto 2018-12-21 um 10 14 24](https://user-images.githubusercontent.com/25565229/50334707-680c6c80-0509-11e9-924d-570c41da1816.png)