### PR TITLE
Use static NSDateFormatter where possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ UserInterfaceState.xcuserstate
 ## Carthage
 Carthage/
 Cartfile.resolved
+/Nextcloud.xcodeproj/xcshareddata/xcbaselines

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -3,10 +3,16 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A58C4A72443609F00BD170B /* ALView+PureLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = F75037441DBFA91A008FB480 /* ALView+PureLayout.m */; };
+		1A58C4A8244360A400BD170B /* NSArray+PureLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = F75037461DBFA91A008FB480 /* NSArray+PureLayout.m */; };
+		1A58C4A9244360A800BD170B /* NSLayoutConstraint+PureLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = F75037481DBFA91A008FB480 /* NSLayoutConstraint+PureLayout.m */; };
+		1A58C4AE2443683700BD170B /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1A58C4AD2443683600BD170B /* XCTest.framework */; platformFilter = ios; };
+		1A9B2EA52443472500433AEF /* NSDate+NCUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A9B2EA32443472300433AEF /* NSDate+NCUtil.m */; };
+		1AACD10D2440CDFE0044910E /* NextcloudTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AACD10C2440CDFE0044910E /* NextcloudTests.m */; platformFilter = ios; };
 		2C1D5D7523E2DE3300334ABB /* NCDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7BAADB41ED5A87C00B7EAD4 /* NCDatabase.swift */; };
 		2C1D5D7623E2DE3300334ABB /* NCManageDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7BAADB51ED5A87C00B7EAD4 /* NCManageDatabase.swift */; };
 		2C1D5D7723E2DE5F00334ABB /* CCUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = F7053E3D1C639DF500741EA5 /* CCUtility.m */; };
@@ -245,9 +251,6 @@
 		F74E432720B5547700C2E54C /* NCNetworkingEndToEnd.m in Sources */ = {isa = PBXBuildFile; fileRef = F74E432520B5547700C2E54C /* NCNetworkingEndToEnd.m */; };
 		F7501C322212E57500FB1415 /* NCMedia.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F7501C302212E57400FB1415 /* NCMedia.storyboard */; };
 		F7501C332212E57500FB1415 /* NCMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7501C312212E57400FB1415 /* NCMedia.swift */; };
-		F750374D1DBFA91A008FB480 /* ALView+PureLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = F75037441DBFA91A008FB480 /* ALView+PureLayout.m */; };
-		F750374F1DBFA91A008FB480 /* NSArray+PureLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = F75037461DBFA91A008FB480 /* NSArray+PureLayout.m */; };
-		F75037511DBFA91A008FB480 /* NSLayoutConstraint+PureLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = F75037481DBFA91A008FB480 /* NSLayoutConstraint+PureLayout.m */; };
 		F75153242226920200323DDC /* FastScroll.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F75153232226920200323DDC /* FastScroll.framework */; };
 		F754EEC921772B6100BB1CDF /* DropdownItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F754EEC421772B6100BB1CDF /* DropdownItem.swift */; };
 		F754EECA21772B6100BB1CDF /* DropUpMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F754EEC521772B6100BB1CDF /* DropUpMenu.swift */; };
@@ -630,6 +633,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1AACD10F2440CDFE0044910E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F7F67BA01A24D27800EE80DA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F77B0DEB1D118A16002130FE;
+			remoteInfo = Nextcloud;
+		};
 		2C33C48423E2C475005F963B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F7F67BA01A24D27800EE80DA /* Project object */;
