### PR TITLE
Update README on need for Firebase config for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ carthage update --use-xcframeworks --platform iOS --cache-builds
 ```
 to fetch and compile the dependencies.
 
+In order to build the project in Xcode you will also need a file `GoogleService-Info.plist` at the root of the repository which contains the Firebase configuration. For development work you can use a mock version found [here](https://github.com/firebase/quickstart-ios/blob/master/mock-GoogleService-Info.plist).
+
 ### Creating Pull requests
 
 #### DCO Signoff


### PR DESCRIPTION
I tried building the project after a fresh clone from `master` and Xcode kept complaining about a missing `GoogleService-Info.plist` file which is referenced in the build configuration.

After some Google searches, I figured out that this was the Firebase configuration that was needed and found a mock version on the Firebase repos that I could use to build the project locally and explore future contributions. 

This PR is trying to add a line to the readme under the dependencies section to point other people at the mock file that I found.