### PR TITLE
Fix share paging UI landscape 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,13 +4,16 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_string
   - explicit_init
   - unneeded_parentheses_in_closure_argument
+  - operator_usage_whitespace
+  - force_unwrapping
 
 empty_count:
   severity: warning
 
 line_length:
   # warning: 120
-  warning: 200
+  warning: 250
+  error: 250
 
 type_body_length:
   # error: 350
@@ -104,15 +107,11 @@ excluded:
   - iOSClient/Select/NCSelect.swift
   - iOSClient/Settings/NCEndToEndInitialize.swift
   - iOSClient/Settings/NCManageAutoUploadFileName.swift
-  - iOSClient/Share/NCShare.swift
   - iOSClient/Share/NCShareCommentsCell.swift
   - iOSClient/Share/NCShareCommon.swift
-  - iOSClient/Share/NCShareLinkCell.swift
   - iOSClient/Share/NCShareLinkMenuView.swift
   - iOSClient/Share/NCShareNetworking.swift
-  - iOSClient/Share/NCSharePaging.swift
   - iOSClient/Share/NCShareQuickStatusMenu.swift
-  - iOSClient/Share/NCShareUserCell.swift
   - iOSClient/Share/NCShareUserMenuView.swift
   - iOSClient/Shares/NCShares.swift
   - iOSClient/Transfers/NCTransferCell.swift

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 		F771E3F820E239B500AFB62D /* FileProviderExtension+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = F771E3F520E239B400AFB62D /* FileProviderExtension+Thumbnail.swift */; };
 		F7725A60251F33BB00D125E0 /* NCFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7725A5E251F33BB00D125E0 /* NCFiles.swift */; };
 		F7725A61251F33BB00D125E0 /* NCFiles.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F7725A5F251F33BB00D125E0 /* NCFiles.storyboard */; };
-		F774264A22EB4D0000B23912 /* NCShareUserDropDownCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F774264822EB4D0000B23912 /* NCShareUserDropDownCell.xib */; };
+		F774264A22EB4D0000B23912 /* NCSearchUserDropDownCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F774264822EB4D0000B23912 /* NCSearchUserDropDownCell.xib */; };
 		F77444F522281649000D5EB0 /* NCGridMediaCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77444F322281649000D5EB0 /* NCGridMediaCell.swift */; };
 		F77444F622281649000D5EB0 /* NCGridMediaCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F77444F422281649000D5EB0 /* NCGridMediaCell.xib */; };
 		F77444F8222816D5000D5EB0 /* NCPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F77444F7222816D5000D5EB0 /* NCPickerViewController.swift */; };
@@ -672,7 +672,7 @@
 		F7725A5E251F33BB00D125E0 /* NCFiles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCFiles.swift; sourceTree = "<group>"; };
 		F7725A5F251F33BB00D125E0 /* NCFiles.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NCFiles.storyboard; sourceTree = "<group>"; };
 		F774264022EB3F7300B23912 /* DropDown.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DropDown.framework; path = Carthage/Build/iOS/DropDown.framework; sourceTree = "<group>"; };
-		F774264822EB4D0000B23912 /* NCShareUserDropDownCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NCShareUserDropDownCell.xib; sourceTree = "<group>"; };
+		F774264822EB4D0000B23912 /* NCSearchUserDropDownCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NCSearchUserDropDownCell.xib; sourceTree = "<group>"; };
 		F77438EB1FCD694900662C46 /* ka-GE */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ka-GE"; path = "ka-GE.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		F77438F21FCD69D300662C46 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F77438F91FCD6A0D00662C46 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -1075,15 +1075,15 @@
 				F73CB3B122E072A000AD728E /* NCShareHeaderView.xib */,
 				F787704E22E7019900F287A9 /* NCShareLinkCell.xib */,
 				AF2D7C7B2742556F00ADF566 /* NCShareLinkCell.swift */,
-				F79728D322F96F2D003CACA7 /* NCShareLinkFolderMenuView.xib */,
-				F769454122E9F0EE000A798A /* NCShareLinkMenuView.swift */,
 				F7DFAA8922E22EF100FC4527 /* NCShareLinkMenuView.xib */,
 				F769454722E9F20D000A798A /* NCShareNetworking.swift */,
 				F769453F22E9F077000A798A /* NCSharePaging.swift */,
 				F77EFC0B26D6751F00806ED6 /* NCShareQuickStatusMenu.swift */,
+				F774264822EB4D0000B23912 /* NCSearchUserDropDownCell.xib */,
 				F769453B22E9CFFF000A798A /* NCShareUserCell.xib */,
 				AF2D7C7D2742559100ADF566 /* NCShareUserCell.swift */,
-				F774264822EB4D0000B23912 /* NCShareUserDropDownCell.xib */,
+				F79728D322F96F2D003CACA7 /* NCShareLinkFolderMenuView.xib */,
+				F769454122E9F0EE000A798A /* NCShareLinkMenuView.swift */,
 				F79728D522F9A0B0003CACA7 /* NCShareUserFolderMenuView.xib */,
 				F769453D22E9E97D000A798A /* NCShareUserMenuView.xib */,
 				F769454322E9F142000A798A /* NCShareUserMenuView.swift */,
@@ -2097,7 +2097,7 @@
 				F7D1612023CF19E30039EBBF /* NCViewerRichWorkspace.storyboard in Resources */,
 				F77B0F631D118A16002130FE /* Localizable.strings in Resources */,
 				F7632FC1218353AA00721B71 /* NCTrashSectionFooter.xib in Resources */,
-				F774264A22EB4D0000B23912 /* NCShareUserDropDownCell.xib in Resources */,
+				F774264A22EB4D0000B23912 /* NCSearchUserDropDownCell.xib in Resources */,
 				F7CB689A2541676B0050EC94 /* NCMore.storyboard in Resources */,
 				F70B866D2642A21300ED5349 /* NCBackgroundImageColor.storyboard in Resources */,
 				F77B0F7D1D118A16002130FE /* Images.xcassets in Resources */,

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		AF4BF61F27562B3F0081CEEF /* NCManageDatabase+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */; };
 		AF4BF62027562B3F0081CEEF /* NCManageDatabase+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */; };
 		AF4BF62127562B3F0081CEEF /* NCManageDatabase+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */; };
+		AF730AF827834B1400B7520E /* NCShare+NCCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF730AF727834B1400B7520E /* NCShare+NCCellDelegate.swift */; };
 		AF817EF1274BC781009ED85B /* NCUserBaseUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF817EF0274BC781009ED85B /* NCUserBaseUrl.swift */; };
 		AF817EF2274BC781009ED85B /* NCUserBaseUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF817EF0274BC781009ED85B /* NCUserBaseUrl.swift */; };
 		AF817EF3274BC781009ED85B /* NCUserBaseUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF817EF0274BC781009ED85B /* NCUserBaseUrl.swift */; };
@@ -462,6 +463,7 @@
 		AF4BF613275629E20081CEEF /* NCManageDatabase+Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+Account.swift"; sourceTree = "<group>"; };
 		AF4BF61827562A4B0081CEEF /* NCManageDatabse+Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCManageDatabse+Metadata.swift"; sourceTree = "<group>"; };
 		AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+Activity.swift"; sourceTree = "<group>"; };
+		AF730AF727834B1400B7520E /* NCShare+NCCellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCShare+NCCellDelegate.swift"; sourceTree = "<group>"; };
 		AF817EF0274BC781009ED85B /* NCUserBaseUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCUserBaseUrl.swift; sourceTree = "<group>"; };
 		AF8ED1F92757821000B8DBC4 /* NextcloudTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextcloudTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF8ED1FB2757821000B8DBC4 /* NextcloudTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextcloudTests.swift; sourceTree = "<group>"; };
@@ -1069,6 +1071,7 @@
 			children = (
 				F700510022DF63AC003A3356 /* NCShare.storyboard */,
 				F700510422DF6A89003A3356 /* NCShare.swift */,
+				AF730AF727834B1400B7520E /* NCShare+NCCellDelegate.swift */,
 				F723B3DC22FC6D1C00301EFE /* NCShareCommentsCell.xib */,
 				F7E4D9C322ED929B003675FD /* NCShareCommentsCell.swift */,
 				F769454522E9F1B0000A798A /* NCShareCommon.swift */,
@@ -2329,6 +2332,7 @@
 				F7A0D1352591FBC5008F8A13 /* String+Extensions.swift in Sources */,
 				F77B0E5F1D118A16002130FE /* NCSettings.m in Sources */,
 				F7F9D1BB25397CE000D9BFF5 /* NCViewer.swift in Sources */,
+				AF730AF827834B1400B7520E /* NCShare+NCCellDelegate.swift in Sources */,
 				F70460522499061800BB98A7 /* NotificationCenter+MainThread.swift in Sources */,
 				F78F74362163781100C2ADAD /* NCTrash.swift in Sources */,
 				AF817EF1274BC781009ED85B /* NCUserBaseUrl.swift in Sources */,

--- a/Nextcloud.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nextcloud.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk",
         "state": {
           "branch": null,
-          "revision": "08686f04881483d2bc098b2696e674c0ba135e47",
-          "version": "8.10.0"
+          "revision": "839cc6b0cd80b0b8bf81fe9bd82b743b25dc6446",
+          "version": "8.9.1"
         }
       },
       {
@@ -168,8 +168,8 @@
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {
           "branch": null,
-          "revision": "611337c330350c9c1823ad6d671e7f936af5ee13",
-          "version": "2.0.0"
+          "revision": "afa9a1ace74e116848d4f743599ab83e584ff8cb",
+          "version": "1.2.12"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/realm/realm-cocoa",
         "state": {
           "branch": null,
-          "revision": "f483fa0a52f6d49897d133a827510a35e21183c1",
-          "version": "10.20.1"
+          "revision": "e83cc9f28e8bccd477b6b81cee521c02239d2773",
+          "version": "10.20.2"
         }
       },
       {
@@ -267,8 +267,8 @@
         "repositoryURL": "https://github.com/yahoojapan/SwiftyXMLParser",
         "state": {
           "branch": null,
-          "revision": "d7a1d23f04c86c1cd2e8f19247dd15d74e0ea8be",
-          "version": "5.6.0"
+          "revision": "ad5eeeaf7797f69e26943aaa53c81c6a9fdaa516",
+          "version": "5.5.0"
         }
       }
     ]

