### PR TITLE
Creating image cache

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7D4BFD5F2321A141009112DA /* LocalImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4BFD5E2321A141009112DA /* LocalImageCache.swift */; };
 		F700222C1EC479840080073F /* Custom.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F700222B1EC479840080073F /* Custom.xcassets */; };
 		F700222D1EC479840080073F /* Custom.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F700222B1EC479840080073F /* Custom.xcassets */; };
 		F70022B31EC4C9100080073F /* OCActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = F70022671EC4C9100080073F /* OCActivity.m */; };
@@ -643,6 +644,7 @@
 		08EA97451E6554FC004C83FA /* FirebaseCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FirebaseCore.framework; sourceTree = "<group>"; };
 		08EA97461E6554FC004C83FA /* FirebaseInstanceID.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FirebaseInstanceID.framework; sourceTree = "<group>"; };
 		08EA97471E6554FC004C83FA /* GoogleToolboxForMac.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = GoogleToolboxForMac.framework; sourceTree = "<group>"; };
+		7D4BFD5E2321A141009112DA /* LocalImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalImageCache.swift; sourceTree = "<group>"; };
 		F700222B1EC479840080073F /* Custom.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Custom.xcassets; sourceTree = "<group>"; };
 		F70022661EC4C9100080073F /* OCActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCActivity.h; sourceTree = "<group>"; };
 		F70022671EC4C9100080073F /* OCActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCActivity.m; sourceTree = "<group>"; };
@@ -2548,6 +2550,7 @@
 				F78071081EDAB65800EAFFF6 /* NSNotificationCenter+MainThread.m */,
 				F73049B81CB567F000C7C320 /* NSString+TruncateToWidth.h */,
 				F73049B91CB567F000C7C320 /* NSString+TruncateToWidth.m */,
+				7D4BFD5E2321A141009112DA /* LocalImageCache.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3771,6 +3774,7 @@
 				F70022BC1EC4C9100080073F /* OCExternalSites.m in Sources */,
 				F73CC07B1E813DFF006E3047 /* BKTouchIDManager.m in Sources */,
 				F762CB031EACB66200B38484 /* XLFormStepCounterCell.m in Sources */,
+				7D4BFD5F2321A141009112DA /* LocalImageCache.swift in Sources */,
 				F760F79321F21F61006B1A73 /* CropView.swift in Sources */,
 				F762CAF71EACB66200B38484 /* XLFormBaseCell.m in Sources */,
 				F70022E01EC4C9100080073F /* OCXMLListParser.m in Sources */,

--- a/iOSClient/Main/NCMainCommon.swift
+++ b/iOSClient/Main/NCMainCommon.swift
@@ -588,7 +588,11 @@ class NCMainCommon: NSObject, PhotoEditorDelegate, NCAudioRecorderViewController
                 
                 // File Image
                 if iconFileExists {
-                    cell.file.image = UIImage.init(contentsOfFile: CCUtility.getDirectoryProviderStorageIconFileID(metadata.fileID, fileNameView: metadata.fileNameView))
+                    
+                    LocalImageCache.shared.loadImage(fileID: metadata.fileID, fileNameView: metadata.fileNameView) { image in
+                        cell.file.image = image
+                    }
+                    
                 } else {
                     if metadata.iconName.count > 0 {
                         cell.file.image = UIImage.init(named: metadata.iconName)
@@ -696,7 +700,9 @@ class NCMainCommon: NSObject, PhotoEditorDelegate, NCAudioRecorderViewController
             let iconFileExists = FileManager.default.fileExists(atPath: CCUtility.getDirectoryProviderStorageIconFileID(metadata.fileID, fileNameView: metadata.fileNameView))
 
             if iconFileExists {
-                cell.file.image = UIImage.init(contentsOfFile: CCUtility.getDirectoryProviderStorageIconFileID(metadata.fileID, fileNameView: metadata.fileNameView))
+                LocalImageCache.shared.loadImage(fileID: metadata.fileID, fileNameView: metadata.fileNameView) { image in
+                    cell.file.image = image
+                }
             } else {
                 if metadata.iconName.count > 0 {
                     cell.file.image = UIImage.init(named: metadata.iconName)

--- a/iOSClient/Utility/LocalImageCache.swift
+++ b/iOSClient/Utility/LocalImageCache.swift
@@ -1,0 +1,52 @@
+//
+//  LocalImageCache.swift
+//  Nextcloud
+//
+//  Created by Marino Faggiana on 18/07/18.
+//  Copyright © 2018 Marino Faggiana. All rights reserved.
+//
+//  Author Marino Faggiana <marino.faggiana@nextcloud.com>
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+final class LocalImageCache {
+    
+    static var shared = LocalImageCache()
+    
+    let cache = NSCache<NSString, UIImage>()
+    
+    func loadImage(fileID: String, fileNameView: String, completion: @escaping (UIImage?) -> Void) {
+        
+        if let image = cache.object(forKey: fileID as NSString) {
+            completion(image)
+            return
+        }
+        
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            
+            let loadedImage = UIImage(contentsOfFile: CCUtility.getDirectoryProviderStorageIconFileID(fileID, fileNameView: fileNameView))
+            
+            DispatchQueue.main.async {
+                
+                if let loadedImage = loadedImage {
+                    self?.cache.setObject(loadedImage, forKey: fileID as NSString)
+                }
+                completion(loadedImage)
+                
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
I noticed we're loading files from disc on the main thread and not caching them.

I've created a class that relies on `NSCache` for caching so it'll automatically purge images as system resources get low. I've assumed `metadata.fileID` is unique so i've used that as the key for the cache.

Additionally I'm loading these images asynchronously off the main thread which helps with scrolling performance.

If you test this in a folder full of images it still stutters a bit as it's loading but once they've all been loaded into memory it's really quick.

Next task is to find out why it's still stuttering as the images are loaded into memory 🤔 