### PR TITLE
Fix double nav bar after previewing with QuickLookViewController

### DIFF
--- a/iOSClient/Main/NCDetailViewController.swift
+++ b/iOSClient/Main/NCDetailViewController.swift
@@ -417,7 +417,7 @@ class NCDetailViewController: UIViewController {
         if let splitViewController = self.splitViewController as? NCSplitViewController {
             if splitViewController.isCollapsed {
                 if let navigationController = splitViewController.viewControllers.last as? UINavigationController {
-                    navigationController.popToRootViewController(animated: true)
+                    navigationController.popViewController(animated: true)
                 }
             } else {
                 


### PR DESCRIPTION
After previewing a file which requires the QuickLookViewController, the main navbar would be under a second a nav bar resulting in weird bug (only happening on non iPad device). 

This commit fixes this behaviour.

The bug before this commit:
![Simulator Screen Shot - iPhone X - iOS 13 - 2020-06-08 at 13 29 58](https://user-images.githubusercontent.com/5843044/84025605-2cc75d00-a98c-11ea-8352-08abb392440b.png)


Signed-off-by: Philippe Weidmann <philippe.weidmann@infomaniak.com>