--- a/Nextcloud.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nextcloud.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,9 +113,9 @@
         "package": "NCCommunication",
         "repositoryURL": "https://github.com/nextcloud/ios-communication-library/",
         "state": {
-          "branch": "develop",
+          "branch": null,
           "revision": "c8e3eac61a846775d570b1d252612a8d2d02930d",
-          "version": null
+          "version": "0.99.3"
         }
       },
       {

--- a/Nextcloud.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Nextcloud.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,9 +113,9 @@
         "package": "NCCommunication",
         "repositoryURL": "https://github.com/nextcloud/ios-communication-library/",
         "state": {
-          "branch": null,
+          "branch": "develop",
           "revision": "c8e3eac61a846775d570b1d252612a8d2d02930d",
-          "version": "0.99.3"
+          "version": null
         }
       },
       {

--- a/iOSClient/Activity/NCActivity.swift
+++ b/iOSClient/Activity/NCActivity.swift
@@ -26,7 +26,7 @@ import UIKit
 import SwiftRichString
 import NCCommunication
 
-class NCActivity: UIViewController {
+class NCActivity: UIViewController, NCSharePagingContent {
 
     @IBOutlet weak var tableView: UITableView!
 
@@ -34,6 +34,7 @@ class NCActivity: UIViewController {
     @IBOutlet weak var imageItem: UIImageView!
     @IBOutlet weak var labelUser: UILabel!
     @IBOutlet weak var newCommentField: UITextField!
+    var textField: UITextField { newCommentField }
 
     @IBOutlet weak var viewContainerConstraint: NSLayoutConstraint!
     var height: CGFloat = 0

--- a/iOSClient/Extensions/String+Extensions.swift
+++ b/iOSClient/Extensions/String+Extensions.swift
@@ -49,7 +49,7 @@ extension String {
         //https://stackoverflow.com/a/32166735/9506784
 
         let length = Int(CC_MD5_DIGEST_LENGTH)
-        let messageData = self.data(using: .utf8)!
+        let messageData = self.data(using: .utf8) ?? Data()
         var digestData = Data(count: length)
 
         _ = digestData.withUnsafeMutableBytes { digestBytes -> UInt8 in

--- a/iOSClient/Menu/NCTrash+Menu.swift
+++ b/iOSClient/Menu/NCTrash+Menu.swift
@@ -81,14 +81,14 @@ extension NCTrash {
             return
         }
 
-        var iconHeader: UIImage!
+        var iconHeader: UIImage
         if let icon = UIImage(contentsOfFile: CCUtility.getDirectoryProviderStorageIconOcId(tableTrash.fileId, etag: tableTrash.fileName)) {
             iconHeader = icon
         } else {
             if tableTrash.directory {
-                iconHeader = UIImage(named: "folder")!.image(color: NCBrandColor.shared.gray, size: 50)
+                iconHeader = NCUtility.shared.loadImage(named: "folder", color: NCBrandColor.shared.gray)
             } else {
-                iconHeader = UIImage(named: tableTrash.iconName)
+                iconHeader = NCUtility.shared.loadImage(named: tableTrash.iconName)
             }
         }
 
@@ -126,7 +126,7 @@ extension NCTrash {
             iconHeader = icon
         } else {
             if tableTrash.directory {
-                iconHeader = UIImage(named: "folder")!.image(color: NCBrandColor.shared.gray, size: 50)
+                iconHeader = UIImage(named: "folder")?.image(color: NCBrandColor.shared.gray, size: 50)
             } else {
                 iconHeader = UIImage(named: tableTrash.iconName)
             }
@@ -143,7 +143,7 @@ extension NCTrash {
         actions.append(
             NCMenuAction(
                 title: NSLocalizedString("_restore_", comment: ""),
-                icon: UIImage(named: "restore")!.image(color: NCBrandColor.shared.gray, size: 50),
+                icon: NCUtility.shared.loadImage(named: "restore", color: NCBrandColor.shared.gray),
                 action: { _ in
                     self.restoreItem(with: objectId)
                 }

--- a/iOSClient/RichWorkspace/NCViewerRichWorkspaceWebView.swift
+++ b/iOSClient/RichWorkspace/NCViewerRichWorkspaceWebView.swift
@@ -41,8 +41,8 @@ class NCViewerRichWorkspaceWebView: UIViewController, WKNavigationDelegate, WKSc
 
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidShow), name: UIResponder.keyboardDidShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-
-        var request = URLRequest(url: URL(string: url)!)
+        guard let url = URL(string: url) else { return }
+        var request = URLRequest(url: url)
         request.addValue("true", forHTTPHeaderField: "OCS-APIRequest")
         let language = NSLocale.preferredLanguages[0] as String
         request.addValue(language, forHTTPHeaderField: "Accept-Language")
@@ -54,7 +54,7 @@ class NCViewerRichWorkspaceWebView: UIViewController, WKNavigationDelegate, WKSc
     }
 
     @objc func keyboardDidShow(notification: Notification) {
-        let safeAreaInsetsBottom = UIApplication.shared.keyWindow!.safeAreaInsets.bottom
+        let safeAreaInsetsBottom = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0
         guard let info = notification.userInfo else { return }
         guard let frameInfo = info[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
         let keyboardFrame = frameInfo.cgRectValue
@@ -73,8 +73,8 @@ class NCViewerRichWorkspaceWebView: UIViewController, WKNavigationDelegate, WKSc
 
             if message.body as? String == "close" {
 
-                if #available(iOS 13.0, *) {
-                    self.presentationController?.delegate?.presentationControllerWillDismiss?(self.presentationController!)
+                if #available(iOS 13.0, *), let presentationController = self.presentationController {
+                    self.presentationController?.delegate?.presentationControllerWillDismiss?(presentationController)
                 }
 
                 dismiss(animated: true) {
@@ -83,8 +83,8 @@ class NCViewerRichWorkspaceWebView: UIViewController, WKNavigationDelegate, WKSc
             }
 
             if message.body as? String == "share" {
-                if metadata != nil {
-                    NCFunctionCenter.shared.openShare(viewController: self, metadata: metadata!, indexPage: .sharing)
+                if let metadata = metadata {
+                    NCFunctionCenter.shared.openShare(viewController: self, metadata: metadata, indexPage: .sharing)
                 }
             }
 

--- a/iOSClient/Share/NCSearchUserDropDownCell.xib
+++ b/iOSClient/Share/NCSearchUserDropDownCell.xib
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="NCShareUserDropDownCell" customModule="Nextcloud" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="NCSearchUserDropDownCell" customModule="Nextcloud" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="487" height="50"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/iOSClient/Share/NCShare+NCCellDelegate.swift
+++ b/iOSClient/Share/NCShare+NCCellDelegate.swift
@@ -1,0 +1,91 @@
+//
+//  NCShare+NCCellDelegate.swift
+//  Nextcloud
+//
+//  Created by Henrik Storch on 03.01.22.
+//  Copyright © 2022 Marino Faggiana. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - NCCell Delegates
+extension NCShare: NCShareLinkCellDelegate, NCShareUserCellDelegate {
+
+    func copyInternalLink(sender: Any) {
+        guard let metadata = self.metadata, let appDelegate = appDelegate else { return }
+
+        let serverUrlFileName = metadata.serverUrl + "/" + metadata.fileName
+        NCNetworking.shared.readFile(serverUrlFileName: serverUrlFileName, account: metadata.account) { _, metadata, errorCode, errorDescription in
+            if errorCode == 0, let metadata = metadata {
+                let internalLink = appDelegate.urlBase + "/index.php/f/" + metadata.fileId
+                NCShareCommon.shared.copyLink(link: internalLink, viewController: self, sender: sender)
+            } else {
+                NCContentPresenter.shared.messageNotification("_share_", description: errorDescription, delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, errorCode: errorCode)
+            }
+        }
+    }
+
+    func tapCopy(with tableShare: tableShare?, sender: Any) {
+        guard let tableShare = tableShare else {
+            return copyInternalLink(sender: sender)
+        }
+        NCShareCommon.shared.copyLink(link: tableShare.url, viewController: self, sender: sender)
+    }
+
+    func tapMenu(with tableShare: tableShare?, sender: Any) {
+        guard let metadata = self.metadata else { return }
+        let isFilesSharingPublicPasswordEnforced = NCManageDatabase.shared.getCapabilitiesServerBool(account: metadata.account, elements: NCElementsJSON.shared.capabilitiesFileSharingPubPasswdEnforced, exists: false)
+
+        if let tableShare = tableShare {
+            // open share menu
+            if tableShare.shareType == 3 {
+                let views = NCShareCommon.shared.openViewMenuShareLink(shareViewController: self, tableShare: tableShare, metadata: metadata)
+                shareLinkMenuView = views.shareLinkMenuView
+                shareMenuViewWindow = views.viewWindow
+
+                let tap = UITapGestureRecognizer(target: self, action: #selector(tapLinkMenuViewWindow))
+                tap.delegate = self
+                shareMenuViewWindow?.addGestureRecognizer(tap)
+            } else {
+                let views = NCShareCommon.shared.openViewMenuUser(shareViewController: self, tableShare: tableShare, metadata: metadata)
+                shareUserMenuView = views.shareUserMenuView
+                shareMenuViewWindow = views.viewWindow
+
+                let tap = UITapGestureRecognizer(target: self, action: #selector(tapLinkMenuViewWindow))
+                tap.delegate = self
+                shareMenuViewWindow?.addGestureRecognizer(tap)
+            }
+        } else if isFilesSharingPublicPasswordEnforced {
+            // create share with pw
+            let alertController = UIAlertController(title: NSLocalizedString("_enforce_password_protection_", comment: ""), message: "", preferredStyle: .alert)
+            alertController.addTextField { textField in
+                textField.isSecureTextEntry = true
+            }
+            alertController.addAction(UIAlertAction(title: NSLocalizedString("_cancel_", comment: ""), style: .default) { _ in })
+            let okAction = UIAlertAction(title: NSLocalizedString("_ok_", comment: ""), style: .default) { _ in
+                let password = alertController.textFields?.first?.text
+                self.networking?.createShareLink(password: password ?? "")
+            }
+
+            alertController.addAction(okAction)
+            self.present(alertController, animated: true, completion: nil)
+        } else {
+            // create sahre without pw
+            networking?.createShareLink(password: "")
+        }
+    }
+
+    func showProfile(with tableShare: tableShare?, sender: Any) {
+        guard let tableShare = tableShare else { return }
+        showProfileMenu(userId: tableShare.shareWith)
+    }
+
+    func quickStatus(with tableShare: tableShare?, sender: Any) {
+        guard let tableShare = tableShare,
+              let metadata = metadata,
+              tableShare.shareType != NCGlobal.shared.permissionDefaultFileRemoteShareNoSupportShareOption else { return }
+
+        let quickStatusMenu = NCShareQuickStatusMenu()
+        quickStatusMenu.toggleMenu(viewController: self, directory: metadata.directory, tableShare: tableShare)
+    }
+}

--- a/iOSClient/Share/NCShare.storyboard
+++ b/iOSClient/Share/NCShare.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Ts3-RO-A9l">
-    <device id="retina5_5" orientation="portrait" appearance="light"/>
+    <device id="retina5_5" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
@@ -13,7 +13,7 @@
             <objects>
                 <viewController id="UdT-J4-zvv" customClass="NCSharePaging" customModule="Nextcloud" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="xka-e7-U7G">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="EQO-kT-aOm"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -30,7 +30,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Ts3-RO-A9l" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="RCF-gN-HcM">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="736" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -47,14 +47,14 @@
             <objects>
                 <viewController storyboardIdentifier="sharing" id="bgO-Rz-2M1" customClass="NCShare" customModule="Nextcloud" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="aV2-U6-JTf">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X2m-IC-J1u" userLabel="View container">
-                                <rect key="frame" x="5" y="0.0" width="404" height="726"/>
+                                <rect key="frame" x="5" y="0.0" width="726" height="404"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="c94-b9-Sim">
-                                        <rect key="frame" x="0.0" y="250" width="404" height="476"/>
+                                        <rect key="frame" x="0.0" y="250" width="726" height="154"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </tableView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8Cj-cK-AKZ">
@@ -72,19 +72,19 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SQW-aQ-ydN">
-                                        <rect key="frame" x="53" y="150" width="261" height="18"/>
+                                        <rect key="frame" x="53" y="150" width="583" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YYp-o8-YJP">
-                                        <rect key="frame" x="53" y="195" width="317" height="18"/>
+                                        <rect key="frame" x="53" y="195" width="639" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pfo-D0-W7b">
-                                        <rect key="frame" x="53" y="216.66666666666666" width="317" height="35"/>
+                                        <rect key="frame" x="53" y="216.66666666666666" width="639" height="35"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="35" id="f8b-mp-xLJ"/>
                                         </constraints>
@@ -93,7 +93,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qek-aQ-NjE" userLabel="ButtonMenu">
-                                        <rect key="frame" x="374" y="149" width="20" height="20"/>
+                                        <rect key="frame" x="696" y="149" width="20" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="BAT-jK-rUt"/>
                                             <constraint firstAttribute="height" constant="20" id="zc5-W6-SXG"/>
@@ -104,7 +104,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cLd-wD-cSC" userLabel="ButtonCopy">
-                                        <rect key="frame" x="324" y="149" width="20" height="20"/>
+                                        <rect key="frame" x="646" y="149" width="20" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="Bzl-zW-yzd"/>
                                             <constraint firstAttribute="height" constant="20" id="RIV-EC-kwC"/>
@@ -115,7 +115,7 @@
                                         </connections>
                                     </button>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oBQ-TP-qof" userLabel="View Shared with you by">
-                                        <rect key="frame" x="-5" y="10" width="409" height="90"/>
+                                        <rect key="frame" x="-5" y="10" width="731" height="90"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fKv-xM-rVY">
                                                 <rect key="frame" x="10" y="0.0" width="40" height="40"/>
@@ -125,7 +125,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shared with you by" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ngi-GT-jvv">
-                                                <rect key="frame" x="60" y="11" width="339" height="18"/>
+                                                <rect key="frame" x="60" y="11" width="661" height="18"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -138,7 +138,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KHG-xj-wfG" customClass="MarqueeLabel" customModule="MarqueeLabel">
-                                                <rect key="frame" x="95" y="48.666666666666664" width="294" height="17.999999999999993"/>
+                                                <rect key="frame" x="95" y="48.666666666666664" width="616" height="17.999999999999993"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -162,7 +162,7 @@
                                         </constraints>
                                     </view>
                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="iSO-mc-0TB">
-                                        <rect key="frame" x="5" y="95" width="389" height="30"/>
+                                        <rect key="frame" x="5" y="95" width="711" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="0aG-z9-fcy"/>
                                         </constraints>
@@ -173,7 +173,7 @@
                                         </connections>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FFi-7t-C8U" userLabel="ButtonCopy">
-                                        <rect key="frame" x="375" y="209" width="20" height="20"/>
+                                        <rect key="frame" x="697" y="209" width="20" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20" id="0KI-54-GMc"/>
                                             <constraint firstAttribute="width" constant="20" id="fcI-Wc-4GE"/>

--- a/iOSClient/Share/NCShare.storyboard
+++ b/iOSClient/Share/NCShare.storyboard
@@ -54,66 +54,9 @@
                                 <rect key="frame" x="5" y="0.0" width="726" height="404"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="c94-b9-Sim">
-                                        <rect key="frame" x="0.0" y="250" width="726" height="154"/>
+                                        <rect key="frame" x="0.0" y="133" width="726" height="271"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </tableView>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8Cj-cK-AKZ">
-                                        <rect key="frame" x="5" y="139" width="40" height="40"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="40" id="CCv-Uu-Vel"/>
-                                            <constraint firstAttribute="width" constant="40" id="egJ-xl-yj4"/>
-                                        </constraints>
-                                    </imageView>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="HPl-mj-r5E">
-                                        <rect key="frame" x="5" y="199" width="40" height="40"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="40" id="6IE-lI-M6i"/>
-                                            <constraint firstAttribute="height" constant="40" id="Odq-bX-Hoz"/>
-                                        </constraints>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SQW-aQ-ydN">
-                                        <rect key="frame" x="53" y="150" width="583" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share link" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YYp-o8-YJP">
-                                        <rect key="frame" x="53" y="195" width="639" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pfo-D0-W7b">
-                                        <rect key="frame" x="53" y="216.66666666666666" width="639" height="35"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="35" id="f8b-mp-xLJ"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qek-aQ-NjE" userLabel="ButtonMenu">
-                                        <rect key="frame" x="696" y="149" width="20" height="20"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="20" id="BAT-jK-rUt"/>
-                                            <constraint firstAttribute="height" constant="20" id="zc5-W6-SXG"/>
-                                        </constraints>
-                                        <state key="normal" image="shareMenu"/>
-                                        <connections>
-                                            <action selector="touchUpInsideButtonMenu:" destination="bgO-Rz-2M1" eventType="touchUpInside" id="ogE-7H-hMG"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cLd-wD-cSC" userLabel="ButtonCopy">
-                                        <rect key="frame" x="646" y="149" width="20" height="20"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="20" id="Bzl-zW-yzd"/>
-                                            <constraint firstAttribute="height" constant="20" id="RIV-EC-kwC"/>
-                                        </constraints>
-                                        <state key="normal" image="shareCopy"/>
-                                        <connections>
-                                            <action selector="touchUpInsideButtonCopy:" destination="bgO-Rz-2M1" eventType="touchUpInside" id="ccu-6N-Tm4"/>
-                                        </connections>
-                                    </button>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oBQ-TP-qof" userLabel="View Shared with you by">
                                         <rect key="frame" x="-5" y="10" width="731" height="90"/>
                                         <subviews>
@@ -172,46 +115,17 @@
                                             <action selector="searchFieldDidEndOnExitWithTextField:" destination="bgO-Rz-2M1" eventType="editingDidEndOnExit" id="xH6-YR-5W9"/>
                                         </connections>
                                     </textField>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FFi-7t-C8U" userLabel="ButtonCopy">
-                                        <rect key="frame" x="697" y="209" width="20" height="20"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="20" id="0KI-54-GMc"/>
-                                            <constraint firstAttribute="width" constant="20" id="fcI-Wc-4GE"/>
-                                        </constraints>
-                                        <state key="normal" image="shareCopy"/>
-                                        <connections>
-                                            <action selector="touchUpInsideButtonCopyInernalLink:" destination="bgO-Rz-2M1" eventType="touchUpInside" id="fmb-gx-9PH"/>
-                                        </connections>
-                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="oBQ-TP-qof" firstAttribute="top" secondItem="X2m-IC-J1u" secondAttribute="top" constant="10" id="09Y-bm-RvQ"/>
-                                    <constraint firstItem="HPl-mj-r5E" firstAttribute="top" secondItem="8Cj-cK-AKZ" secondAttribute="bottom" constant="20" id="0dX-Ni-vDj"/>
                                     <constraint firstAttribute="trailing" secondItem="c94-b9-Sim" secondAttribute="trailing" id="BtN-cJ-TTc"/>
-                                    <constraint firstItem="c94-b9-Sim" firstAttribute="top" secondItem="iSO-mc-0TB" secondAttribute="bottom" constant="125" id="Co6-l6-HiT"/>
-                                    <constraint firstItem="FFi-7t-C8U" firstAttribute="leading" secondItem="YYp-o8-YJP" secondAttribute="trailing" constant="5" id="IE6-R3-yOv"/>
-                                    <constraint firstItem="SQW-aQ-ydN" firstAttribute="centerY" secondItem="8Cj-cK-AKZ" secondAttribute="centerY" id="LtS-8d-L7a"/>
-                                    <constraint firstItem="Qek-aQ-NjE" firstAttribute="centerY" secondItem="8Cj-cK-AKZ" secondAttribute="centerY" id="NYZ-hc-SBk"/>
-                                    <constraint firstItem="SQW-aQ-ydN" firstAttribute="leading" secondItem="8Cj-cK-AKZ" secondAttribute="trailing" constant="8" id="Oby-Ea-MaC"/>
-                                    <constraint firstItem="cLd-wD-cSC" firstAttribute="leading" secondItem="SQW-aQ-ydN" secondAttribute="trailing" constant="10" id="PFh-qU-yXY"/>
-                                    <constraint firstItem="YYp-o8-YJP" firstAttribute="leading" secondItem="HPl-mj-r5E" secondAttribute="trailing" constant="8" id="R36-FW-w0B"/>
-                                    <constraint firstItem="pfo-D0-W7b" firstAttribute="centerY" secondItem="HPl-mj-r5E" secondAttribute="centerY" constant="15" id="Rji-xW-vn7"/>
+                                    <constraint firstItem="c94-b9-Sim" firstAttribute="top" secondItem="iSO-mc-0TB" secondAttribute="bottom" constant="8" id="Co6-l6-HiT"/>
                                     <constraint firstAttribute="bottom" secondItem="c94-b9-Sim" secondAttribute="bottom" id="Svm-RV-vnl"/>
                                     <constraint firstAttribute="trailing" secondItem="iSO-mc-0TB" secondAttribute="trailing" constant="10" id="Vhu-GP-EJN"/>
-                                    <constraint firstItem="8Cj-cK-AKZ" firstAttribute="leading" secondItem="X2m-IC-J1u" secondAttribute="leading" constant="5" id="WlZ-CY-x4s"/>
                                     <constraint firstAttribute="trailing" secondItem="oBQ-TP-qof" secondAttribute="trailing" id="ZuM-2G-aoM"/>
-                                    <constraint firstItem="Qek-aQ-NjE" firstAttribute="leading" secondItem="cLd-wD-cSC" secondAttribute="trailing" constant="30" id="bSw-vM-d12"/>
                                     <constraint firstItem="iSO-mc-0TB" firstAttribute="leading" secondItem="X2m-IC-J1u" secondAttribute="leading" constant="5" id="d8E-WM-YfC"/>
-                                    <constraint firstItem="FFi-7t-C8U" firstAttribute="centerY" secondItem="HPl-mj-r5E" secondAttribute="centerY" id="fkL-uP-Iob"/>
-                                    <constraint firstItem="YYp-o8-YJP" firstAttribute="centerY" secondItem="HPl-mj-r5E" secondAttribute="centerY" constant="-15" id="iu4-c5-p5k"/>
                                     <constraint firstItem="iSO-mc-0TB" firstAttribute="top" secondItem="X2m-IC-J1u" secondAttribute="top" constant="95" id="jPM-Uo-0lS"/>
-                                    <constraint firstItem="pfo-D0-W7b" firstAttribute="leading" secondItem="HPl-mj-r5E" secondAttribute="trailing" constant="8" symbolic="YES" id="oKN-Ui-VIn"/>
-                                    <constraint firstAttribute="trailing" secondItem="Qek-aQ-NjE" secondAttribute="trailing" constant="10" id="puY-4D-ARy"/>
                                     <constraint firstItem="c94-b9-Sim" firstAttribute="leading" secondItem="X2m-IC-J1u" secondAttribute="leading" id="rvD-u3-Dug"/>
-                                    <constraint firstItem="8Cj-cK-AKZ" firstAttribute="top" secondItem="iSO-mc-0TB" secondAttribute="bottom" constant="14" id="shO-sV-GWB"/>
-                                    <constraint firstItem="cLd-wD-cSC" firstAttribute="centerY" secondItem="8Cj-cK-AKZ" secondAttribute="centerY" id="xia-sb-RNk"/>
-                                    <constraint firstItem="FFi-7t-C8U" firstAttribute="leading" secondItem="pfo-D0-W7b" secondAttribute="trailing" constant="5" id="zez-7B-WAb"/>
-                                    <constraint firstItem="HPl-mj-r5E" firstAttribute="leading" secondItem="X2m-IC-J1u" secondAttribute="leading" constant="5" id="zpN-ax-gny"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -223,20 +137,11 @@
                             <constraint firstItem="X2m-IC-J1u" firstAttribute="top" secondItem="aV2-U6-JTf" secondAttribute="top" id="aXO-v9-CBF"/>
                             <constraint firstItem="eAi-wv-a4Y" firstAttribute="trailing" secondItem="X2m-IC-J1u" secondAttribute="trailing" constant="5" id="hVX-vu-qJn"/>
                             <constraint firstItem="oBQ-TP-qof" firstAttribute="leading" secondItem="eAi-wv-a4Y" secondAttribute="leading" id="r7R-MU-9cw"/>
-                            <constraint firstItem="eAi-wv-a4Y" firstAttribute="trailing" secondItem="FFi-7t-C8U" secondAttribute="trailing" constant="14" id="xLc-ai-2T1"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="buttonCopy" destination="cLd-wD-cSC" id="Sib-oL-uQx"/>
-                        <outlet property="buttonInternalCopy" destination="FFi-7t-C8U" id="2ez-LZ-iZ0"/>
-                        <outlet property="buttonMenu" destination="Qek-aQ-NjE" id="xfp-a1-YDn"/>
                         <outlet property="searchField" destination="iSO-mc-0TB" id="1vY-Js-dGQ"/>
                         <outlet property="searchFieldTopConstraint" destination="jPM-Uo-0lS" id="yfd-cG-1mu"/>
-                        <outlet property="shareInternalLinkDescription" destination="pfo-D0-W7b" id="uRy-U9-bQu"/>
-                        <outlet property="shareInternalLinkImage" destination="HPl-mj-r5E" id="CDi-ev-3eO"/>
-                        <outlet property="shareInternalLinkLabel" destination="YYp-o8-YJP" id="rir-aT-bt5"/>
-                        <outlet property="shareLinkImage" destination="8Cj-cK-AKZ" id="dIZ-nv-gyf"/>
-                        <outlet property="shareLinkLabel" destination="SQW-aQ-ydN" id="nBK-WJ-oKy"/>
                         <outlet property="sharedWithYouByImage" destination="fKv-xM-rVY" id="EJ0-sV-By8"/>
                         <outlet property="sharedWithYouByLabel" destination="ngi-GT-jvv" id="Qay-IG-tZh"/>
                         <outlet property="sharedWithYouByNote" destination="KHG-xj-wfG" id="4m5-u6-7RW"/>
@@ -258,7 +163,5 @@
     </designables>
     <resources>
         <image name="note.text" width="24" height="24"/>
-        <image name="shareCopy" width="329" height="329"/>
-        <image name="shareMenu" width="329" height="329"/>
     </resources>
 </document>

--- a/iOSClient/Share/NCShare.swift
+++ b/iOSClient/Share/NCShare.swift
@@ -28,7 +28,7 @@ import DropDown
 import NCCommunication
 import MarqueeLabel
 
-class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingDelegate {
+class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingDelegate, NCSharePagingContent {
 
     @IBOutlet weak var viewContainerConstraint: NSLayoutConstraint!
     @IBOutlet weak var sharedWithYouByView: UIView!
@@ -38,6 +38,8 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
     @IBOutlet weak var sharedWithYouByNote: MarqueeLabel!
     @IBOutlet weak var searchFieldTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var searchField: UITextField!
+    var textField: UITextField { searchField }
+
     @IBOutlet weak var tableView: UITableView!
 
     private let appDelegate = UIApplication.shared.delegate as! AppDelegate
@@ -170,9 +172,7 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
     // MARK: - IBAction
 
     @IBAction func searchFieldDidEndOnExit(textField: UITextField) {
-
-        guard let searchString = textField.text else { return }
-
+        guard let searchString = textField.text, !searchString.isEmpty else { return }
         networking?.getSharees(searchString: searchString)
     }
 

--- a/iOSClient/Share/NCShare.swift
+++ b/iOSClient/Share/NCShare.swift
@@ -308,6 +308,10 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
 extension NCShare: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if indexPath.section == 0, indexPath.row == 0 {
+            // internal cell has description
+            return 90
+        }
         return 70
     }
 }

--- a/iOSClient/Share/NCShare.swift
+++ b/iOSClient/Share/NCShare.swift
@@ -252,9 +252,9 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
         dropDown.width = searchField.bounds.width
         dropDown.direction = .bottom
 
-        dropDown.cellNib = UINib(nibName: "NCShareUserDropDownCell", bundle: nil)
-        dropDown.customCellConfiguration = { (index: Index, _: String, cell: DropDownCell) -> Void in
-            guard let cell = cell as? NCShareUserDropDownCell else { return }
+        dropDown.cellNib = UINib(nibName: "NCSearchUserDropDownCell", bundle: nil)
+        dropDown.customCellConfiguration = { (index: Index, item: String, cell: DropDownCell) -> Void in
+            guard let cell = cell as? NCSearchUserDropDownCell else { return }
             let sharee = sharees[index]
             cell.imageItem.image = NCShareCommon.shared.getImageShareType(shareType: sharee.shareType)
             cell.imageShareeType.image = NCShareCommon.shared.getImageShareType(shareType: sharee.shareType)

--- a/iOSClient/Share/NCShare.swift
+++ b/iOSClient/Share/NCShare.swift
@@ -38,14 +38,6 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
     @IBOutlet weak var sharedWithYouByNote: MarqueeLabel!
     @IBOutlet weak var searchFieldTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var searchField: UITextField!
-    @IBOutlet weak var shareLinkImage: UIImageView!
-    @IBOutlet weak var shareLinkLabel: UILabel!
-    @IBOutlet weak var shareInternalLinkImage: UIImageView!
-    @IBOutlet weak var shareInternalLinkLabel: UILabel!
-    @IBOutlet weak var shareInternalLinkDescription: UILabel!
-    @IBOutlet weak var buttonInternalCopy: UIButton!
-    @IBOutlet weak var buttonCopy: UIButton!
-    @IBOutlet weak var buttonMenu: UIButton!
     @IBOutlet weak var tableView: UITableView!
 
     private let appDelegate = UIApplication.shared.delegate as! AppDelegate
@@ -53,6 +45,8 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
     public var metadata: tableMetadata?
     public var sharingEnabled = true
     public var height: CGFloat = 0
+
+    var shares: (firstShareLink: tableShare?,  share: [tableShare]?) = (nil, nil)
 
     private var shareLinkMenuView: NCShareLinkMenuView?
     private var shareUserMenuView: NCShareUserMenuView?
@@ -71,17 +65,7 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
         searchFieldTopConstraint.constant = 10
 
         searchField.placeholder = NSLocalizedString("_shareLinksearch_placeholder_", comment: "")
-
-        shareLinkImage.image = NCShareCommon.shared.createLinkAvatar(imageName: "sharebylink", colorCircle: NCBrandColor.shared.brandElement)
-        shareLinkLabel.text = NSLocalizedString("_share_link_", comment: "")
-        shareLinkLabel.textColor = NCBrandColor.shared.label
-        buttonCopy.setImage(UIImage(named: "shareCopy")?.image(color: .gray, size: 50), for: .normal)
-
-        shareInternalLinkImage.image = NCShareCommon.shared.createLinkAvatar(imageName: "shareInternalLink", colorCircle: .gray)
-        shareInternalLinkLabel.text = NSLocalizedString("_share_internal_link_", comment: "")
-        shareInternalLinkDescription.text = NSLocalizedString("_share_internal_link_des_", comment: "")
-        buttonInternalCopy.setImage(UIImage(named: "shareCopy")?.image(color: .gray, size: 50), for: .normal)
-
+        
         tableView.dataSource = self
         tableView.delegate = self
         tableView.allowsSelection = false
@@ -179,23 +163,7 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
     // MARK: -
 
     @objc func reloadData() {
-        let shares = NCManageDatabase.shared.getTableShares(metadata: metadata!)
-        if shares.firstShareLink == nil {
-            buttonMenu.setImage(UIImage(named: "shareAdd")?.image(color: .gray, size: 50), for: .normal)
-            buttonCopy.isHidden = true
-        } else {
-            buttonMenu.setImage(UIImage(named: "shareMenu")?.image(color: .gray, size: 50), for: .normal)
-            buttonCopy.isHidden = false
-
-            shareLinkLabel.text = NSLocalizedString("_share_link_", comment: "")
-            if shares.firstShareLink?.label.count ?? 0 > 0 {
-                if let shareLinkLabel = shareLinkLabel {
-                    if let label = shares.firstShareLink?.label {
-                        shareLinkLabel.text = NSLocalizedString("_share_link_", comment: "") + " (" + label + ")"
-                    }
-                }
-            }
-        }
+        shares = NCManageDatabase.shared.getTableShares(metadata: metadata!)
         tableView.reloadData()
     }
 
@@ -206,29 +174,6 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
         guard let searchString = textField.text else { return }
 
         networking?.getSharees(searchString: searchString)
-    }
-
-    @IBAction func touchUpInsideButtonCopy(_ sender: Any) {
-
-        guard let metadata = self.metadata else { return }
-
-        let shares = NCManageDatabase.shared.getTableShares(metadata: metadata)
-        tapCopy(with: shares.firstShareLink, sender: sender)
-    }
-
-    @IBAction func touchUpInsideButtonCopyInernalLink(_ sender: Any) {
-
-        guard let metadata = self.metadata else { return }
-
-        let serverUrlFileName = metadata.serverUrl + "/" + metadata.fileName
-        NCNetworking.shared.readFile(serverUrlFileName: serverUrlFileName, account: metadata.account, queue: .main) { _, metadata, errorCode, errorDescription in
-            if errorCode == 0 && metadata != nil {
-                let internalLink = self.appDelegate.urlBase + "/index.php/f/" + metadata!.fileId
-                NCShareCommon.shared.copyLink(link: internalLink, viewController: self, sender: sender)
-            } else {
-                NCContentPresenter.shared.messageNotification("_share_", description: errorDescription, delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, errorCode: errorCode)
-            }
-        }
     }
 
     func checkEnforcedPassword(callback: @escaping (String?) -> Void) {
@@ -251,20 +196,6 @@ class NCShare: UIViewController, UIGestureRecognizerDelegate, NCShareNetworkingD
         self.present(alertController, animated: true, completion:nil)
     }
     
-    @IBAction func touchUpInsideButtonMenu(_ sender: Any) {
-
-        guard let metadata = self.metadata else { return }
-        let shares = NCManageDatabase.shared.getTableShares(metadata: metadata)
-
-        if shares.firstShareLink == nil {
-            checkEnforcedPassword { password in
-                self.networking?.createShareLink(password: password)
-            }
-        } else {
-            tapMenu(with: shares.firstShareLink!, sender: sender)
-        }
-    }
-
     @objc func tapLinkMenuViewWindow(gesture: UITapGestureRecognizer) {
         shareLinkMenuView?.unLoad()
         shareLinkMenuView = nil
@@ -386,24 +317,29 @@ extension NCShare: UITableViewDelegate {
 extension NCShare: UITableViewDataSource {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        return 2
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-
-        var numOfRows = 0
-        let shares = NCManageDatabase.shared.getTableShares(metadata: metadata!)
-
-        if shares.share != nil {
-            numOfRows = shares.share!.count
-        }
-
-        return numOfRows
+        guard section != 0 else { return 2 }
+        return shares.share?.count ?? 0
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-
-        let shares = NCManageDatabase.shared.getTableShares(metadata: metadata!)
+        // Setup default share cells
+        guard indexPath.section != 0 else {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: "cellLink", for: indexPath) as? NCShareLinkCell
+            else { return UITableViewCell() }
+            cell.delegate = self
+            if indexPath.row == 0 {
+                cell.isInternalLink = true
+            } else {
+                cell.tableShare = shares.firstShareLink
+            }
+            cell.setupCellUI()
+            return cell
+        }
+        
         let tableShare = shares.share![indexPath.row]
 
         // LINK
@@ -411,11 +347,7 @@ extension NCShare: UITableViewDataSource {
             if let cell = tableView.dequeueReusableCell(withIdentifier: "cellLink", for: indexPath) as? NCShareLinkCell {
                 cell.tableShare = tableShare
                 cell.delegate = self
-                cell.labelTitle.text = NSLocalizedString("_share_link_", comment: "")
-                if tableShare.label.count > 0 {
-                    cell.labelTitle.text = NSLocalizedString("_share_link_", comment: "") + " (" + tableShare.label + ")"
-                }
-                cell.labelTitle.textColor = NCBrandColor.shared.label
+                cell.setupCellUI()
                 return cell
             }
         } else {
@@ -473,33 +405,67 @@ extension NCShare: UITableViewDataSource {
 // MARK: - NCCell Delegates
 extension NCShare: NCShareLinkCellDelegate, NCShareUserCellDelegate {
 
-    func tapCopy(with tableShare: tableShare?, sender: Any) {
+    func copyInternalLink(sender: Any) {
+        guard let metadata = self.metadata else { return }
 
-        if let link = tableShare?.url {
-            NCShareCommon.shared.copyLink(link: link, viewController: self, sender: sender)
+        let serverUrlFileName = metadata.serverUrl + "/" + metadata.fileName
+        NCNetworking.shared.readFile(serverUrlFileName: serverUrlFileName, account: metadata.account) { (account, metadata, errorCode, errorDescription) in
+            if errorCode == 0 && metadata != nil {
+                let internalLink = self.appDelegate.urlBase + "/index.php/f/" + metadata!.fileId
+                NCShareCommon.shared.copyLink(link: internalLink, viewController: self, sender: sender)
+            } else {
+                NCContentPresenter.shared.messageNotification("_share_", description: errorDescription, delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, errorCode: errorCode)
+            }
         }
     }
 
+    func tapCopy(with tableShare: tableShare?, sender: Any) {
+        guard let tableShare = tableShare else {
+            return copyInternalLink(sender: sender)
+        }
+        NCShareCommon.shared.copyLink(link: tableShare.url, viewController: self, sender: sender)
+    }
+
     func tapMenu(with tableShare: tableShare?, sender: Any) {
+        guard let metadata = self.metadata else { return }
+        let isFilesSharingPublicPasswordEnforced = NCManageDatabase.shared.getCapabilitiesServerBool(account: metadata.account, elements: NCElementsJSON.shared.capabilitiesFileSharingPubPasswdEnforced, exists: false)
 
-        guard let tableShare = tableShare else { return }
-
-        if tableShare.shareType == 3 {
-            let views = NCShareCommon.shared.openViewMenuShareLink(shareViewController: self, tableShare: tableShare, metadata: metadata!)
-            shareLinkMenuView = views.shareLinkMenuView
-            shareMenuViewWindow = views.viewWindow
-
-            let tap = UITapGestureRecognizer(target: self, action: #selector(tapLinkMenuViewWindow))
-            tap.delegate = self
-            shareMenuViewWindow?.addGestureRecognizer(tap)
+        if let tableShare = tableShare {
+            // open share menu
+            if tableShare.shareType == 3 {
+                let views = NCShareCommon.shared.openViewMenuShareLink(shareViewController: self, tableShare: tableShare, metadata: metadata)
+                shareLinkMenuView = views.shareLinkMenuView
+                shareMenuViewWindow = views.viewWindow
+                
+                let tap = UITapGestureRecognizer(target: self, action: #selector(tapLinkMenuViewWindow))
+                tap.delegate = self
+                shareMenuViewWindow?.addGestureRecognizer(tap)
+            } else {
+                let views = NCShareCommon.shared.openViewMenuUser(shareViewController: self, tableShare: tableShare, metadata: metadata)
+                shareUserMenuView = views.shareUserMenuView
+                shareMenuViewWindow = views.viewWindow
+                
+                let tap = UITapGestureRecognizer(target: self, action: #selector(tapLinkMenuViewWindow))
+                tap.delegate = self
+                shareMenuViewWindow?.addGestureRecognizer(tap)
+            }
+        } else if isFilesSharingPublicPasswordEnforced {
+            // create share with pw
+            let alertController = UIAlertController(title: NSLocalizedString("_enforce_password_protection_", comment: ""), message: "", preferredStyle: .alert)
+            alertController.addTextField { (textField) in
+                textField.isSecureTextEntry = true
+            }
+            alertController.addAction(UIAlertAction(title: NSLocalizedString("_cancel_", comment: ""), style: .default) { (action:UIAlertAction) in })
+            let okAction = UIAlertAction(title: NSLocalizedString("_ok_", comment: ""), style: .default) { (action:UIAlertAction) in
+                let password = alertController.textFields?.first?.text
+                self.networking?.createShareLink(password: password ?? "")
+            }
+            
+            alertController.addAction(okAction)
+            self.present(alertController, animated: true, completion: nil)
         } else {
-            let views = NCShareCommon.shared.openViewMenuUser(shareViewController: self, tableShare: tableShare, metadata: metadata!)
-            shareUserMenuView = views.shareUserMenuView
-            shareMenuViewWindow = views.viewWindow
-
-            let tap = UITapGestureRecognizer(target: self, action: #selector(tapLinkMenuViewWindow))
-            tap.delegate = self
-            shareMenuViewWindow?.addGestureRecognizer(tap)
+            // create sahre without pw
+            networking?.createShareLink(password: "")
         }
     }
 

--- a/iOSClient/Share/NCShareCommon.swift
+++ b/iOSClient/Share/NCShareCommon.swift
@@ -187,8 +187,9 @@ class NCShareCommon: NSObject {
                 activityViewController.popoverPresentationController?.sourceRect = (sender as AnyObject).bounds
             }
         }
-
-        viewController.present(activityViewController, animated: true, completion: nil)
+        DispatchQueue.main.async {
+            viewController.present(activityViewController, animated: true, completion: nil)
+        }
     }
 
     func getImageShareType(shareType: Int) -> UIImage? {

--- a/iOSClient/Share/NCShareHeaderView.xib
+++ b/iOSClient/Share/NCShareHeaderView.xib
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_0" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="NCShareHeaderView" customModule="Nextcloud" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <rect key="frame" x="0.0" y="0.0" width="474" height="100"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="79H-PA-1m2">
-                    <rect key="frame" x="100" y="70" width="120" height="120"/>
+                    <rect key="frame" x="20" y="0.0" width="100" height="100"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="120" id="Imw-QI-Org"/>
-                        <constraint firstAttribute="width" constant="120" id="YKb-24-fln"/>
+                        <constraint firstAttribute="width" secondItem="79H-PA-1m2" secondAttribute="height" id="kPd-Ha-PKN"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="headTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n1G-pn-D8s" customClass="MarqueeLabel" customModule="MarqueeLabel">
-                    <rect key="frame" x="15" y="520" width="290" height="18"/>
+                    <rect key="frame" x="128" y="8" width="326" height="18"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -29,43 +28,44 @@
                         <userDefinedRuntimeAttribute type="boolean" keyPath="tapToScroll" value="YES"/>
                     </userDefinedRuntimeAttributes>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bOQ-tC-40T">
-                    <rect key="frame" x="40" y="543" width="265" height="15"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="calibratedRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EaW-fI-EmD">
-                    <rect key="frame" x="15" y="542" width="15" height="15"/>
+                    <rect key="frame" x="128" y="77" width="15" height="15"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="15" id="Rli-bh-8fJ"/>
-                        <constraint firstAttribute="width" constant="15" id="cU5-4t-7Qf"/>
+                        <constraint firstAttribute="width" constant="15" id="GQs-ak-G4R"/>
+                        <constraint firstAttribute="height" constant="15" id="gFH-uD-FZ0"/>
                     </constraints>
                     <state key="normal" image="favorite"/>
                     <connections>
                         <action selector="touchUpInsideFavorite:" destination="iN0-l3-epB" eventType="touchUpInside" id="r4F-nS-R08"/>
                     </connections>
                 </button>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bOQ-tC-40T">
+                    <rect key="frame" x="148" y="77" width="31" height="15"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                    <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <constraints>
-                <constraint firstItem="EaW-fI-EmD" firstAttribute="top" secondItem="n1G-pn-D8s" secondAttribute="bottom" constant="4" id="8Jc-BA-mYt"/>
-                <constraint firstItem="bOQ-tC-40T" firstAttribute="top" secondItem="n1G-pn-D8s" secondAttribute="bottom" constant="5" id="IRS-qU-ubd"/>
-                <constraint firstAttribute="bottom" secondItem="bOQ-tC-40T" secondAttribute="bottom" constant="10" id="KvA-Oh-KeQ"/>
-                <constraint firstAttribute="trailing" secondItem="bOQ-tC-40T" secondAttribute="trailing" constant="15" id="LAA-Eb-HZj"/>
-                <constraint firstItem="n1G-pn-D8s" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="15" id="cpD-9L-mBy"/>
-                <constraint firstAttribute="trailing" secondItem="n1G-pn-D8s" secondAttribute="trailing" constant="15" id="g7A-jG-74Q"/>
-                <constraint firstItem="79H-PA-1m2" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="70" id="k8q-dk-ofe"/>
-                <constraint firstItem="EaW-fI-EmD" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="15" id="oRc-nv-VzO"/>
-                <constraint firstItem="79H-PA-1m2" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="t10-qd-7Cn"/>
-                <constraint firstItem="bOQ-tC-40T" firstAttribute="leading" secondItem="EaW-fI-EmD" secondAttribute="trailing" constant="10" id="uf6-8A-fN4"/>
+                <constraint firstAttribute="trailing" secondItem="n1G-pn-D8s" secondAttribute="trailing" constant="20" id="0ss-6p-laS"/>
+                <constraint firstItem="EaW-fI-EmD" firstAttribute="leading" secondItem="79H-PA-1m2" secondAttribute="trailing" constant="8" symbolic="YES" id="7jw-Bt-GHm"/>
+                <constraint firstItem="bOQ-tC-40T" firstAttribute="leading" secondItem="EaW-fI-EmD" secondAttribute="trailing" constant="5" id="HNe-K2-JNt"/>
+                <constraint firstAttribute="bottom" secondItem="bOQ-tC-40T" secondAttribute="bottom" constant="8" id="LkB-ps-xwS"/>
+                <constraint firstItem="n1G-pn-D8s" firstAttribute="leading" secondItem="79H-PA-1m2" secondAttribute="trailing" constant="8" symbolic="YES" id="ca1-QS-7XL"/>
+                <constraint firstItem="EaW-fI-EmD" firstAttribute="centerY" secondItem="bOQ-tC-40T" secondAttribute="centerY" id="g7i-UL-F1V"/>
+                <constraint firstItem="n1G-pn-D8s" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="8" id="gf7-1r-fAJ"/>
+                <constraint firstItem="79H-PA-1m2" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="pxE-GL-Wu8"/>
+                <constraint firstItem="79H-PA-1m2" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="sPO-Xj-c1R"/>
+                <constraint firstAttribute="bottom" secondItem="79H-PA-1m2" secondAttribute="bottom" id="yMh-bh-mR7"/>
             </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="favorite" destination="EaW-fI-EmD" id="dv5-Qo-tPx"/>
                 <outlet property="imageView" destination="79H-PA-1m2" id="t6m-wr-OQ5"/>
                 <outlet property="info" destination="bOQ-tC-40T" id="N7R-YH-Xek"/>
                 <outlet property="path" destination="n1G-pn-D8s" id="ckb-qc-lqb"/>
             </connections>
-            <point key="canvasLocation" x="38" y="253"/>
+            <point key="canvasLocation" x="-12.67605633802817" y="45"/>
         </view>
     </objects>
     <designables>

--- a/iOSClient/Share/NCShareLinkCell.swift
+++ b/iOSClient/Share/NCShareLinkCell.swift
@@ -26,27 +26,47 @@ class NCShareLinkCell: UITableViewCell {
 
     @IBOutlet weak var imageItem: UIImageView!
     @IBOutlet weak var labelTitle: UILabel!
-    @IBOutlet weak var buttonCopy: UIButton!
-    @IBOutlet weak var buttonMenu: UIButton!
-
-    private let iconShare: CGFloat = 200
-
+    @IBOutlet weak var descriptionLabel: UILabel!
+    
+    @IBOutlet weak var menuButton: UIButton!
+    @IBOutlet weak var copyButton: UIButton!
     var tableShare: tableShare?
-    weak var delegate: NCShareLinkCellDelegate?
+    var delegate: NCShareLinkCellDelegate?
+    var isInternalLink = false
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        var imageName: String
+        var imageBGColor: UIColor
+        var menuImageName = "shareMenu"
 
-        imageItem.image = NCShareCommon.shared.createLinkAvatar(imageName: "sharebylink", colorCircle: NCBrandColor.shared.brandElement)
-        buttonCopy.setImage(UIImage(named: "shareCopy")!.image(color: .gray, size: 50), for: .normal)
-        buttonMenu.setImage(UIImage(named: "shareMenu")!.image(color: .gray, size: 50), for: .normal)
+        if isInternalLink {
+            imageName = "shareInternalLink"
+            imageBGColor = .gray
+            descriptionLabel.text = "_share_internal_link_des_"
+            labelTitle.text = "_share_internal_link_"
+            menuButton.removeFromSuperview()
+        } else {
+            if tableShare == nil {
+                copyButton.removeFromSuperview()
+                menuImageName = "shareAdd"
+            }
+            imageName = "sharebylink"
+            imageBGColor = NCBrandColor.shared.brandElement
+            labelTitle.text = "_share_link_"
+            descriptionLabel.removeFromSuperview()
+            menuButton.setImage(UIImage.init(named: menuImageName)!.image(color: .gray, size: 50), for: .normal)
+        }
+
+        imageItem.image = NCShareCommon.shared.createLinkAvatar(imageName: imageName, colorCircle: imageBGColor)
+        copyButton.setImage(UIImage.init(named: "shareCopy")!.image(color: .gray, size: 50), for: .normal)
     }
 
-    @IBAction func touchUpInsideCopy(_ sender: Any) {
+    @IBAction func touchUpCopy(_ sender: Any) {
         delegate?.tapCopy(with: tableShare, sender: sender)
     }
 
-    @IBAction func touchUpInsideMenu(_ sender: Any) {
+    @IBAction func touchUpMenu(_ sender: Any) {
         delegate?.tapMenu(with: tableShare, sender: sender)
     }
 }

--- a/iOSClient/Share/NCShareLinkCell.swift
+++ b/iOSClient/Share/NCShareLinkCell.swift
@@ -24,44 +24,57 @@ import UIKit
 
 class NCShareLinkCell: UITableViewCell {
 
-    @IBOutlet weak var imageItem: UIImageView!
-    @IBOutlet weak var labelTitle: UILabel!
-    @IBOutlet weak var descriptionLabel: UILabel!
-    
-    @IBOutlet weak var menuButton: UIButton!
-    @IBOutlet weak var copyButton: UIButton!
+    @IBOutlet private weak var imageItem: UIImageView!
+    @IBOutlet private weak var labelTitle: UILabel!
+    @IBOutlet private weak var descriptionLabel: UILabel!
+
+    @IBOutlet private weak var menuButton: UIButton!
+    @IBOutlet private weak var copyButton: UIButton!
     var tableShare: tableShare?
     var delegate: NCShareLinkCellDelegate?
     var isInternalLink = false
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        isInternalLink = false
+        tableShare = nil
+    }
+
+    func setupCellUI() {
         var imageName: String
         var imageBGColor: UIColor
         var menuImageName = "shareMenu"
 
+        menuButton.isHidden = isInternalLink
+        descriptionLabel.isHidden = !isInternalLink
+        copyButton.isHidden = !isInternalLink && tableShare == nil
+
         if isInternalLink {
             imageName = "shareInternalLink"
             imageBGColor = .gray
-            descriptionLabel.text = "_share_internal_link_des_"
-            labelTitle.text = "_share_internal_link_"
-            menuButton.removeFromSuperview()
+            labelTitle.text = NSLocalizedString("_share_internal_link_", comment: "")
+            descriptionLabel.text = NSLocalizedString("_share_internal_link_des_", comment: "")
         } else {
-            if tableShare == nil {
-                copyButton.removeFromSuperview()
+            labelTitle.text = NSLocalizedString("_share_link_", comment: "")
+            if let tableShare = tableShare {
+                if !tableShare.label.isEmpty {
+                    labelTitle.text? += " (\(tableShare.label))"
+                }
+            } else {
                 menuImageName = "shareAdd"
             }
+
             imageName = "sharebylink"
             imageBGColor = NCBrandColor.shared.brandElement
-            labelTitle.text = "_share_link_"
-            descriptionLabel.removeFromSuperview()
+
             menuButton.setImage(UIImage.init(named: menuImageName)!.image(color: .gray, size: 50), for: .normal)
         }
 
+        labelTitle.textColor = NCBrandColor.shared.label
         imageItem.image = NCShareCommon.shared.createLinkAvatar(imageName: imageName, colorCircle: imageBGColor)
         copyButton.setImage(UIImage.init(named: "shareCopy")!.image(color: .gray, size: 50), for: .normal)
     }
-
+    
     @IBAction func touchUpCopy(_ sender: Any) {
         delegate?.tapCopy(with: tableShare, sender: sender)
     }

--- a/iOSClient/Share/NCShareLinkCell.swift
+++ b/iOSClient/Share/NCShareLinkCell.swift
@@ -31,7 +31,7 @@ class NCShareLinkCell: UITableViewCell {
     @IBOutlet private weak var menuButton: UIButton!
     @IBOutlet private weak var copyButton: UIButton!
     var tableShare: tableShare?
-    var delegate: NCShareLinkCellDelegate?
+    weak var delegate: NCShareLinkCellDelegate?
     var isInternalLink = false
 
     override func prepareForReuse() {
@@ -67,14 +67,14 @@ class NCShareLinkCell: UITableViewCell {
             imageName = "sharebylink"
             imageBGColor = NCBrandColor.shared.brandElement
 
-            menuButton.setImage(UIImage.init(named: menuImageName)!.image(color: .gray, size: 50), for: .normal)
+            menuButton.setImage(UIImage(named: menuImageName)?.image(color: .gray, size: 50), for: .normal)
         }
 
         labelTitle.textColor = NCBrandColor.shared.label
         imageItem.image = NCShareCommon.shared.createLinkAvatar(imageName: imageName, colorCircle: imageBGColor)
-        copyButton.setImage(UIImage.init(named: "shareCopy")!.image(color: .gray, size: 50), for: .normal)
+        copyButton.setImage(UIImage(named: "shareCopy")?.image(color: .gray, size: 50), for: .normal)
     }
-    
+
     @IBAction func touchUpCopy(_ sender: Any) {
         delegate?.tapCopy(with: tableShare, sender: sender)
     }

--- a/iOSClient/Share/NCShareLinkCell.xib
+++ b/iOSClient/Share/NCShareLinkCell.xib
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,7 +14,7 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="90"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qJF-Yc-gKE" id="3Oe-gU-3Nk">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="89.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="90"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" image="circle" translatesAutoresizingMaskIntoConstraints="NO" id="qDs-UG-Mn7" userLabel="ImageItem">
@@ -25,63 +24,82 @@
                             <constraint firstAttribute="width" constant="40" id="GNY-Va-SIJ"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" tag="101" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share link" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="otH-mT-7Z4" userLabel="labelTitle">
-                        <rect key="frame" x="55" y="36" width="150" height="18"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="150" id="4Oa-yZ-HZK"/>
-                            <constraint firstAttribute="height" constant="18" id="iet-xr-SX6"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xaz-vY-Jzu" userLabel="ButtonCopy">
-                        <rect key="frame" x="520" y="35" width="20" height="20"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="20" id="0JR-eM-oir"/>
-                            <constraint firstAttribute="height" constant="20" id="HVo-ht-9m6"/>
-                        </constraints>
-                        <state key="normal" image="shareCopy"/>
-                        <connections>
-                            <action selector="touchUpInsideCopy:" destination="qJF-Yc-gKE" eventType="touchUpInside" id="hSV-RK-FAe"/>
-                        </connections>
-                    </button>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J1z-RG-U4A" userLabel="ButtonMenu">
-                        <rect key="frame" x="570" y="35" width="20" height="20"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="20" id="G48-LB-BsD"/>
-                            <constraint firstAttribute="width" constant="20" id="vLI-cJ-Jqx"/>
-                        </constraints>
-                        <state key="normal" image="shareMenu"/>
-                        <connections>
-                            <action selector="touchUpInsideMenu:" destination="qJF-Yc-gKE" eventType="touchUpInside" id="GT2-Ef-FfR"/>
-                        </connections>
-                    </button>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="OQv-Vf-bvD">
+                        <rect key="frame" x="500" y="35" width="70" height="20"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xaz-vY-Jzu" userLabel="ButtonCopy">
+                                <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="20" id="0JR-eM-oir"/>
+                                    <constraint firstAttribute="height" constant="20" id="HVo-ht-9m6"/>
+                                </constraints>
+                                <state key="normal" image="shareCopy"/>
+                                <connections>
+                                    <action selector="touchUpCopy:" destination="qJF-Yc-gKE" eventType="touchUpInside" id="s3f-6n-cKF"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J1z-RG-U4A" userLabel="ButtonMenu">
+                                <rect key="frame" x="50" y="0.0" width="20" height="20"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="G48-LB-BsD"/>
+                                    <constraint firstAttribute="width" constant="20" id="vLI-cJ-Jqx"/>
+                                </constraints>
+                                <state key="normal" image="shareMenu"/>
+                                <connections>
+                                    <action selector="touchUpMenu:" destination="qJF-Yc-gKE" eventType="touchUpInside" id="hFx-Ib-xay"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </stackView>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Wxr-1B-Czy">
+                        <rect key="frame" x="53" y="20.5" width="150" height="49"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" tag="101" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share link" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="otH-mT-7Z4" userLabel="labelTitle">
+                                <rect key="frame" x="0.0" y="0.0" width="150" height="18"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="150" id="4Oa-yZ-HZK"/>
+                                    <constraint firstAttribute="height" constant="18" id="iet-xr-SX6"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WJj-9P-3bn">
+                                <rect key="frame" x="0.0" y="33" width="150" height="16"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="otH-mT-7Z4" firstAttribute="leading" secondItem="qDs-UG-Mn7" secondAttribute="trailing" constant="10" id="7o5-Rj-6lV"/>
-                    <constraint firstItem="otH-mT-7Z4" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="JNE-HJ-E36"/>
+                    <constraint firstItem="OQv-Vf-bvD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Wxr-1B-Czy" secondAttribute="trailing" constant="15" id="8QW-n0-4lO"/>
                     <constraint firstItem="qDs-UG-Mn7" firstAttribute="leading" secondItem="3Oe-gU-3Nk" secondAttribute="leading" constant="5" id="KOm-wo-CBa"/>
-                    <constraint firstItem="J1z-RG-U4A" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="TvQ-yn-L5w"/>
+                    <constraint firstAttribute="trailing" secondItem="OQv-Vf-bvD" secondAttribute="trailing" constant="30" id="W3b-ww-vbQ"/>
                     <constraint firstItem="qDs-UG-Mn7" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="ZrD-Aw-xkx"/>
-                    <constraint firstItem="J1z-RG-U4A" firstAttribute="leading" secondItem="xaz-vY-Jzu" secondAttribute="trailing" constant="30" id="gGI-DA-dwq"/>
-                    <constraint firstItem="xaz-vY-Jzu" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="o6o-Zj-1aU"/>
-                    <constraint firstAttribute="trailing" secondItem="J1z-RG-U4A" secondAttribute="trailing" constant="10" id="pQA-B9-MM5"/>
+                    <constraint firstItem="Wxr-1B-Czy" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="blr-Mw-Yjl"/>
+                    <constraint firstItem="OQv-Vf-bvD" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="eLc-gk-xAr"/>
+                    <constraint firstItem="Wxr-1B-Czy" firstAttribute="leading" secondItem="qDs-UG-Mn7" secondAttribute="trailing" constant="8" id="nXI-b3-EJM"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
-                <outlet property="buttonCopy" destination="xaz-vY-Jzu" id="WVv-oI-jD8"/>
-                <outlet property="buttonMenu" destination="J1z-RG-U4A" id="L2V-Ev-Cx0"/>
+                <outlet property="copyButton" destination="xaz-vY-Jzu" id="pMt-Zu-ORX"/>
+                <outlet property="descriptionLabel" destination="WJj-9P-3bn" id="QC7-SX-O3M"/>
                 <outlet property="imageItem" destination="qDs-UG-Mn7" id="jxL-r7-BVs"/>
                 <outlet property="labelTitle" destination="otH-mT-7Z4" id="f9z-Oa-OiR"/>
+                <outlet property="menuButton" destination="J1z-RG-U4A" id="VCC-y1-LRK"/>
             </connections>
             <point key="canvasLocation" x="97.599999999999994" y="276.1619190404798"/>
         </tableViewCell>
     </objects>
     <resources>
-        <image name="circle" width="329" height="329"/>
+        <image name="circle" width="300" height="300"/>
         <image name="shareCopy" width="329" height="329"/>
         <image name="shareMenu" width="329" height="329"/>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/iOSClient/Share/NCShareLinkCell.xib
+++ b/iOSClient/Share/NCShareLinkCell.xib
@@ -52,12 +52,11 @@
                         </subviews>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Wxr-1B-Czy">
-                        <rect key="frame" x="53" y="20.5" width="150" height="49"/>
+                        <rect key="frame" x="53" y="20.5" width="432" height="49"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" tag="101" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share link" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="otH-mT-7Z4" userLabel="labelTitle">
-                                <rect key="frame" x="0.0" y="0.0" width="150" height="18"/>
+                                <rect key="frame" x="0.0" y="0.0" width="432" height="18"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="150" id="4Oa-yZ-HZK"/>
                                     <constraint firstAttribute="height" constant="18" id="iet-xr-SX6"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -65,7 +64,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WJj-9P-3bn">
-                                <rect key="frame" x="0.0" y="33" width="150" height="16"/>
+                                <rect key="frame" x="0.0" y="33" width="432" height="16"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
@@ -74,7 +73,7 @@
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="OQv-Vf-bvD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Wxr-1B-Czy" secondAttribute="trailing" constant="15" id="8QW-n0-4lO"/>
+                    <constraint firstItem="OQv-Vf-bvD" firstAttribute="leading" secondItem="Wxr-1B-Czy" secondAttribute="trailing" constant="15" id="8QW-n0-4lO"/>
                     <constraint firstItem="qDs-UG-Mn7" firstAttribute="leading" secondItem="3Oe-gU-3Nk" secondAttribute="leading" constant="5" id="KOm-wo-CBa"/>
                     <constraint firstAttribute="trailing" secondItem="OQv-Vf-bvD" secondAttribute="trailing" constant="30" id="W3b-ww-vbQ"/>
                     <constraint firstItem="qDs-UG-Mn7" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="ZrD-Aw-xkx"/>

--- a/iOSClient/Share/NCShareLinkCell.xib
+++ b/iOSClient/Share/NCShareLinkCell.xib
@@ -51,20 +51,22 @@
                             </button>
                         </subviews>
                     </stackView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Wxr-1B-Czy">
-                        <rect key="frame" x="53" y="20.5" width="432" height="49"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Wxr-1B-Czy">
+                        <rect key="frame" x="53" y="12" width="432" height="66"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" tag="101" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share link" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="otH-mT-7Z4" userLabel="labelTitle">
-                                <rect key="frame" x="0.0" y="0.0" width="432" height="18"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="18" id="iet-xr-SX6"/>
-                                </constraints>
+                                <rect key="frame" x="0.0" y="0.0" width="432" height="22"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WJj-9P-3bn">
-                                <rect key="frame" x="0.0" y="33" width="432" height="16"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="245" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WJj-9P-3bn">
+                                <rect key="frame" x="0.0" y="26" width="432" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="Eo4-Rq-ETK"/>
+                                </constraints>
+                                <string key="text">Only works....
+.;...</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
@@ -75,11 +77,12 @@
                 <constraints>
                     <constraint firstItem="OQv-Vf-bvD" firstAttribute="leading" secondItem="Wxr-1B-Czy" secondAttribute="trailing" constant="15" id="8QW-n0-4lO"/>
                     <constraint firstItem="qDs-UG-Mn7" firstAttribute="leading" secondItem="3Oe-gU-3Nk" secondAttribute="leading" constant="5" id="KOm-wo-CBa"/>
+                    <constraint firstAttribute="bottom" secondItem="Wxr-1B-Czy" secondAttribute="bottom" constant="12" id="MM0-9i-BpF"/>
                     <constraint firstAttribute="trailing" secondItem="OQv-Vf-bvD" secondAttribute="trailing" constant="30" id="W3b-ww-vbQ"/>
                     <constraint firstItem="qDs-UG-Mn7" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="ZrD-Aw-xkx"/>
-                    <constraint firstItem="Wxr-1B-Czy" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="blr-Mw-Yjl"/>
                     <constraint firstItem="OQv-Vf-bvD" firstAttribute="centerY" secondItem="3Oe-gU-3Nk" secondAttribute="centerY" id="eLc-gk-xAr"/>
                     <constraint firstItem="Wxr-1B-Czy" firstAttribute="leading" secondItem="qDs-UG-Mn7" secondAttribute="trailing" constant="8" id="nXI-b3-EJM"/>
+                    <constraint firstItem="Wxr-1B-Czy" firstAttribute="top" secondItem="3Oe-gU-3Nk" secondAttribute="top" constant="12" id="vxe-9X-O1f"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/iOSClient/Share/NCSharePaging.swift
+++ b/iOSClient/Share/NCSharePaging.swift
@@ -97,10 +97,10 @@ class NCSharePaging: UIViewController {
         // Contrain the paging view to all edges.
         pagingViewController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            pagingViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            pagingViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            pagingViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            pagingViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            pagingViewController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            pagingViewController.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            pagingViewController.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            pagingViewController.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
 
         pagingViewController.dataSource = self
@@ -241,8 +241,8 @@ class NCShareHeaderViewController: PagingViewController {
 }
 
 class NCSharePagingView: PagingView {
-
-    static let HeaderHeight: CGFloat = 250
+    
+    static let HeaderHeight: CGFloat = 100
     var metadata = tableMetadata()
 
     var headerHeightConstraint: NSLayoutConstraint?

--- a/iOSClient/Share/NCSharePaging.swift
+++ b/iOSClient/Share/NCSharePaging.swift
@@ -110,6 +110,7 @@ class NCSharePaging: UIViewController {
         self.title = pagingIndexItem.title
 
         NotificationCenter.default.addObserver(self, selector: #selector(self.changeTheming), name: NSNotification.Name(rawValue: NCGlobal.shared.notificationCenterChangeTheming), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.orientationDidChange), name: UIDevice.orientationDidChangeNotification, object: nil)
         changeTheming()
     }
 
@@ -131,11 +132,22 @@ class NCSharePaging: UIViewController {
         NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterReloadDataSource, userInfo: ["ocId": metadata.ocId, "serverUrl": metadata.serverUrl])
     }
 
+    deinit {
+       NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
+    }
+
     @objc func exitTapped() {
         self.dismiss(animated: true, completion: nil)
     }
 
-    // MARK: - NotificationCenter
+    //MARK: - NotificationCenter
+
+    @objc func orientationDidChange() {
+        print(#function, self.view.bounds.width, view.frame.width)
+        pagingViewController.menuItemSize = .fixed(
+            width: self.view.bounds.width / CGFloat(NCGlobal.NCSharePagingIndex.allCases.count),
+            height: 40)
+    }
 
     @objc func changeTheming() {
         pagingViewController.indicatorColor = NCBrandColor.shared.brandElement
@@ -170,8 +182,8 @@ extension NCSharePaging: PagingViewControllerDelegate {
 extension NCSharePaging: PagingViewControllerDataSource {
 
     func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
-
-        let height = pagingViewController.options.menuHeight + NCSharePagingView.HeaderHeight
+    
+        let height = pagingViewController.options.menuHeight + NCSharePagingView.headerHeight
 
         switch NCGlobal.NCSharePagingIndex(rawValue: index) {
         case .activity:
@@ -242,7 +254,7 @@ class NCShareHeaderViewController: PagingViewController {
 
 class NCSharePagingView: PagingView {
     
-    static let HeaderHeight: CGFloat = 100
+    static let headerHeight: CGFloat = 100
     var metadata = tableMetadata()
 
     var headerHeightConstraint: NSLayoutConstraint?
@@ -293,7 +305,7 @@ class NCSharePagingView: PagingView {
         headerView.translatesAutoresizingMaskIntoConstraints = false
 
         headerHeightConstraint = headerView.heightAnchor.constraint(
-            equalToConstant: NCSharePagingView.HeaderHeight
+            equalToConstant: NCSharePagingView.headerHeight
         )
         headerHeightConstraint?.isActive = true
 

--- a/iOSClient/Share/NCShareUserCell.swift
+++ b/iOSClient/Share/NCShareUserCell.swift
@@ -87,9 +87,9 @@ protocol NCShareUserCellDelegate: AnyObject {
     func quickStatus(with tableShare: tableShare?, sender: Any)
 }
 
-// MARK: - NCShareUserDropDownCell
+// MARK: - NCSearchUserDropDownCell
 
-class NCShareUserDropDownCell: DropDownCell, NCCellProtocol {
+class NCSearchUserDropDownCell: DropDownCell, NCCellProtocol {
 
     @IBOutlet weak var imageItem: UIImageView!
     @IBOutlet weak var imageStatus: UIImageView!


### PR DESCRIPTION
Fixes #1770 

This PR fixes the UI of NCShare and NCActivity in NCSharePaging when in landscape mode. 
- make default share cells dynamic, scrollable
- smaller header view, more space for share content / activities
- push up entire paging view (if needed) when a textfield becomes active

**Note**:
This PR will not include an update for the NCShareUserMenu / NCShareLinkMenu. These views will be refactored at a later time.


TODO: 
- [x] test
- [x] linting