### PR TITLE
Remove "(Experimental)" from E2EE settings

### DIFF
--- a/iOSClient/Settings/NCSettings.m
+++ b/iOSClient/Settings/NCSettings.m
@@ -100,7 +100,7 @@
     [form addFormSection:section];
     
     // EndToEnd Encryption
-    NSString *title = [NSString stringWithFormat:@"%@ (%@)",NSLocalizedString(@"_e2e_settings_", nil), NSLocalizedString(@"_experimental_", nil)];
+    NSString *title = [NSString stringWithFormat:@"%@",NSLocalizedString(@"_e2e_settings_", nil)];
     row = [XLFormRowDescriptor formRowDescriptorWithTag:@"e2eEncryption" rowType:XLFormRowDescriptorTypeButton title:title];
     row.cellConfigAtConfigure[@"backgroundColor"] = NCBrandColor.shared.secondarySystemGroupedBackground;
     [row.cellConfig setObject:[UIFont systemFontOfSize:15.0] forKey:@"textLabel.font"];


### PR DESCRIPTION
Fix #1718 
Fix #1418 

I kept the "_experimental_" l10n translations. Might be useful in the future. On the other hand it needs 43 lines of 'code' that are (as of now) unnecessary.