### PR TITLE
Provide a banal 'paste' postmessage implementation.

### DIFF
--- a/iOSClient/Viewer/NCViewerRichdocument.swift
+++ b/iOSClient/Viewer/NCViewerRichdocument.swift
@@ -111,6 +111,11 @@ class NCViewerRichdocument: WKWebView, WKNavigationDelegate, WKScriptMessageHand
             if message.body as! String == "share" {
                 appDelegate.activeMain.openShare(with: self.detail.metadataDetail)
             }
+
+	    // Javascript cannot do this by itself, so help out.
+            if message.body as! String == "paste" {
+                self.paste(self)
+            }
         }
     }
     


### PR DESCRIPTION
Browsers will allow apps to populate the clipboard, but not read
from it without user input. This patch makes it possible for
context menus with 'Paste' in them to trigger a real OS paste
when hosted inside the webview.