### PR TITLE
Remove DZNEmptyDataSet lib from bridging header.

### DIFF
--- a/iOSClient/Nextcloud-Bridging-Header.h
+++ b/iOSClient/Nextcloud-Bridging-Header.h
@@ -9,5 +9,4 @@
 #import "NCEndToEndEncryption.h"
 #import "NYMnemonic.h"
 #import "PKStopDownloadButton.h"
-#import <DZNEmptyDataSet/UIScrollView+EmptyDataSet.h>
 #import "CCPeekPop.h"


### PR DESCRIPTION
The library is not used any more.