### PR TITLE
Capability default permissions

### DIFF
--- a/iOSClient/Data/NCManageDatabase.swift
+++ b/iOSClient/Data/NCManageDatabase.swift
@@ -1067,10 +1067,8 @@ class NCManageDatabase: NSObject {
 
         let realm = try! Realm()
         
-        guard let result = realm.objects(tableCapabilities.self).filter("account == %@", account).first else {
-            return 0
-        }
-        guard let jsondata = result.jsondata else {
+        guard let result = realm.objects(tableCapabilities.self).filter("account == %@", account).first,
+              let jsondata = result.jsondata else {
             return 0
         }
         

--- a/iOSClient/NCGlobal.swift
+++ b/iOSClient/NCGlobal.swift
@@ -238,7 +238,7 @@ class NCGlobal: NSObject {
     @objc let permissionCanMove                     = "V"
     
     //Share permission
-    //permissions - (int) 1 = read; 2 = update; 4 = create; 8 = delete; 16 = share; 31 = all (default: 31, for public shares: 1)
+    //permissions - (int) 1 = read; 2 = update; 4 = create; 8 = delete; 16 = share; 31 = all
     //
     @objc let permissionReadShare: Int              = 1
     @objc let permissionUpdateShare: Int            = 2

--- a/iOSClient/Share/NCShareNetworking.swift
+++ b/iOSClient/Share/NCShareNetworking.swift
@@ -75,8 +75,11 @@ class NCShareNetworking: NSObject {
     func createShare(shareWith: String, shareType: Int, metadata: tableMetadata) {
         NCUtility.shared.startActivityIndicator(backgroundView: view, blurEffect: false)
         let filenamePath = CCUtility.returnFileNamePath(fromFileName: metadata.fileName, serverUrl: metadata.serverUrl, urlBase: urlBase, account: metadata.account)!
-        var permission: Int = 1
-        if metadata.directory { permission = NCGlobal.shared.permissionMaxFolderShare } else { permission = NCGlobal.shared.permissionMaxFileShare }
+        var permission: Int = NCManageDatabase.shared.getCapabilitiesServerInt(account: metadata.account, elements: ["ocs","data","capabilities","files_sharing","default_permissions"])
+        if permission <= 0 {
+            permission = metadata.directory ? NCGlobal.shared.permissionMaxFolderShare : NCGlobal.shared.permissionMaxFileShare
+        }
+
         NCCommunication.shared.createShare(path: filenamePath, shareType: shareType, shareWith: shareWith, permissions: permission) { (account, share, errorCode, errorDescription) in
             NCUtility.shared.stopActivityIndicator()
             if errorCode == 0 && share != nil {

--- a/iOSClient/Share/NCShareQuickStatusMenu.swift
+++ b/iOSClient/Share/NCShareQuickStatusMenu.swift
@@ -16,24 +16,6 @@ class NCShareQuickStatusMenu: NSObject {
         let menuViewController = UIStoryboard.init(name: "NCMenu", bundle: nil).instantiateInitialViewController() as! NCMenu
         var actions = [NCMenuAction]()
 
-//        "_share_read_only_"             = "Read only";
-//        "_share_editing_"               = "Editing";
-//        "_share_allow_upload_"          = "Allow upload and editing";
-//        "_share_file_drop_"             = "File drop (upload only)";
-        
-//        @objc let permissionReadShare: Int              = 1
-//        @objc let permissionUpdateShare: Int            = 2
-//        @objc let permissionCreateShare: Int            = 4
-//        @objc let permissionDeleteShare: Int            = 8
-//        @objc let permissionShareShare: Int             = 16
-        
-//        @objc let permissionMinFileShare: Int           = 1
-//        @objc let permissionMaxFileShare: Int           = 19
-//        @objc let permissionMinFolderShare: Int         = 1
-//        @objc let permissionMaxFolderShare: Int         = 31
-//        @objc let permissionDefaultFileRemoteShareNoSupportShareOption: Int     = 3
-//        @objc let permissionDefaultFolderRemoteShareNoSupportShareOption: Int   = 15
-        
         actions.append(
             NCMenuAction(
                 title: NSLocalizedString("_share_read_only_", comment: ""),
@@ -52,7 +34,7 @@ class NCShareQuickStatusMenu: NSObject {
             NCMenuAction(
                 title: directory ? NSLocalizedString("_share_allow_upload_", comment: "") : NSLocalizedString("_share_editing_", comment: ""),
                 icon: UIImage(),
-                selected: tableShare.permissions == NCGlobal.shared.permissionMaxFileShare || tableShare.permissions == NCGlobal.shared.permissionMaxFolderShare || tableShare.permissions == NCGlobal.shared.permissionDefaultFileRemoteShareNoSupportShareOption || tableShare.permissions == NCGlobal.shared.permissionDefaultFolderRemoteShareNoSupportShareOption,
+                selected: hasUploadPermission(tableShare: tableShare),
                 on: false,
                 action: { menuAction in
                     let canShare = CCUtility.isPermission(toCanShare: tableShare.permissions)
@@ -61,24 +43,7 @@ class NCShareQuickStatusMenu: NSObject {
                 }
             )
         )
-        
-        /*
-        if directory {
-            actions.append(
-                NCMenuAction(
-                    title: NSLocalizedString("_share_file_drop_", comment: ""),
-                    icon: UIImage(),
-                    selected: tableShare.permissions == NCGlobal.shared.permissionCreateShare,
-                    on: false,
-                    action: { menuAction in
-                        let permissions = NCGlobal.shared.permissionCreateShare
-                        NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterShareChangePermissions, userInfo: ["idShare": tableShare.idShare, "permissions": permissions, "hideDownload": tableShare.hideDownload])
-                    }
-                )
-            )
-        }
-        */
-        
+
         menuViewController.actions = actions
 
         let menuPanelController = NCMenuPanelController()
@@ -88,6 +53,15 @@ class NCShareQuickStatusMenu: NSObject {
         menuPanelController.track(scrollView: menuViewController.tableView)
 
         viewController.present(menuPanelController, animated: true, completion: nil)
+    }
+
+    fileprivate func hasUploadPermission(tableShare: tableShare) -> Bool {
+        let uploadPermissions = [
+            NCGlobal.shared.permissionMaxFileShare,
+            NCGlobal.shared.permissionMaxFolderShare,
+            NCGlobal.shared.permissionDefaultFileRemoteShareNoSupportShareOption,
+            NCGlobal.shared.permissionDefaultFolderRemoteShareNoSupportShareOption]
+        return uploadPermissions.contains(tableShare.permissions)
     }
 }
 


### PR DESCRIPTION
- Close #1701 

As fallback (if not set, or not loaded) use max permissions. Folder = 31 (all), File = 19 (read, update, share).
If permission is `0`, [server set minimum permission](https://github.com/nextcloud/server/blob/6ea81dd2cbfb8a9013895d07fb4df17b8df27348/apps/files_sharing/lib/Controller/ShareAPIController.php#L485). If unset, [server falls back to config or max permission](https://github.com/nextcloud/server/blob/6ea81dd2cbfb8a9013895d07fb4df17b8df27348/apps/files_sharing/lib/Controller/ShareAPIController.php#L456-L458).