### PR TITLE
Improve scroll performance

### DIFF
--- a/iOSClient/Main/CCMain.m
+++ b/iOSClient/Main/CCMain.m
@@ -75,6 +75,10 @@
     BOOL _loadingFolder;
     tableMetadata *_metadataFolder;
 }
+
+@property (nonatomic, readonly, strong) UIImage *cellFavouriteImage;
+@property (nonatomic, readonly, strong) UIImage *cellTrashImage;
+
 @end
 
 @implementation CCMain
@@ -120,6 +124,9 @@
     _searchFileName = @"";
     _noFilesSearchTitle = @"";
     _noFilesSearchDescription = @"";
+    
+    _cellFavouriteImage = [CCGraphics changeThemingColorImage:[UIImage imageNamed:@"favorite"] width:50 height:50 color:[UIColor whiteColor]];
+    _cellTrashImage = [CCGraphics changeThemingColorImage:[UIImage imageNamed:@"trash"] width:50 height:50 color:[UIColor whiteColor]];
     
     // delegate
     self.tableView.delegate = self;
@@ -3818,7 +3825,7 @@
         ((CCCellMain *)cell).delegate = self;
 
         // LEFT
-        ((CCCellMain *)cell).leftButtons = @[[MGSwipeButton buttonWithTitle:@"" icon:[CCGraphics changeThemingColorImage:[UIImage imageNamed:@"favorite"] width:50 height:50 color:[UIColor whiteColor]] backgroundColor:[NCBrandColor sharedInstance].yellowFavorite padding:25]];
+        ((CCCellMain *)cell).leftButtons = @[[MGSwipeButton buttonWithTitle:@"" icon:self.cellFavouriteImage backgroundColor:[NCBrandColor sharedInstance].yellowFavorite padding:25]];
         
         ((CCCellMain *)cell).leftExpansion.buttonIndex = 0;
         ((CCCellMain *)cell).leftExpansion.fillOnTrigger = NO;
@@ -3828,7 +3835,7 @@
         [favoriteButton centerIconOverText];
         
         // RIGHT
-        ((CCCellMain *)cell).rightButtons = @[[MGSwipeButton buttonWithTitle:@"" icon:[CCGraphics changeThemingColorImage:[UIImage imageNamed:@"trash"] width:50 height:50 color:[UIColor whiteColor]] backgroundColor:[UIColor redColor] padding:25]];
+        ((CCCellMain *)cell).rightButtons = @[[MGSwipeButton buttonWithTitle:@"" icon:self.cellTrashImage backgroundColor:[UIColor redColor] padding:25]];
         
         ((CCCellMain *)cell).rightExpansion.buttonIndex = 0;
         ((CCCellMain *)cell).rightExpansion.fillOnTrigger = NO;

--- a/iOSClient/Main/NCMainCommon.swift
+++ b/iOSClient/Main/NCMainCommon.swift
@@ -29,6 +29,14 @@ import ZIPFoundation
 
 class NCMainCommon: NSObject, PhotoEditorDelegate, NCAudioRecorderViewControllerDelegate, UIDocumentInteractionControllerDelegate {
     
+    struct NCMainCommonImages {
+        static let cellShareImage = CCGraphics.changeThemingColorImage(UIImage.init(named: "share"), width: 50, height: 50, color: NCBrandColor.sharedInstance.optionItem)
+        static let cellShareMountedImage = CCGraphics.changeThemingColorImage(UIImage.init(named: "shareMounted"), width: 50, height: 50, color: NCBrandColor.sharedInstance.optionItem)
+        static let cellShareByLinkImage = CCGraphics.changeThemingColorImage(UIImage.init(named: "sharebylink"), width: 50, height: 50, color: NCBrandColor.sharedInstance.optionItem)
+        static let cellFavouriteImage = CCGraphics.changeThemingColorImage(UIImage.init(named: "favorite"), multiplier: 2, color: NCBrandColor.sharedInstance.yellowFavorite)
+        static let cellMoreImage = CCGraphics.changeThemingColorImage(UIImage.init(named: "more"), multiplier: 1, color: NCBrandColor.sharedInstance.optionItem)
+    }
+    
     @objc static let sharedInstance: NCMainCommon = {
         let instance = NCMainCommon()
         return instance
@@ -612,13 +620,13 @@ class NCMainCommon: NSObject, PhotoEditorDelegate, NCAudioRecorderViewController
                 
                 // Share
                 if (isShare) {
-                    cell.shared.image = CCGraphics.changeThemingColorImage(UIImage.init(named: "share"), width: 50, height: 50, color: NCBrandColor.sharedInstance.optionItem)
+                    cell.shared.image = NCMainCommonImages.cellShareImage
                 } else if (isMounted) {
-                    cell.shared.image = CCGraphics.changeThemingColorImage(UIImage.init(named: "shareMounted"), width: 50, height: 50, color: NCBrandColor.sharedInstance.optionItem)
+                    cell.shared.image = NCMainCommonImages.cellShareMountedImage
                 } else if (sharesLink != nil) {
-                    cell.shared.image = CCGraphics.changeThemingColorImage(UIImage.init(named: "sharebylink"), width: 50, height: 50, color: NCBrandColor.sharedInstance.optionItem)
+                    cell.shared.image = NCMainCommonImages.cellShareByLinkImage
                 } else if (sharesUserAndGroup != nil) {
-                    cell.shared.image = CCGraphics.changeThemingColorImage(UIImage.init(named: "share"), width: 50, height: 50, color: NCBrandColor.sharedInstance.optionItem)
+                    cell.shared.image = NCMainCommonImages.cellShareImage
                 }
             }
             
@@ -628,11 +636,11 @@ class NCMainCommon: NSObject, PhotoEditorDelegate, NCAudioRecorderViewController
             
             // Favorite
             if metadata.favorite {
-                cell.favorite.image = CCGraphics.changeThemingColorImage(UIImage.init(named: "favorite"), multiplier: 2, color: NCBrandColor.sharedInstance.yellowFavorite)
+                cell.favorite.image = NCMainCommonImages.cellFavouriteImage
             }
             
             // More Image
-            cell.more.image = CCGraphics.changeThemingColorImage(UIImage.init(named: "more"), multiplier: 1, color: NCBrandColor.sharedInstance.optionItem)
+            cell.more.image = NCMainCommonImages.cellMoreImage
             
             return cell
             


### PR DESCRIPTION
 The scrolling performance is pretty choppy at the moment. Looking through instruments I can see there's a few bottle necks where we're tinting images so I've cached the images after they've been tinted.

I'd quite like to have another look at this to get the scrolling more performant but these were some quick wins.

<img width="720" alt="Screenshot 2019-08-28 at 21 27 03" src="https://user-images.githubusercontent.com/2152528/63890570-33777b80-c9db-11e9-9975-9f82f31becb2.png">