@@ -695,6 +705,12 @@
 		08EA97451E6554FC004C83FA /* FirebaseCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FirebaseCore.framework; sourceTree = "<group>"; };
 		08EA97461E6554FC004C83FA /* FirebaseInstanceID.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FirebaseInstanceID.framework; sourceTree = "<group>"; };
 		08EA97471E6554FC004C83FA /* GoogleToolboxForMac.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = GoogleToolboxForMac.framework; sourceTree = "<group>"; };
+		1A58C4AD2443683600BD170B /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		1A9B2EA32443472300433AEF /* NSDate+NCUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+NCUtil.m"; sourceTree = "<group>"; };
+		1A9B2EA42443472400433AEF /* NSDate+NCUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+NCUtil.h"; sourceTree = "<group>"; };
+		1AACD10A2440CDFE0044910E /* NextcloudTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextcloudTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1AACD10C2440CDFE0044910E /* NextcloudTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NextcloudTests.m; sourceTree = "<group>"; };
+		1AACD10E2440CDFE0044910E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2C33C47F23E2C475005F963B /* Notification Service Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Notification Service Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C33C48123E2C475005F963B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		2C33C48A23E2CC26005F963B /* Notification_Service_Extension-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Notification_Service_Extension-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1462,6 +1478,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1AACD1072440CDFE0044910E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1A58C4AE2443683700BD170B /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2C33C47C23E2C475005F963B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1543,6 +1567,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1AACD10B2440CDFE0044910E /* NextcloudTests */ = {
+			isa = PBXGroup;
+			children = (
+				1AACD10C2440CDFE0044910E /* NextcloudTests.m */,
+				1AACD10E2440CDFE0044910E /* Info.plist */,
+			);
+			path = NextcloudTests;
+			sourceTree = "<group>";
+		};
 		2C33C48023E2C475005F963B /* Notification Service Extension */ = {
 			isa = PBXGroup;
 			children = (
@@ -2472,11 +2505,13 @@
 				F765608E23BF813500765969 /* NCContentPresenter.swift */,
 				F707C26421A2DC5200F6181E /* NCStoreReview.swift */,
 				F70BFC7320E0FA7C00C67599 /* NCUtility.swift */,
-				F70CEF5523E9C7E50007035B /* UIColor+adjust.swift */,
+				1A9B2EA42443472400433AEF /* NSDate+NCUtil.h */,
+				1A9B2EA32443472300433AEF /* NSDate+NCUtil.m */,
 				F78071071EDAB65800EAFFF6 /* NSNotificationCenter+MainThread.h */,
 				F78071081EDAB65800EAFFF6 /* NSNotificationCenter+MainThread.m */,
 				F73049B81CB567F000C7C320 /* NSString+TruncateToWidth.h */,
 				F73049B91CB567F000C7C320 /* NSString+TruncateToWidth.m */,
+				F70CEF5523E9C7E50007035B /* UIColor+adjust.swift */,
 				F7B7504A2397D38E004E13EC /* UIImage+fixedOrientation.swift */,
 			);
 			path = Utility;
@@ -2828,10 +2863,12 @@
 				F771E3D120E2392D00AFB62D /* File Provider Extension */,
 				F7C0F46D1C8880540059EC54 /* Share */,
 				2C33C48023E2C475005F963B /* Notification Service Extension */,
+				1AACD10B2440CDFE0044910E /* NextcloudTests */,
 				F7FC7D651DC1F98700BB2C6A /* Products */,
 				F7FC7D541DC1F93700BB2C6A /* Frameworks */,
 				F771E3D020E2392D00AFB62D /* File Provider Extension.appex */,
 				2C33C47F23E2C475005F963B /* Notification Service Extension.appex */,
+				1AACD10A2440CDFE0044910E /* NextcloudTests.xctest */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2902,6 +2939,7 @@
 		F7FC7D541DC1F93700BB2C6A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1A58C4AD2443683600BD170B /* XCTest.framework */,
 				F7DBD82B23E46A4700ECB7C6 /* MarkdownKit.framework */,
 				371B5A3223D0BD5500FAFAE9 /* FloatingPanel.framework */,
 				F765608A23BF80A400765969 /* SwiftEntryKit.framework */,
@@ -2986,6 +3024,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		1AACD1092440CDFE0044910E /* NextcloudTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1AACD1112440CDFE0044910E /* Build configuration list for PBXNativeTarget "NextcloudTests" */;
+			buildPhases = (
+				1AACD1062440CDFE0044910E /* Sources */,
+				1AACD1072440CDFE0044910E /* Frameworks */,
+				1AACD1082440CDFE0044910E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1AACD1102440CDFE0044910E /* PBXTargetDependency */,
+			);
+			name = NextcloudTests;
+			productName = NextcloudTests;
+			productReference = 1AACD10A2440CDFE0044910E /* NextcloudTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		2C33C47E23E2C475005F963B /* Notification Service Extension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2C33C48923E2C475005F963B /* Build configuration list for PBXNativeTarget "Notification Service Extension" */;
@@ -3073,6 +3129,12 @@
 				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Marino Faggiana";
 				TargetAttributes = {
+					1AACD1092440CDFE0044910E = {
+						CreatedOnToolsVersion = 11.4;
+						DevelopmentTeam = 7G8XW6MU88;
+						ProvisioningStyle = Automatic;
+						TestTargetID = F77B0DEB1D118A16002130FE;
+					};
 					2C33C47E23E2C475005F963B = {
 						CreatedOnToolsVersion = 11.3.1;
 						DevelopmentTeam = 6JLRKY9ZV7;
@@ -3170,11 +3232,19 @@
 				F71459B41D12E3B700CAFEEC /* Share */,
 				F771E3CF20E2392D00AFB62D /* File Provider Extension */,
 				2C33C47E23E2C475005F963B /* Notification Service Extension */,
+				1AACD1092440CDFE0044910E /* NextcloudTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1AACD1082440CDFE0044910E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2C33C47D23E2C475005F963B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3424,6 +3494,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1AACD1062440CDFE0044910E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1AACD10D2440CDFE0044910E /* NextcloudTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2C33C47B23E2C475005F963B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3639,7 +3717,6 @@
 				371B5A2E23D0B04500FAFAE9 /* NCMainMenuTableViewController.swift in Sources */,
 				F76C6F8E21943C8C0063591B /* NCActionSheetHeader.swift in Sources */,
 				F760F79121F21F61006B1A73 /* EmojiCollectionViewCell.swift in Sources */,
-				F750374F1DBFA91A008FB480 /* NSArray+PureLayout.m in Sources */,
 				F77444F8222816D5000D5EB0 /* NCPhotosPickerViewController.swift in Sources */,
 				F77B0E141D118A16002130FE /* CCError.m in Sources */,
 				F7E09CE523E3088C00FB3E9E /* NCSplitViewController.swift in Sources */,
@@ -3688,12 +3765,14 @@
 				F7DFB7E0219C312D00680748 /* NCRichDocumentTemplate.m in Sources */,
 				F769454222E9F0EE000A798A /* NCShareLinkMenuView.swift in Sources */,
 				F73B4F0B1F470D9100BBEE4B /* nsGB2312Prober.cpp in Sources */,
+				1A58C4A9244360A800BD170B /* NSLayoutConstraint+PureLayout.m in Sources */,
 				F762CAFE1EACB66200B38484 /* XLFormLeftRightSelectorCell.m in Sources */,
 				F77B0E301D118A16002130FE /* CCHud.m in Sources */,
 				F76673ED22C901F6007ED366 /* FileProviderDomain.swift in Sources */,
 				F7D423891F0596C6009C9782 /* ReaderViewController.m in Sources */,
 				F70022E91EC4C9100080073F /* OCXMLShareByLinkParser.m in Sources */,
 				F77B0E311D118A16002130FE /* CCExifGeo.m in Sources */,
+				1A58C4A72443609F00BD170B /* ALView+PureLayout.m in Sources */,
 				F73B4F0E1F470D9100BBEE4B /* nsMBCSGroupProber.cpp in Sources */,
 				F7D423831F0596C6009C9782 /* ReaderThumbFetch.m in Sources */,
 				F73B4F171F470D9100BBEE4B /* uchardet.cpp in Sources */,
@@ -3757,7 +3836,6 @@
 				F73CC0751E813DFF006E3047 /* BKPasscodeViewController.m in Sources */,
 				F749C10B23C4A5340027D966 /* NCIntroCollectionViewCell.swift in Sources */,
 				F7DBC37F23325E2E001A85BA /* NCXMLGetAppPasswordParser.m in Sources */,
-				F750374D1DBFA91A008FB480 /* ALView+PureLayout.m in Sources */,
 				F7381EE1218218C9000B1560 /* NCOffline.swift in Sources */,
 				F7D423861F0596C6009C9782 /* ReaderThumbRequest.m in Sources */,
 				F73B4EF51F470D9100BBEE4B /* JpCntx.cpp in Sources */,
@@ -3767,7 +3845,6 @@
 				F760F79821F21F61006B1A73 /* StickerCollectionViewCell.swift in Sources */,
 				F70022FB1EC4C9100080073F /* NSString+Encode.m in Sources */,
 				F769454422E9F142000A798A /* NCShareUserMenuView.swift in Sources */,
-				F75037511DBFA91A008FB480 /* NSLayoutConstraint+PureLayout.m in Sources */,
 				F762CAFA1EACB66200B38484 /* XLFormDateCell.m in Sources */,
 				F70022B91EC4C9100080073F /* OCCommunication.m in Sources */,
 				F762CB181EACB66200B38484 /* XLFormValidationStatus.m in Sources */,
@@ -3783,6 +3860,7 @@
 				F77B0E9B1D118A16002130FE /* CCBKPasscode.m in Sources */,
 				F760F77F21F21F61006B1A73 /* PhotoEditor+Controls.swift in Sources */,
 				F7169A1D1EE590930086BD69 /* NCSharesCell.m in Sources */,
+				1A9B2EA52443472500433AEF /* NSDate+NCUtil.m in Sources */,
 				F7B7504B2397D38F004E13EC /* UIImage+fixedOrientation.swift in Sources */,
 				F77B0EA61D118A16002130FE /* NSString+TruncateToWidth.m in Sources */,
 				F70022C21EC4C9100080073F /* OCNotifications.m in Sources */,
@@ -3864,6 +3942,7 @@
 				F73B4F141F470D9100BBEE4B /* nsUTF8Prober.cpp in Sources */,
 				F70022C81EC4C9100080073F /* OCRichObjectStrings.m in Sources */,
 				F7D423841F0596C6009C9782 /* ReaderThumbQueue.m in Sources */,
+				1A58C4A8244360A400BD170B /* NSArray+PureLayout.m in Sources */,
 				F77B0ED11D118A16002130FE /* Acknowledgements.m in Sources */,
 				F7E4D9C422ED929B003675FD /* NCShareComments.swift in Sources */,
 				F73CC06C1E813DFF006E3047 /* BKPasscodeField.m in Sources */,
@@ -3877,6 +3956,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1AACD1102440CDFE0044910E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F77B0DEB1D118A16002130FE /* Nextcloud */;
+			targetProxy = 1AACD10F2440CDFE0044910E /* PBXContainerItemProxy */;
+		};
 		2C33C48523E2C475005F963B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2C33C47E23E2C475005F963B /* Notification Service Extension */;
@@ -3957,6 +4041,81 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1AACD1122440CDFE0044910E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 7G8XW6MU88;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/**",
+				);
+				INFOPLIST_FILE = NextcloudTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tiberiushk.NextcloudTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nextcloud.app/Nextcloud";
+			};
+			name = Debug;
+		};
+		1AACD1132440CDFE0044910E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 7G8XW6MU88;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/**",
+				);
+				INFOPLIST_FILE = NextcloudTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tiberiushk.NextcloudTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nextcloud.app/Nextcloud";
+			};
+			name = Release;
+		};
 		2C33C48723E2C475005F963B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3991,7 +4150,11 @@
 				HEADER_SEARCH_PATHS = "\"Libraries external\"/**";
 				INFOPLIST_FILE = "$(SRCROOT)/iOSClient/Brand/Notification_Service_Extension.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "\"Libraries external\"/**";
 				MARKETING_VERSION = 2.26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -4042,7 +4205,11 @@
 				HEADER_SEARCH_PATHS = "\"Libraries external\"/**";
 				INFOPLIST_FILE = "$(SRCROOT)/iOSClient/Brand/Notification_Service_Extension.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "\"Libraries external\"/**";
 				MARKETING_VERSION = 2.26.0;
 				MTL_FAST_MATH = YES;
@@ -4085,7 +4252,11 @@
 				HEADER_SEARCH_PATHS = "\"Libraries external\"/**";
 				INFOPLIST_FILE = "$(SRCROOT)/iOSClient/Brand/Share.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "\"Libraries external\"/**";
 				MARKETING_VERSION = 2.26.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -4129,7 +4300,11 @@
 				HEADER_SEARCH_PATHS = "\"Libraries external\"/**";
 				INFOPLIST_FILE = "$(SRCROOT)/iOSClient/Brand/Share.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "\"Libraries external\"/**";
 				MARKETING_VERSION = 2.26.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -4179,7 +4354,11 @@
 				HEADER_SEARCH_PATHS = "\"Libraries external\"/**";
 				INFOPLIST_FILE = "$(SRCROOT)/iOSClient/Brand/File_Provider_Extension.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "\"Libraries external\"/**";
 				MARKETING_VERSION = 2.26.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -4229,7 +4408,11 @@
 				HEADER_SEARCH_PATHS = "\"Libraries external\"/**";
 				INFOPLIST_FILE = "$(SRCROOT)/iOSClient/Brand/File_Provider_Extension.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "\"Libraries external\"/**";
 				MARKETING_VERSION = 2.26.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -4270,7 +4453,11 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)\"/Libraries external/openssl\"";
 				INFOPLIST_FILE = "$(SRCROOT)/iOSClient/Brand/iOSClient.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "";
 				MARKETING_VERSION = 2.26.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -4316,7 +4503,11 @@
 				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)\"/Libraries external/openssl\"";
 				INFOPLIST_FILE = "$(SRCROOT)/iOSClient/Brand/iOSClient.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = "";
 				MARKETING_VERSION = 2.26.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -4450,7 +4641,8 @@
 				);
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG NC";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -4459,6 +4651,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1AACD1112440CDFE0044910E /* Build configuration list for PBXNativeTarget "NextcloudTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1AACD1122440CDFE0044910E /* Debug */,
+				1AACD1132440CDFE0044910E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		2C33C48923E2C475005F963B /* Build configuration list for PBXNativeTarget "Notification Service Extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -706,6 +706,7 @@
 		08EA97461E6554FC004C83FA /* FirebaseInstanceID.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FirebaseInstanceID.framework; sourceTree = "<group>"; };
 		08EA97471E6554FC004C83FA /* GoogleToolboxForMac.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = GoogleToolboxForMac.framework; sourceTree = "<group>"; };
 		1A58C4AD2443683600BD170B /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		1A7EC387244476080053AA05 /* NCAutoUpload+NCUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NCAutoUpload+NCUtil.h"; sourceTree = "<group>"; };
 		1A9B2EA32443472300433AEF /* NSDate+NCUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+NCUtil.m"; sourceTree = "<group>"; };
 		1A9B2EA42443472400433AEF /* NSDate+NCUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+NCUtil.h"; sourceTree = "<group>"; };
 		1AACD10A2440CDFE0044910E /* NextcloudTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextcloudTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1570,8 +1571,9 @@
 		1AACD10B2440CDFE0044910E /* NextcloudTests */ = {
 			isa = PBXGroup;
 			children = (
-				1AACD10C2440CDFE0044910E /* NextcloudTests.m */,
 				1AACD10E2440CDFE0044910E /* Info.plist */,
+				1AACD10C2440CDFE0044910E /* NextcloudTests.m */,
+				1A7EC387244476080053AA05 /* NCAutoUpload+NCUtil.h */,
 			);
 			path = NextcloudTests;
 			sourceTree = "<group>";
@@ -4049,6 +4051,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
@@ -4056,6 +4059,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 7G8XW6MU88;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)\"/Libraries external/Fabric\"",
+					"$(PROJECT_DIR)\"/Libraries external/Firebase\"",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -4063,7 +4072,8 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/**",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_TEMP_DIR)/**",
 				);
 				INFOPLIST_FILE = NextcloudTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
@@ -4072,10 +4082,20 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
+				OTHER_CFLAGS = (
+					"-Wno-documentation",
+					"-Wno-deprecated-declarations",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.tiberiushk.NextcloudTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "Nextcloud-Swift.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nextcloud.app/Nextcloud";
 			};
@@ -4089,6 +4109,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
@@ -4096,6 +4117,12 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 7G8XW6MU88;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)\"/Libraries external/Fabric\"",
+					"$(PROJECT_DIR)\"/Libraries external/Firebase\"",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4108,9 +4135,18 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MTL_FAST_MATH = YES;
+				OTHER_CFLAGS = (
+					"-Wno-documentation",
+					"-Wno-deprecated-declarations",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.tiberiushk.NextcloudTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "Nextcloud-Swift.h";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Nextcloud.app/Nextcloud";
 			};
@@ -4577,6 +4613,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-Wno-deprecated-implementations",
+					"-Wno-deprecated-declarations",
+				);
 				OTHER_LDFLAGS = (
 					"-Obj-C",
 					"-all_load",
@@ -4635,6 +4675,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"-Wno-deprecated-implementations",
+					"-Wno-deprecated-declarations",
+				);
 				OTHER_LDFLAGS = (
 					"-Obj-C",
 					"-all_load",

--- a/Nextcloud.xcodeproj/xcshareddata/xcschemes/File Provider Extension.xcscheme
+++ b/Nextcloud.xcodeproj/xcshareddata/xcschemes/File Provider Extension.xcscheme
@@ -42,8 +42,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -53,14 +51,25 @@
             ReferencedContainer = "container:Nextcloud.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1AACD1092440CDFE0044910E"
+               BuildableName = "NextcloudTests.xctest"
+               BlueprintName = "NextcloudTests"
+               ReferencedContainer = "container:Nextcloud.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
+      askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
@@ -77,8 +86,6 @@
             ReferencedContainer = "container:Nextcloud.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Nextcloud.xcodeproj/xcshareddata/xcschemes/Nextcloud.xcscheme
+++ b/Nextcloud.xcodeproj/xcshareddata/xcschemes/Nextcloud.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Nextcloud.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1AACD1092440CDFE0044910E"
+               BuildableName = "NextcloudTests.xctest"
+               BlueprintName = "NextcloudTests"
+               ReferencedContainer = "container:Nextcloud.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -37,6 +51,17 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1AACD1092440CDFE0044910E"
+               BuildableName = "NextcloudTests.xctest"
+               BlueprintName = "NextcloudTests"
+               ReferencedContainer = "container:Nextcloud.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Nextcloud.xcodeproj/xcshareddata/xcschemes/Share.xcscheme
+++ b/Nextcloud.xcodeproj/xcshareddata/xcschemes/Share.xcscheme
@@ -42,8 +42,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -53,14 +51,25 @@
             ReferencedContainer = "container:Nextcloud.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1AACD1092440CDFE0044910E"
+               BuildableName = "NextcloudTests.xctest"
+               BlueprintName = "NextcloudTests"
+               ReferencedContainer = "container:Nextcloud.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
+      askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
@@ -77,8 +86,6 @@
             ReferencedContainer = "container:Nextcloud.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/NextcloudTests/Info.plist
+++ b/NextcloudTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/NextcloudTests/NCAutoUpload+NCUtil.h
+++ b/NextcloudTests/NCAutoUpload+NCUtil.h
@@ -1,0 +1,19 @@
+//
+//  NCAutoUpload+NCUtil.h
+//  NextcloudTests
+//
+//  Created by James Stout on 13/4/2020.
+//  Copyright © 2020 Marino Faggiana. All rights reserved.
+//
+
+#import "NCAutoUpload.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NCAutoUpload ()
+// extension to make the method public
+- (PHFetchResult *)getCameraRollAssets:(tableAccount *)account selector:(NSString *)selector alignPhotoLibrary:(BOOL)alignPhotoLibrary;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/NextcloudTests/NextcloudTests.m
+++ b/NextcloudTests/NextcloudTests.m
@@ -1,0 +1,209 @@
+//
+//  NextcloudTests.m
+//  NextcloudTests
+//
+//  Created by James Stout on 12/4/20.
+//  Copyright (c) 2020, James Stout (stoutyhk@gmail.com) All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+@import Foundation;
+@import UIKit;
+#import <XCTest/XCTest.h>
+
+#import "NSDate+NCUtil.h"
+
+@interface NextcloudTests : XCTestCase
+
+@property (class, readonly, copy) NSArray<XCTPerformanceMetric> *defaultPerformanceMetrics;
+
+@end
+
+@implementation NextcloudTests
+
+//override metrics used by measureBlock
++(NSArray<XCTPerformanceMetric> *)defaultPerformanceMetrics{
+    
+    return @[XCTPerformanceMetric_WallClockTime,
+             @"com.apple.XCTPerformanceMetric_TemporaryHeapAllocationsKilobytes",
+             @"com.apple.XCTPerformanceMetric_UserTime"];
+}
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+// here we are testing the date formatting code from NSDate+NCUtil.m
+// which uses a static NSDateFormatter
+// 10000 iterations = 0.0775s, heap allocs: 27800KB (around 27MB)
+// vs existing code: 1200% faster, 2100% fewer kb heap allocs (for 10000 iterations)
+- (void)testPerformanceNC_stringWithFormat {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        int const iterations = 10000;
+        NSDate *date = [NSDate date];
+        
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                NSString __unused *yearString = [date NC_stringFromDateWithFormat:@"yyyy"];
+                NSString __unused *monthString = [date NC_stringFromDateWithFormat:@"MM"];
+            }
+        }
+    }];
+}
+
+// here we are testing the date formatting code from NCAutoUpload.m
+// which, when uploading entire camera roll, will be called 1000s of times
+// 10000 iterations = 1.0s,  heap allocs: 598000 KB (~580MB)
+- (void)testPerformanceCurrentDateFormatter {
+    
+    [self measureBlock:^{
+        int const iterations = 10000;
+        NSDate *date = [NSDate date];
+
+        for (int i = 0; i < iterations; i++) {
+            @autoreleasepool {
+                NSDateFormatter *formatter = [NSDateFormatter new];
+                
+                [formatter setDateFormat:@"yyyy"];
+                NSString __unused *yearString = [formatter stringFromDate:date];
+                
+                [formatter setDateFormat:@"MM"];
+                NSString __unused *monthString = [formatter stringFromDate:date];
+            }
+        }
+    }];
+}
+
+// test NC_stringWithFormat returns the same date string as using a formatter and stringFromDate
+// for 10000 random dates
+- (void)testDateFormattersReturnSame {
+
+    int const iterations = 10000;
+    
+    for (int i = 0; i < iterations; i++) {
+
+        NSDate *assetDate = [self generateRandomDateWithinDaysBeforeToday:i];
+
+        NSDateFormatter *formatter = [NSDateFormatter new];
+        
+        [formatter setDateFormat:@"yyyy"];
+        NSString *yearString = [formatter stringFromDate:assetDate];
+        
+        [formatter setDateFormat:@"MM"];
+        NSString *monthString = [formatter stringFromDate:assetDate];
+        
+        NSString *yearStringNEW = [assetDate NC_stringFromDateWithFormat:@"yyyy"];
+        NSString *monthStringNEW = [assetDate NC_stringFromDateWithFormat:@"MM"];
+        
+        XCTAssertTrue([yearString isEqualToString:yearStringNEW]);
+        XCTAssertTrue([monthString isEqualToString:monthStringNEW]);
+        
+        // also test @"yy-MM-dd HH-mm-ss" for createFileNameDate in CCUtility.m
+        [formatter setDateFormat:@"yy-MM-dd HH-mm-ss"];
+        NSString *fileNameDate = [formatter stringFromDate:assetDate];
+        NSString *fileNameDateNEW = [assetDate NC_stringFromDateWithFormat:@"yy-MM-dd HH-mm-ss"];
+        XCTAssertTrue([fileNameDate isEqualToString:fileNameDateNEW]);
+        
+        // also test formats in createFileName in CCUtility.m
+        [formatter setDateFormat:@"dd"];
+        NSString *dayNumber = [formatter stringFromDate:assetDate];
+        NSString *dayNumberNEW = [assetDate NC_stringFromDateWithFormat:@"dd"];
+        XCTAssertTrue([dayNumber isEqualToString:dayNumberNEW]);
+
+        [formatter setDateFormat:@"MMM"];
+        NSString *month = [formatter stringFromDate:assetDate];
+        NSString *monthNEW = [assetDate NC_stringFromDateWithFormat:@"MMM"];
+        XCTAssertTrue([month isEqualToString:monthNEW]);
+
+        [formatter setDateFormat:@"MM"];
+        NSString *monthNumber = [formatter stringFromDate:assetDate];
+        NSString *monthNumberNEW = [assetDate NC_stringFromDateWithFormat:@"MM"];
+        XCTAssertTrue([monthNumber isEqualToString:monthNumberNEW]);
+        
+        [formatter setDateFormat:@"yyyy"];
+        NSString *year = [formatter stringFromDate:assetDate];
+        NSString *yearNEW = [assetDate NC_stringFromDateWithFormat:@"yyyy"];
+        XCTAssertTrue([year isEqualToString:yearNEW]);
+        
+        [formatter setDateFormat:@"yy"];
+        NSString *yearNumber = [formatter stringFromDate:assetDate];
+        NSString *yearNumberNEW = [assetDate NC_stringFromDateWithFormat:@"yy"];
+        XCTAssertTrue([yearNumber isEqualToString:yearNumberNEW]);
+        
+        [formatter setDateFormat:@"HH"];
+        NSString *hour24 = [formatter stringFromDate:assetDate];
+        NSString *hour24NEW = [assetDate NC_stringFromDateWithFormat:@"HH"];
+        XCTAssertTrue([hour24 isEqualToString:hour24NEW]);
+        
+        [formatter setDateFormat:@"hh"];
+        NSString *hour12 = [formatter stringFromDate:assetDate];
+        NSString *hour12NEW = [assetDate NC_stringFromDateWithFormat:@"hh"];
+        XCTAssertTrue([hour12 isEqualToString:hour12NEW]);
+        
+        [formatter setDateFormat:@"mm"];
+        NSString *minute = [formatter stringFromDate:assetDate];
+        NSString *minuteNEW = [assetDate NC_stringFromDateWithFormat:@"mm"];
+        XCTAssertTrue([minute isEqualToString:minuteNEW]);
+        
+        [formatter setDateFormat:@"ss"];
+        NSString *second = [formatter stringFromDate:assetDate];
+        NSString *secondNEW = [assetDate NC_stringFromDateWithFormat:@"ss"];
+        XCTAssertTrue([second isEqualToString:secondNEW]);
+        
+        [formatter setDateFormat:@"a"];
+        NSString *ampm = [formatter stringFromDate:assetDate];
+        NSString *ampmNEW = [assetDate NC_stringFromDateWithFormat:@"a"];
+        XCTAssertTrue([ampm isEqualToString:ampmNEW]);
+        
+//        NSLog(@"date: %@", assetDate.description);
+        
+    }
+}
+
+#pragma mark - Helpers
+/**
+ Generate a random date sometime between now and n days before day.
+ 
+ Also, generate a random time to go with the day while we are at it.
+ @param daysBack date range between today and minimum date to generate
+ @return random date
+ @see http://stackoverflow.com/questions/10092468/how-do-you-generate-a-random-date-in-objective-c
+ */
+- (NSDate *)generateRandomDateWithinDaysBeforeToday:(NSUInteger)daysBack {
+    NSUInteger day = arc4random_uniform((u_int32_t)daysBack);  // explisit cast
+    NSUInteger hour = arc4random_uniform(23);
+    NSUInteger minute = arc4random_uniform(59);
+
+    NSDate *today = [NSDate new];
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+
+    NSDateComponents *offsetComponents = [NSDateComponents new];
+    [offsetComponents setDay:(day * -1)];
+    [offsetComponents setHour:hour];
+    [offsetComponents setMinute:minute];
+
+    NSDate *randomDate = [gregorian dateByAddingComponents:offsetComponents
+                                                    toDate:today
+                                                   options:0];
+
+    return randomDate;
+}
+
+
+@end

--- a/iOSClient/AutoUpload/NCAutoUpload.m
+++ b/iOSClient/AutoUpload/NCAutoUpload.m
@@ -24,6 +24,7 @@
 #import "NCAutoUpload.h"
 #import "AppDelegate.h"
 #import "NCBridgeSwift.h"
+#import "NSDate+NCUtil.h"
 
 #pragma GCC diagnostic ignored "-Wundeclared-selector"
 
@@ -387,13 +388,8 @@
         if (assetMediaType == PHAssetMediaTypeImage && tableAccount.autoUploadWWAnPhoto) session = k_upload_session_wwan;
         if (assetMediaType == PHAssetMediaTypeVideo && tableAccount.autoUploadWWAnVideo) session = k_upload_session_wwan;
         
-        NSDateFormatter *formatter = [NSDateFormatter new];
-        
-        [formatter setDateFormat:@"yyyy"];
-        NSString *yearString = [formatter stringFromDate:assetDate];
-        
-        [formatter setDateFormat:@"MM"];
-        NSString *monthString = [formatter stringFromDate:assetDate];
+        NSString *yearString = [assetDate NC_stringFromDateWithFormat:@"yyyy"];
+        NSString *monthString = [assetDate NC_stringFromDateWithFormat:@"MM"];
         
         if (tableAccount.autoUploadCreateSubfolder)
             serverUrl = [NSString stringWithFormat:@"%@/%@/%@", autoUploadPath, yearString, monthString];

--- a/iOSClient/Main/CCMain.m
+++ b/iOSClient/Main/CCMain.m
@@ -33,7 +33,7 @@
 #import "NCBridgeSwift.h"
 #import "NCNetworkingEndToEnd.h"
 #import "PKDownloadButton.h"
-
+#import "NSDate+NCUtil.h"
 @interface CCMain () <UITextViewDelegate, createFormUploadAssetsDelegate, MGSwipeTableCellDelegate, NCSelectDelegate, UITextFieldDelegate, UIAdaptivePresentationControllerDelegate>
 {
     AppDelegate *appDelegate;
@@ -1033,16 +1033,12 @@
         NSString *fileName = [CCUtility createFileName:[asset valueForKey:@"filename"] fileDate:asset.creationDate fileType:asset.mediaType keyFileName:k_keyFileNameMask keyFileNameType:k_keyFileNameType keyFileNameOriginal:k_keyFileNameOriginal];
         
         NSDate *assetDate = asset.creationDate;
-        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
         
         // Create serverUrl if use sub folder
         if (useSubFolder) {
             
-            [formatter setDateFormat:@"yyyy"];
-            NSString *yearString = [formatter stringFromDate:assetDate];
-        
-            [formatter setDateFormat:@"MM"];
-            NSString *monthString = [formatter stringFromDate:assetDate];
+            NSString *yearString = [assetDate NC_stringFromDateWithFormat:@"yyyy"];
+            NSString *monthString = [assetDate NC_stringFromDateWithFormat:@"MM"];
             
             serverUrl = [NSString stringWithFormat:@"%@/%@/%@", autoUploadPath, yearString, monthString];
         }

--- a/iOSClient/Utility/CCUtility.m
+++ b/iOSClient/Utility/CCUtility.m
@@ -25,6 +25,7 @@
 #import "CCGraphics.h"
 #import "NCBridgeSwift.h"
 #import <OpenSSL/OpenSSL.h>
+#import "NSDate+NCUtil.h"
 
 #define INTRO_MessageType       @"MessageType_"
 
@@ -816,9 +817,8 @@
 
 + (NSString *)createFileNameDate:(NSString *)fileName extension:(NSString *)extension
 {
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yy-MM-dd HH-mm-ss"];
-    NSString *fileNameDate = [formatter stringFromDate:[NSDate date]];
+  
+    NSString *fileNameDate = [[NSDate date] NC_stringFromDateWithFormat:@"yy-MM-dd HH-mm-ss"];
     NSString *returnFileName;
     
     if ([fileName isEqualToString:@""] && ![extension isEqualToString:@""]) {
@@ -853,10 +853,8 @@
     if ([fileName length] > 8) numberFileName = [fileName substringWithRange:NSMakeRange(04, 04)];
     else numberFileName = [CCUtility getIncrementalNumber];
     
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"yy-MM-dd HH-mm-ss"];
-    NSString *fileNameDate = [formatter stringFromDate:fileDate];
-    
+    NSString *fileNameDate = [fileDate NC_stringFromDateWithFormat:@"yy-MM-dd HH-mm-ss"];
+
     NSString *fileNameType = @"";
     if (fileType == PHAssetMediaTypeImage)
         fileNameType = NSLocalizedString(@"_photo_", nil);
@@ -879,26 +877,16 @@
         
         if ([fileName length] > 0) {
             
-            [formatter setDateFormat:@"dd"];
-            NSString *dayNumber = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"MMM"];
-            NSString *month = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"MM"];
-            NSString *monthNumber = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"yyyy"];
-            NSString *year = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"yy"];
-            NSString *yearNumber = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"HH"];
-            NSString *hour24 = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"hh"];
-            NSString *hour12 = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"mm"];
-            NSString *minute = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"ss"];
-            NSString *second = [formatter stringFromDate:fileDate];
-            [formatter setDateFormat:@"a"];
-            NSString *ampm = [formatter stringFromDate:fileDate];
+            NSString *dayNumber = [fileDate NC_stringFromDateWithFormat:@"dd"];
+            NSString *month = [fileDate NC_stringFromDateWithFormat:@"MMM"];;
+            NSString *monthNumber = [fileDate NC_stringFromDateWithFormat:@"MM"];
+            NSString *year = [fileDate NC_stringFromDateWithFormat:@"yyyy"];
+            NSString *yearNumber = [fileDate NC_stringFromDateWithFormat:@"yy"];
+            NSString *hour24 = [fileDate NC_stringFromDateWithFormat:@"HH"];
+            NSString *hour12 = [fileDate NC_stringFromDateWithFormat:@"hh"];
+            NSString *minute = [fileDate NC_stringFromDateWithFormat:@"mm"];
+            NSString *second = [fileDate NC_stringFromDateWithFormat:@"ss"];
+            NSString *ampm = [fileDate NC_stringFromDateWithFormat:@"a"];
             
             // Replace string with date
 
