### PR TITLE
fix: folder creation with whitespaces at start/end

### DIFF
--- a/iOSClient/Data/NCManageDatabse+Metadata.swift
+++ b/iOSClient/Data/NCManageDatabse+Metadata.swift
@@ -141,6 +141,8 @@ extension NCManageDatabase {
 
         let metadata = tableMetadata()
         let resultInternalType = NCCommunicationCommon.shared.getInternalType(fileName: fileName, mimeType: contentType, directory: false)
+        
+        let fileName = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
 
         metadata.account = account
         metadata.chunk = false

--- a/iOSClient/Main/Create cloud/NCCreateFormUploadDocuments.swift
+++ b/iOSClient/Main/Create cloud/NCCreateFormUploadDocuments.swift
@@ -275,7 +275,7 @@ import XLForm
         } else {
 
             //Trim whitespaces after checks above
-            fileNameForm = fileNameForm.trimmingCharacters(in: .whitespacesAndNewlines)
+            fileNameForm = (fileNameForm as! String).trimmingCharacters(in: .whitespacesAndNewlines)
 
             let result = NCCommunicationCommon.shared.getInternalType(fileName: fileNameForm as! String, mimeType: "", directory: false)
             if NCUtility.shared.isDirectEditing(account: appDelegate.account, contentType: result.mimeType).count == 0 {

--- a/iOSClient/Main/Create cloud/NCCreateFormUploadDocuments.swift
+++ b/iOSClient/Main/Create cloud/NCCreateFormUploadDocuments.swift
@@ -274,6 +274,9 @@ import XLForm
             return
         } else {
 
+            //Trim whitespaces after checks above
+            fileNameForm = fileNameForm.trimmingCharacters(in: .whitespacesAndNewlines)
+
             let result = NCCommunicationCommon.shared.getInternalType(fileName: fileNameForm as! String, mimeType: "", directory: false)
             if NCUtility.shared.isDirectEditing(account: appDelegate.account, contentType: result.mimeType).count == 0 {
                 fileNameForm = (fileNameForm as! NSString).deletingPathExtension + "." + fileNameExtension

--- a/iOSClient/Networking/NCNetworking.swift
+++ b/iOSClient/Networking/NCNetworking.swift
@@ -921,7 +921,9 @@ import Queuer
     @objc func createFolder(fileName: String, serverUrl: String, account: String, urlBase: String, overwrite: Bool = false, completion: @escaping (_ errorCode: Int, _ errorDescription: String) -> Void) {
 
         let isDirectoryEncrypted = CCUtility.isFolderEncrypted(serverUrl, e2eEncrypted: false, account: account, urlBase: urlBase)
-
+        
+        let fileName = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
+        
         if isDirectoryEncrypted {
             #if !EXTENSION
             NCNetworkingE2EE.shared.createFolder(fileName: fileName, serverUrl: serverUrl, account: account, urlBase: urlBase, completion: completion)
@@ -1173,6 +1175,7 @@ import Queuer
 
         let isDirectoryEncrypted = CCUtility.isFolderEncrypted(metadata.serverUrl, e2eEncrypted: metadata.e2eEncrypted, account: metadata.account, urlBase: metadata.urlBase)
         let metadataLive = NCManageDatabase.shared.getMetadataLivePhoto(metadata: metadata)
+        let fileNameNew = fileNameNew.trimmingCharacters(in: .whitespacesAndNewlines)
         let fileNameNewLive = (fileNameNew as NSString).deletingPathExtension + ".mov"
 
         if isDirectoryEncrypted {


### PR DESCRIPTION
This fix is a adaption of this issue nextcloud/server#5843, sadly it was still possible to create a folder with whitespaces at start/end to break the windows sync.

requested new because wrong target branch https://github.com/nextcloud/ios/pull/1852

Signed-off-by: McP4nth3r <burg41@yahoo.de>