### PR TITLE
Feature: Re-Selecting "Sort By..." will reverse order

### DIFF
--- a/iOSClient/Media/NCMedia.swift
+++ b/iOSClient/Media/NCMedia.swift
@@ -497,7 +497,7 @@ extension NCMedia {
         }
               
         DispatchQueue.global().async {
-            self.metadatas = NCManageDatabase.shared.getMetadatasMedia(predicate: predicateForGetMetadatasMedia, sort: CCUtility.getMediaSortDate())
+            self.metadatas = NCManageDatabase.shared.getMetadatasMedia(predicate: predicateForGetMetadatasMedia, sort: CCUtility.getMediaSortDate(), ascending: CCUtility.getMediaSortOrder())
             DispatchQueue.main.sync {
                 self.reloadDataThenPerform {
                     self.updateMediaControlVisibility()

--- a/iOSClient/Menu/NCMedia+Menu.swift
+++ b/iOSClient/Menu/NCMedia+Menu.swift
@@ -97,6 +97,9 @@ extension NCMedia {
                     selected: CCUtility.getMediaSortDate() == "date",
                     on: true,
                     action: { menuAction in
+                        if (CCUtility.getMediaSortDate() == "date") {
+                            CCUtility.setMediaSortOrder(!CCUtility.getMediaSortOrder())
+                        }
                         CCUtility.setMediaSortDate("date")
                         self.reloadDataSourceWithCompletion { (_) in }
                     }
@@ -110,6 +113,9 @@ extension NCMedia {
                     selected: CCUtility.getMediaSortDate() == "creationDate",
                     on: true,
                     action: { menuAction in
+                        if (CCUtility.getMediaSortDate() == "creationDate") {
+                            CCUtility.setMediaSortOrder(!CCUtility.getMediaSortOrder())
+                        }
                         CCUtility.setMediaSortDate("creationDate")
                         self.reloadDataSourceWithCompletion { (_) in }
                     }
@@ -123,6 +129,9 @@ extension NCMedia {
                     selected: CCUtility.getMediaSortDate() == "uploadDate",
                     on: true,
                     action: { menuAction in
+                        if (CCUtility.getMediaSortDate() == "uploadDate") {
+                            CCUtility.setMediaSortOrder(!CCUtility.getMediaSortOrder())
+                        }
                         CCUtility.setMediaSortDate("uploadDate")
                         self.reloadDataSourceWithCompletion { (_) in }
                     }

--- a/iOSClient/Utility/CCUtility.h
+++ b/iOSClient/Utility/CCUtility.h
@@ -158,6 +158,8 @@
 
 + (NSString *)getMediaSortDate;
 + (void)setMediaSortDate:(NSString *)value;
++ (BOOL)getMediaSortOrder;
++ (void)setMediaSortOrder:(BOOL)set;
 
 + (NSInteger)getTextRecognitionStatus;
 + (void)setTextRecognitionStatus:(NSInteger)value;

--- a/iOSClient/Utility/CCUtility.m
+++ b/iOSClient/Utility/CCUtility.m
@@ -599,13 +599,13 @@
 + (BOOL)getLivePhoto
 {
     NSString *valueString = [UICKeyChainStore stringForKey:@"livePhoto" service:NCGlobal.shared.serviceShareKeyChain];
-    
+
     // Default TRUE
     if (valueString == nil) {
         [self setLivePhoto:YES];
         return true;
     }
-    
+
     return [valueString boolValue];
 }
 
@@ -631,6 +631,25 @@
 + (void)setMediaSortDate:(NSString *)value
 {
     [UICKeyChainStore setString:value forKey:@"mediaSortDate" service:NCGlobal.shared.serviceShareKeyChain];
+}
+
++ (BOOL)getMediaSortOrder
+{
+    NSString *valueString = [UICKeyChainStore stringForKey:@"sortOrder" service:NCGlobal.shared.serviceShareKeyChain];
+
+    // Default FALSE
+    if (valueString == nil) {
+        [self setMediaSortOrder:NO];
+        return false;
+    }
+
+    return [valueString boolValue];
+}
+
++ (void)setMediaSortOrder:(BOOL)set
+{
+    NSString *sSet = (set) ? @"true" : @"false";
+    [UICKeyChainStore setString:sSet forKey:@"sortOrder" service:NCGlobal.shared.serviceShareKeyChain];
 }
 
 + (NSInteger)getTextRecognitionStatus


### PR DESCRIPTION
This PR introduces reverse sorting under the "Media" tab.
I'm not sure if there was a particular reason this feature did not exist, but it is quite useful in my use cases.

**This does not include any localization.**
 > feature: Re-selecting "Sort By..." will change between ascending & descending order  under "Media"

## 1. Select "Media"
> Default sort is **_descending_**

<img width="377" alt="1" src="https://user-images.githubusercontent.com/16694155/134551058-e72b553e-5b2e-4486-8e43-990ec4b4442c.png">

## 2. Default Sort

1             |  2 | 3
:-------------------------:|:-------------------------:|:-------------------------:
<img width="377" alt="2" src="https://user-images.githubusercontent.com/16694155/134551793-67680637-19dc-46d8-8e26-213f6357929c.png"> | <img width="421" alt="3" src="https://user-images.githubusercontent.com/16694155/134551976-7a62e716-9511-49f1-af11-605ea41a7f5a.png"> | <img width="421" alt="4" src="https://user-images.githubusercontent.com/16694155/134552595-457e7c02-8306-44ff-8c82-301dc5fc24a2.png">


## 2. Re-selecting sort will reverse order

Re-select Sort By...             |  Order is now ascending 
:-------------------------:|:-------------------------:
<img width="421" alt="5" src="https://user-images.githubusercontent.com/16694155/134552647-326dafc6-0147-4ff9-aa19-64c7e64973e3.png"> | <img width="421" alt="Screen Shot 2021-09-23 at 1 06 39 PM" src="https://user-images.githubusercontent.com/16694155/134552669-880123b8-dedf-4807-ae61-761dfcc82cc1.png">