@@ -1323,14 +1311,11 @@
         
         NSDate *assetDate = asset.creationDate;
         
-        NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-        [formatter setDateFormat:@"yyyy"];
-        NSString *yearString = [formatter stringFromDate:assetDate];
+        NSString *yearString = [assetDate NC_stringFromDateWithFormat:@"yyyy"];
         if (yearString)
             [datesSubFolder addObject:yearString];
         
-        [formatter setDateFormat:@"MM"];
-        NSString *monthString = [formatter stringFromDate:assetDate];
+        NSString *monthString = [assetDate NC_stringFromDateWithFormat:@"MM"];
         monthString = [NSString stringWithFormat:@"%@/%@", yearString, monthString];
         if (monthString)
             [datesSubFolder addObject:monthString];

--- a/iOSClient/Utility/NSDate+NCUtil.h
+++ b/iOSClient/Utility/NSDate+NCUtil.h
@@ -1,0 +1,25 @@
+//  NSDate+NCUtil.h
+//  Nextcloud
+//
+//  Created by James Stout on 12/4/20.
+//  Copyright (c) 2020, James Stout (stoutyhk@gmail.com) All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+@import Foundation;
+
+@interface NSDate (NCUtil)
+
+- (NSString *)NC_stringFromDateWithFormat:(NSString*)format;
+
+@end

