### PR TITLE
Fix searchcontroller background color when active

### DIFF
--- a/iOSClient/Main/CCMain.m
+++ b/iOSClient/Main/CCMain.m
@@ -297,6 +297,7 @@
     // color searchbar
     self.searchController.searchBar.barTintColor = NCBrandColor.sharedInstance.brand;
     self.searchController.searchBar.backgroundColor = NCBrandColor.sharedInstance.brand;
+    self.view.backgroundColor = NCBrandColor.sharedInstance.brand;
     // color searchbbar button text (cancel)
     UIButton *searchButton = self.searchController.searchBar.subviews.firstObject.subviews.lastObject;
     if (searchButton && [searchButton isKindOfClass:[UIButton class]]) {


### PR DESCRIPTION
Fix for #1086
![Simulator Screen Shot - iPhone 11 - 2020-01-13 at 10 28 21](https://user-images.githubusercontent.com/5843044/72244857-72574800-35ef-11ea-9319-e480779dffbf.png)
