### PR TITLE
Check dark mode at first launch - Fix #1052

### DIFF
--- a/iOSClient/Utility/CCUtility.m
+++ b/iOSClient/Utility/CCUtility.m
@@ -659,6 +659,11 @@
 
 + (BOOL)getDarkMode
 {
+    if ([self getDarkModeDetect]) {
+        if (@available(iOS 12.0, *)) {
+            return [UIScreen mainScreen].traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
+        }
+    }
     return [[UICKeyChainStore stringForKey:@"darkMode" service:k_serviceShareKeyChain] boolValue];
 }
 


### PR DESCRIPTION
Ensure that dark mode is enabled according to system preferences.
Fix for #1052

Signed-off-by: Philippe Weidmann <philippe.weidmann@infomaniak.com>