### PR TITLE
Use themingLogoBlack only when using theming color.

### DIFF
--- a/iOSClient/Main/CCMain.m
+++ b/iOSClient/Main/CCMain.m
@@ -586,7 +586,7 @@
     UIImage *image = [UIImage imageNamed:@"themingLogo"];
     
     tableCapabilities *capabilities = [[NCManageDatabase sharedInstance] getCapabilitesWithAccount:appDelegate.activeAccount];
-    if ([capabilities.themingColorText isEqualToString:@"#000000"] && [UIImage imageNamed:@"themingLogoBlack"]) {
+    if ([NCBrandOptions sharedInstance].use_themingColor && [capabilities.themingColorText isEqualToString:@"#000000"] && [UIImage imageNamed:@"themingLogoBlack"]) {
         image = [UIImage imageNamed:@"themingLogoBlack"];
     }
    


### PR DESCRIPTION
This fixes an issue where the themingLogoBlack image was being used in branded versions.