### PR TITLE
Fix bad quality for PDF scanning

### DIFF
--- a/iOSClient/Main/Create cloud/NCCreateFormUploadScanDocument.swift
+++ b/iOSClient/Main/Create cloud/NCCreateFormUploadScanDocument.swift
@@ -661,15 +661,19 @@ class NCCreateFormUploadScanDocument: XLFormViewController, NCSelectDelegate, NC
     func changeCompressionImage(_ image: UIImage, dpiQuality: typeDpiQuality) -> UIImage {
         
         var compressionQuality: CGFloat = 0.5
-        let maxHeight: Float = 595.2        // A4
-        let maxWidth: Float = 841.8         // A4
+        var maxHeight: Float = 595.2        // A4
+        var maxWidth: Float = 841.8    // A4
 
         switch dpiQuality {
         case typeDpiQuality.low:
             compressionQuality = 0.1
         case typeDpiQuality.medium:
+            maxHeight*=2
+            maxWidth*=2
             compressionQuality = 0.5
         case typeDpiQuality.hight:
+            maxHeight*=4
+            maxWidth*=4
             compressionQuality = 0.9
         }
         


### PR DESCRIPTION
The logic to change the quality of PDF file seems wrong and results in bad PDF quality even when choosing "high" setting.
Signed-off-by: Philippe Weidmann <philippe.weidmann@infomaniak.com>