### PR TITLE
typo fix

### DIFF
--- a/iOSClient/Main/Create cloud/NCCreateFormUploadAssets.swift
+++ b/iOSClient/Main/Create cloud/NCCreateFormUploadAssets.swift
@@ -510,7 +510,7 @@ class NCCreateFormUploadAssets: XLFormViewController, NCSelectDelegate {
             returnString = CCUtility.createFileName(asset.value(forKey: "filename") as! String?, fileDate: asset.creationDate, fileType: asset.mediaType, keyFileName: nil, keyFileNameType: k_keyFileNameType, keyFileNameOriginal: k_keyFileNameOriginal)
         }
         
-        return String(format: NSLocalizedString("_preview_filename_", comment: ""), "MM,MMM,DD,YY,YYYY and HH,hh,mm,ss,ampm") + ":" + "\n\n" + returnString
+        return String(format: NSLocalizedString("_preview_filename_", comment: ""), "MM, MMM, DD, YY, YYYY, HH, hh, mm, ss, ampm") + ":" + "\n\n" + returnString
     }
     
     @objc func changeDestinationFolder(_ sender: XLFormRowDescriptor) {

--- a/iOSClient/Settings/NCManageAutoUploadFileName.swift
+++ b/iOSClient/Settings/NCManageAutoUploadFileName.swift
@@ -212,6 +212,6 @@ class NCManageAutoUploadFileName: XLFormViewController {
             returnString = CCUtility.createFileName("IMG_0001.JPG", fileDate: dateExample, fileType: PHAssetMediaType.image, keyFileName: nil, keyFileNameType: k_keyFileNameAutoUploadType, keyFileNameOriginal: k_keyFileNameOriginalAutoUpload)
         }
         
-        return String(format: NSLocalizedString("_preview_filename_", comment: ""), "MM,MMM,DD,YY,YYYY and HH,hh,mm,ss,ampm") + ":" + "\n\n" + returnString
+        return String(format: NSLocalizedString("_preview_filename_", comment: ""), "MM, MMM, DD, YY, YYYY, HH, hh, mm, ss, ampm") + ":" + "\n\n" + returnString
     }
 }


### PR DESCRIPTION
Fixing typos: Adding spaces after the commas and removing the word "and", since this string is used in all i18n versions.