### PR TITLE
Fix for hidesSearchBarWhenScrolling

### DIFF
--- a/iOSClient/Main/CCMain.m
+++ b/iOSClient/Main/CCMain.m
@@ -215,6 +215,9 @@
 {
     [super viewWillAppear:animated];
     [self updateNavBarShadow:self.tableView force:false];
+    if (@available(iOS 13.0, *)) {
+        self.navigationItem.hidesSearchBarWhenScrolling = true;
+    }
     // test
     if (appDelegate.activeAccount.length == 0)
         return;
@@ -242,8 +245,6 @@
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    self.navigationItem.hidesSearchBarWhenScrolling = true;
-
     // Active Main
     appDelegate.activeMain = self;
     
@@ -306,6 +307,7 @@
 // detect scroll for remove keyboard in search mode
 - (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
 {
+    self.navigationItem.hidesSearchBarWhenScrolling = true;
     if (self.searchController.isActive && scrollView == self.tableView) {
         
         [self.searchController.searchBar endEditing:YES];


### PR DESCRIPTION
Fix for #1246, it seems that this is a bug with iOS 13 and our tableview layout. 
The fix only mitigates the issue as the search bar is now hidden in the child view controllers but still visible when scrolling up.

Signed-off-by: Philippe Weidmann <philippe.weidmann@infomaniak.com>