### PR TITLE
Fix "photos in edit mode are moving during drawing" #1138 

### DIFF
--- a/iOSClient/Main/NCMainCommon.swift
+++ b/iOSClient/Main/NCMainCommon.swift
@@ -1053,6 +1053,7 @@ class NCMainCommon: NSObject, PhotoEditorDelegate, NCAudioRecorderViewController
         photoEditor.clearButtonImage = CCGraphics.changeThemingColorImage(UIImage(named: "photoEditorClear")!, multiplier:2, color: .white)
         photoEditor.continueButtonImage = CCGraphics.changeThemingColorImage(UIImage(named: "photoEditorDone")!, multiplier:2, color: .white)
         
+        photoEditor.modalPresentationStyle = .fullScreen
         viewController.present(photoEditor, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
Remade on develop branch.

Fix "photos in edit mode are moving during drawing" #1138.

iOS 13 introduced new default modal presentation style. This commit sets the PhotoEditorViewController's presentation style to fullscreen to avoid the view being moved while drawing.

Signed-off-by: onehappycat <onehappycat@gmx.com>