### PR TITLE
fix typo in github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 ### Server configuration
 
-**Operating system**:
+**Operating system:**
 
 **Web server:**
 


### PR DESCRIPTION
Except for the operating system on all other server configuration points the
colon is bold. The colon of the operating system wants to be bold, too.