### PR TITLE
Go to settings from no passcode alert

### DIFF
--- a/iOSClient/Main/CCMain.m
+++ b/iOSClient/Main/CCMain.m
@@ -2503,8 +2503,17 @@
     if ([[CCUtility getBlockCode] length] == 0) {
         
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"_warning_", nil) message:NSLocalizedString(@"_only_lock_passcode_", nil) preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *goToSettingsAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"_go_to_app_settings_", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
+            [self.tabBarController setSelectedIndex:4];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.5 * NSEC_PER_SEC), dispatch_get_main_queue(), ^(void) {
+                NSIndexPath *selectedIndex = [NSIndexPath indexPathForRow:0 inSection:1];
+                [appDelegate.activeMore.tableView selectRowAtIndexPath:selectedIndex animated:true scrollPosition: UITableViewScrollPositionNone];
+                [appDelegate.activeMore tableView:appDelegate.activeMore.tableView didSelectRowAtIndexPath:selectedIndex];
+            });
+        }];
         UIAlertAction *okAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"_ok_", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {}];
 
+        [alertController addAction:goToSettingsAction];
         [alertController addAction:okAction];
         [self presentViewController:alertController animated:YES completion:nil];
         return;

--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -352,6 +352,7 @@
 "_download_selected_files_folders_" = "Download files and folders";
 "_error_operation_canc_"        = "Error: Operation canceled.";
 "_only_lock_passcode_"          = "Available only with Lock password activated. Activate it in the \"Settings\".";
+"_go_to_app_settings_"          = "Go to app settings";
 "_passcode_protection_"         = "Password protection";
 "_remove_favorites_"            = "Remove from favorites";
 "_remove_offline_"              = "Remove from offline";


### PR DESCRIPTION
Allow user to go directly to app settings from the alert.
![Simulator Screen Shot - iPhone 11 - 2020-02-04 at 09 48 07](https://user-images.githubusercontent.com/5843044/73728392-8ba56d00-4733-11ea-91a0-7d2a6468e2f4.png)
Signed-off-by: Philippe Weidmann <philippe.weidmann@infomaniak.com>

