### PR TITLE
Add files_sharing capabilities

### DIFF
--- a/iOSClient/Data/NCElementsJSON.swift
+++ b/iOSClient/Data/NCElementsJSON.swift
@@ -34,6 +34,8 @@ import UIKit
     
     @objc public let capabilitiesFileSharingApiEnabled:         Array = ["ocs","data","capabilities","files_sharing","api_enabled"]
     @objc public let capabilitiesFileSharingPubPasswdEnforced:  Array = ["ocs","data","capabilities","files_sharing","public","password","enforced"]
+    // NC >= 23
+    @objc public let capabilitiesFileSharingSendPasswordMail:  Array = ["ocs","data","capabilities","files_sharing","sharebymail","send_password_by_mail"]
 
     @objc public let capabilitiesThemingColor:                  Array = ["ocs","data","capabilities","theming","color"]
     @objc public let capabilitiesThemingColorElement:           Array = ["ocs","data","capabilities","theming","color-element"]

--- a/iOSClient/Data/NCElementsJSON.swift
+++ b/iOSClient/Data/NCElementsJSON.swift
@@ -34,6 +34,7 @@ import UIKit
     
     @objc public let capabilitiesFileSharingApiEnabled:         Array = ["ocs","data","capabilities","files_sharing","api_enabled"]
     @objc public let capabilitiesFileSharingPubPasswdEnforced:  Array = ["ocs","data","capabilities","files_sharing","public","password","enforced"]
+    @objc public let capabilitiesFileSharingDefaultPermissions: Array = ["ocs","data","capabilities","files_sharing","default_permissions"]
     // NC >= 23
     @objc public let capabilitiesFileSharingSendPasswordMail:  Array = ["ocs","data","capabilities","files_sharing","sharebymail","send_password_by_mail"]
 


### PR DESCRIPTION
Add json paths for 
- `send_password_by_mail` capability bool value
  - Close #1754 
- `default_permissions` int value
  - #1701 
  - https://github.com/nextcloud/files-clients/issues/4

Usage:
`
NCManageDatabase.shared.getCapabilitiesServerBool(account: <#User account#>, elements: NCElementsJSON.shared.capabilitiesFileSharingSendPasswordMail, exists: false)
`
