### PR TITLE
removed deprecated viewDidUnload implementations

### DIFF
--- a/iOSClient/Library/MWPhotoBrowser/MWPhotoBrowser.m
+++ b/iOSClient/Library/MWPhotoBrowser/MWPhotoBrowser.m
@@ -285,19 +285,6 @@ static void * MWVideoPlayerObservation = &MWVideoPlayerObservation;
     
 }
 
-// Release any retained subviews of the main view.
-- (void)viewDidUnload {
-	_currentPageIndex = 0;
-    _pagingScrollView = nil;
-    _visiblePages = nil;
-    _recycledPages = nil;
-    _toolbar = nil;
-    _previousButton = nil;
-    _nextButton = nil;
-    _progressHUD = nil;
-    [super viewDidUnload];
-}
-
 - (BOOL)presentingViewControllerPrefersStatusBarHidden {
     UIViewController *presenting = self.presentingViewController;
     if (presenting) {

--- a/iOSClient/Library/VFR Pdf Reader/Sources/ReaderViewController.m
+++ b/iOSClient/Library/VFR Pdf Reader/Sources/ReaderViewController.m
@@ -439,23 +439,6 @@
 	[super viewDidDisappear:animated];
 }
 
-- (void)viewDidUnload
-{
-#ifdef DEBUG
-	NSLog(@"%s", __FUNCTION__);
-#endif
-
-	mainToolbar = nil; mainPagebar = nil;
-
-	theScrollView = nil; contentViews = nil; lastHideTime = nil;
-
-	documentInteraction = nil; printInteraction = nil;
-
-	lastAppearSize = CGSizeZero; currentPage = 0;
-
-	[super viewDidUnload];
-}
-
 - (BOOL)prefersStatusBarHidden
 {
 	return YES;

--- a/iOSClient/Library/VFR Pdf Reader/Sources/ThumbsViewController.m
+++ b/iOSClient/Library/VFR Pdf Reader/Sources/ThumbsViewController.m
@@ -176,17 +176,6 @@
 	[super viewDidDisappear:animated];
 }
 
-- (void)viewDidUnload
-{
-#ifdef DEBUG
-	NSLog(@"%s", __FUNCTION__);
-#endif
-
-	mainToolbar = nil; theThumbsView = nil;
-
-	[super viewDidUnload];
-}
-
 - (BOOL)prefersStatusBarHidden
 {
 	return YES;


### PR DESCRIPTION
From docs: Deprecated - Views are no longer purged under low-memory conditions and so this method is never called.

Signed-off-by: James Stout <stoutyhk@gmail.com>