--- a/iOSClient/Utility/NSDate+NCUtil.m
+++ b/iOSClient/Utility/NSDate+NCUtil.m
@@ -1,0 +1,44 @@
+//  NSDate+NCUtil.m
+//  Nextcloud
+//
+//  Created by James Stout on 12/4/20.
+//  Copyright (c) 2020, James Stout (stoutyhk@gmail.com) All rights reserved.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import "NSDate+NCUtil.h"
+
+@implementation NSDate (NCUtil)
+
+/**
+ *  Convenience method that returns a formatted string representing the receiver's date formatted to a given style,
+ *
+ *  @param format    NSString - Desired date formatting style
+
+ *
+ *  @return NSString representing the formatted date string
+ */
+- (NSString *)NC_stringFromDateWithFormat:(NSString*)format {
+    static NSDateFormatter *formatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+    });
+
+    [formatter setDateFormat:format];
+
+    return [formatter stringFromDate:self];
+}
+
+@end


### PR DESCRIPTION
Per Apple: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/DataFormatting/Articles/dfDateFormatting10_4.html#//apple_ref/doc/uid/TP40002369-SW10

> Creating a date formatter is not a cheap operation. If you are likely to use a formatter frequently, it is typically more efficient to cache a single instance than to create and dispose of multiple instances. One approach is to use a static variable.

I've added performance and equality tests. All equality tests pass and performance in these simple tests show 1200% speed up and 2100% fewer heap allocs.

The new tests for CreatingNewAssetsToUpload using a device with ~28000 assets, show a 14% improvement (8 mins vs 9 mins) with the static formatter.

Signed-off-by: James Stout <stoutyhk@gmail.com>