### PR TITLE
Update NCLoginWeb.swift

### DIFF
--- a/iOSClient/Login/NCLoginWeb.swift
+++ b/iOSClient/Login/NCLoginWeb.swift
@@ -106,12 +106,17 @@ class NCLoginWeb: UIViewController {
         
         let language = NSLocale.preferredLanguages[0] as String
         var request = URLRequest(url: url)
-        let userAgent = CCUtility.getUserAgent()
+
+        if let deviceName = "\(UIDevice.current.name) (\(NCBrandOptions.shared.brand) iOS)".cString(using: .utf8),
+            let deviceUserAgent = String(cString: deviceName, encoding: .ascii) {
+            webView.customUserAgent = deviceUserAgent
+        } else {
+            webView.customUserAgent = CCUtility.getUserAgent()
+        }
 
         request.addValue("true", forHTTPHeaderField: "OCS-APIRequest")
         request.addValue(language, forHTTPHeaderField: "Accept-Language")
-        
-        webView.customUserAgent = userAgent
+
         webView.load(request)
     }
     

--- a/iOSClient/Login/NCLoginWeb.swift
+++ b/iOSClient/Login/NCLoginWeb.swift
@@ -106,9 +106,8 @@ class NCLoginWeb: UIViewController {
         
         let language = NSLocale.preferredLanguages[0] as String
         var request = URLRequest(url: url)
-        let deviceName = UIDevice.current.name
-        let userAgent = deviceName + " " + "(iOS Files)"
-        
+        let userAgent = CCUtility.getUserAgent()
+
         request.addValue("true", forHTTPHeaderField: "OCS-APIRequest")
         request.addValue(language, forHTTPHeaderField: "Accept-Language")
         


### PR DESCRIPTION
Use default app user agent for login. This will display *Nextcloud iOS app* in the user security settings.

- Fixes #1791 
- Fixes #1800 
- Fixes #1803 

- [x] Tested