### PR TITLE
Improve NCMenu select options

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		AF4BF61F27562B3F0081CEEF /* NCManageDatabase+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */; };
 		AF4BF62027562B3F0081CEEF /* NCManageDatabase+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */; };
 		AF4BF62127562B3F0081CEEF /* NCManageDatabase+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */; };
+		AF68326A27BE65A90010BF0B /* NCMenuAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF68326927BE65A90010BF0B /* NCMenuAction.swift */; };
 		AF730AFA27843E4C00B7520E /* NCShareExtension+NCDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF730AF927843E4C00B7520E /* NCShareExtension+NCDelegate.swift */; };
 		AF7E504E27A2D8FF00B5E4AF /* UIBarButton+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7E504D27A2D8FF00B5E4AF /* UIBarButton+Extension.swift */; };
 		AF7E505027A2D92300B5E4AF /* NCSelectableNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF7E504F27A2D92300B5E4AF /* NCSelectableNavigationView.swift */; };
@@ -473,6 +474,7 @@
 		AF4BF613275629E20081CEEF /* NCManageDatabase+Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+Account.swift"; sourceTree = "<group>"; };
 		AF4BF61827562A4B0081CEEF /* NCManageDatabse+Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCManageDatabse+Metadata.swift"; sourceTree = "<group>"; };
 		AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+Activity.swift"; sourceTree = "<group>"; };
+		AF68326927BE65A90010BF0B /* NCMenuAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMenuAction.swift; sourceTree = "<group>"; };
 		AF730AF927843E4C00B7520E /* NCShareExtension+NCDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCShareExtension+NCDelegate.swift"; sourceTree = "<group>"; };
 		AF7E504D27A2D8FF00B5E4AF /* UIBarButton+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButton+Extension.swift"; sourceTree = "<group>"; };
 		AF7E504F27A2D92300B5E4AF /* NCSelectableNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCSelectableNavigationView.swift; sourceTree = "<group>"; };
@@ -948,6 +950,7 @@
 			children = (
 				3704EB2923D5A58400455C5B /* NCMenu.storyboard */,
 				371B5A2D23D0B04500FAFAE9 /* NCMenu.swift */,
+				AF68326927BE65A90010BF0B /* NCMenuAction.swift */,
 				AF935066276B84E700BD078F /* NCMenu+FloatingPanel.swift */,
 				3781B9AF23DB2B7E006B4B1D /* AppDelegate+Menu.swift */,
 				8491B1CC273BBA82001C8C5B /* UIViewController+Menu.swift */,
@@ -2415,6 +2418,7 @@
 				F78ACD4A21903F850088454D /* NCTrashListCell.swift in Sources */,
 				F7B8CD91261AF3F7007C1359 /* NCNetworkingChunkedUpload.swift in Sources */,
 				F760329F252F0F8E0015A421 /* NCTransferCell.swift in Sources */,
+				AF68326A27BE65A90010BF0B /* NCMenuAction.swift in Sources */,
 				F7682FE023C36B0500983A04 /* NCMainTabBar.swift in Sources */,
 				F7A0D1352591FBC5008F8A13 /* String+Extensions.swift in Sources */,
 				F77B0E5F1D118A16002130FE /* NCSettings.m in Sources */,

--- a/iOSClient/Main/Collection Common/NCSelectableNavigationView.swift
+++ b/iOSClient/Main/Collection Common/NCSelectableNavigationView.swift
@@ -107,7 +107,7 @@ extension NCSelectableNavigationView where Self: UIViewController {
         }
 
         actions.append(.moveOrCopyAction(selectedMetadatas: selectedMetadatas, completion: tapSelect))
-        actions.append(.copyAction(selectOcId: selectOcId, completion: tapSelect))
+        actions.append(.copyAction(selectOcId: selectOcId, hudView: self.view, completion: tapSelect))
         actions.append(.deleteAction(selectedMetadatas: selectedMetadatas, viewController: self, completion: tapSelect))
         return actions
     }

--- a/iOSClient/Main/NCFunctionCenter.swift
+++ b/iOSClient/Main/NCFunctionCenter.swift
@@ -230,7 +230,7 @@ import JGProgressHUD
 
         for metadata in selectedMetadata {
             guard !metadata.directory else { continue }
-            if !CCUtility.fileProviderStorageExists(metadata.ocId, fileNameView: metadata.fileNameView) {
+            if !CCUtility.fileProviderStorageExists(metadata) {
                 let semaphore = Semaphore()
                 NCNetworking.shared.download(metadata: metadata, selector: "") { errorCode in
                     error = errorCode
@@ -427,7 +427,7 @@ import JGProgressHUD
 
             DispatchQueue.main.async(execute: hud.dismiss)
 
-            // do 5 downloads in paralell to optimize efficiancy
+            // do 5 downloads in parallel to optimize efficiency
             let parallelizer = ParallelWorker(n: 5, titleKey: "_downloading_", totalTasks: downloadMetadatas.count, hudView: hudView)
 
             for metadata in downloadMetadatas {

--- a/iOSClient/Main/NCFunctionCenter.swift
+++ b/iOSClient/Main/NCFunctionCenter.swift
@@ -221,32 +221,28 @@ import JGProgressHUD
         documentController?.presentOptionsMenu(from: mainTabBar.menuRect, in: mainTabBar, animated: true)
     }
 
-    func openActivityViewController(selectOcId: [String]) {
+    func openActivityViewController(selectedMetadata: [tableMetadata]) {
 
         NCUtility.shared.startActivityIndicator(backgroundView: nil, blurEffect: true)
 
         var error: Int = 0
         var items: [Any] = []
 
-        for ocId in selectOcId {
-            if let metadata = NCManageDatabase.shared.getMetadataFromOcId(ocId) {
-                if metadata.directory {
-                    continue
+        for metadata in selectedMetadata {
+            guard !metadata.directory else { continue }
+            if !CCUtility.fileProviderStorageExists(metadata.ocId, fileNameView: metadata.fileNameView) {
+                let semaphore = Semaphore()
+                NCNetworking.shared.download(metadata: metadata, selector: "") { errorCode in
+                    error = errorCode
+                    semaphore.continue()
                 }
-                if !CCUtility.fileProviderStorageExists(metadata) {
-                    let semaphore = Semaphore()
-                    NCNetworking.shared.download(metadata: metadata, selector: "") { errorCode in
-                        error = errorCode
-                        semaphore.continue()
-                    }
-                    semaphore.wait()
-                }
-                if error != 0 {
-                    break
-                }
-                let fileURL = URL(fileURLWithPath: CCUtility.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView))
-                items.append(fileURL)
+                semaphore.wait()
             }
+            if error != 0 {
+                break
+            }
+            let fileURL = URL(fileURLWithPath: CCUtility.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView))
+            items.append(fileURL)
         }
         if error == 0 && items.count > 0 {
 
@@ -545,7 +541,7 @@ import JGProgressHUD
         }
     }
 
-    func openSelectView(items: [Any], viewController: UIViewController) {
+    func openSelectView(items: [Any]) {
 
         let navigationController = UIStoryboard(name: "NCSelect", bundle: nil).instantiateInitialViewController() as! UINavigationController
         let topViewController = navigationController.topViewController as! NCSelect
@@ -593,7 +589,7 @@ import JGProgressHUD
         navigationController.setViewControllers(listViewController, animated: false)
         navigationController.modalPresentationStyle = .formSheet
 
-        viewController.present(navigationController, animated: true, completion: nil)
+        appDelegate.window?.rootViewController?.present(navigationController, animated: true, completion: nil)
     }
 
     // MARK: - Context Menu Configuration
@@ -708,7 +704,7 @@ import JGProgressHUD
         // let open = UIMenu(title: NSLocalizedString("_open_", comment: ""), image: UIImage(systemName: "square.and.arrow.up"), children: [openIn, openQuickLook])
 
         let moveCopy = UIAction(title: NSLocalizedString("_move_or_copy_", comment: ""), image: UIImage(systemName: "arrow.up.right.square")) { _ in
-            self.openSelectView(items: [metadata], viewController: viewController)
+            self.openSelectView(items: [metadata])
         }
 
         let rename = UIAction(title: NSLocalizedString("_rename_", comment: ""), image: UIImage(systemName: "pencil")) { _ in

--- a/iOSClient/Menu/NCCollectionViewCommon+Menu.swift
+++ b/iOSClient/Menu/NCCollectionViewCommon+Menu.swift
@@ -252,7 +252,7 @@ extension NCCollectionViewCommon {
         // COPY
         //
         if !metadata.directory {
-            actions.append(.copyAction(selectOcId: [metadata.ocId]))
+            actions.append(.copyAction(selectOcId: [metadata.ocId], hudView: self.view))
         }
         
         /*

--- a/iOSClient/Menu/NCMedia+Menu.swift
+++ b/iOSClient/Menu/NCMedia+Menu.swift
@@ -169,7 +169,7 @@ extension NCMedia {
             //
             // COPY
             //
-            actions.append(.copyAction(selectOcId: selectOcId, completion: tapSelect))
+            actions.append(.copyAction(selectOcId: selectOcId, hudView: self.view, completion: tapSelect))
 
             //
             // DELETE

--- a/iOSClient/Menu/NCMenu.swift
+++ b/iOSClient/Menu/NCMenu.swift
@@ -115,33 +115,3 @@ extension NCMenu: FloatingPanelControllerDelegate {
         fpc.dismiss(animated: true, completion: nil)
     }
 }
-
-class NCMenuAction {
-
-    let title: String
-    let icon: UIImage
-    let selectable: Bool
-    var onTitle: String?
-    var onIcon: UIImage?
-    var selected: Bool = false
-    var isOn: Bool = false
-    var action: ((_ menuAction: NCMenuAction) -> Void)?
-
-    init(title: String, icon: UIImage, action: ((_ menuAction: NCMenuAction) -> Void)?) {
-        self.title = title
-        self.icon = icon
-        self.action = action
-        self.selectable = false
-    }
-
-    init(title: String, icon: UIImage, onTitle: String? = nil, onIcon: UIImage? = nil, selected: Bool, on: Bool, action: ((_ menuAction: NCMenuAction) -> Void)?) {
-        self.title = title
-        self.icon = icon
-        self.onTitle = onTitle ?? title
-        self.onIcon = onIcon ?? icon
-        self.action = action
-        self.selected = selected
-        self.isOn = on
-        self.selectable = true
-    }
-}

--- a/iOSClient/Menu/NCMenuAction.swift
+++ b/iOSClient/Menu/NCMenuAction.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 class NCMenuAction {
     let title: String
@@ -37,7 +38,7 @@ class NCMenuAction {
     }
 }
 
-// MARK: - Actons
+// MARK: - Actions
 
 extension NCMenuAction {
 
@@ -51,12 +52,12 @@ extension NCMenuAction {
     }
 
     /// Copy files to pasteboard
-    static func copyAction(selectOcId: [String], completion: (() -> Void)? = nil) -> NCMenuAction {
+    static func copyAction(selectOcId: [String], hudView: UIView, completion: (() -> Void)? = nil) -> NCMenuAction {
         NCMenuAction(
             title: NSLocalizedString("_copy_file_", comment: ""),
             icon: NCUtility.shared.loadImage(named: "doc.on.doc"),
             action: { _ in
-                NCFunctionCenter.shared.copyPasteboard(pasteboardOcIds: selectOcId)
+                NCFunctionCenter.shared.copyPasteboard(pasteboardOcIds: selectOcId, hudView: hudView)
                 completion?()
             }
         )
@@ -117,7 +118,7 @@ extension NCMenuAction {
         )
     }
 
-    /// Open "share view" (activity VC) to open files iin another app
+    /// Open "share view" (activity VC) to open files in another app
     static func openInAction(selectedMetadatas: [tableMetadata], viewController: UIViewController, completion: (() -> Void)? = nil) -> NCMenuAction {
         NCMenuAction(
             title: NSLocalizedString("_open_in_", comment: ""),
@@ -135,7 +136,7 @@ extension NCMenuAction {
         )
     }
 
-    /// Save selected files to user's prohot library
+    /// Save selected files to user's photo library
     static func saveMediaAction(selectedMediaMetadatas: [tableMetadata], completion: (() -> Void)? = nil) -> NCMenuAction {
         var title: String = NSLocalizedString("_save_selected_files_", comment: "")
         var icon = NCUtility.shared.loadImage(named: "square.and.arrow.down")
@@ -152,7 +153,7 @@ extension NCMenuAction {
                     if let metadataMOV = NCManageDatabase.shared.getMetadataLivePhoto(metadata: metadata) {
                         NCFunctionCenter.shared.saveLivePhoto(metadata: metadata, metadataMOV: metadataMOV)
                     } else {
-                        if CCUtility.fileProviderStorageExists(metadata.ocId, fileNameView: metadata.fileNameView) {
+                        if CCUtility.fileProviderStorageExists(metadata) {
                             NCFunctionCenter.shared.saveAlbum(metadata: metadata)
                         } else {
                             NCOperationQueue.shared.download(metadata: metadata, selector: NCGlobal.shared.selectorSaveAlbum)

--- a/iOSClient/Menu/NCMenuAction.swift
+++ b/iOSClient/Menu/NCMenuAction.swift
@@ -85,19 +85,32 @@ extension NCMenuAction {
             }
         } // else: no metadata selected
 
+        var fileList = ""
+        for (ix, metadata) in selectedMetadatas.enumerated() {
+            guard ix < 3 else { fileList += "\n - ..."; break }
+            fileList += "\n - " + metadata.fileName
+        }
+
         return NCMenuAction(
             title: titleDelete,
             icon: NCUtility.shared.loadImage(named: "trash"),
             action: { _ in
-                let alertController = UIAlertController(title: "", message: NSLocalizedString("_want_delete_", comment: ""), preferredStyle: .alert)
+                let alertController = UIAlertController(
+                    title: titleDelete,
+                    message: NSLocalizedString("_want_delete_", comment: "") + fileList,
+                    preferredStyle: .alert)
                 alertController.addAction(UIAlertAction(title: NSLocalizedString("_yes_delete_", comment: ""), style: .default) { (_: UIAlertAction) in
                     selectedMetadatas.forEach({ NCOperationQueue.shared.delete(metadata: $0, onlyLocalCache: false) })
                     completion?()
                 })
-                alertController.addAction(UIAlertAction(title: NSLocalizedString("_remove_local_file_", comment: ""), style: .default) { (_: UIAlertAction) in
-                    selectedMetadatas.forEach({ NCOperationQueue.shared.delete(metadata: $0, onlyLocalCache: true) })
-                    completion?()
-                })
+
+                // NCMedia removes image from collection view if removed from cache
+                if !(viewController is NCMedia) {
+                    alertController.addAction(UIAlertAction(title: NSLocalizedString("_remove_local_file_", comment: ""), style: .default) { (_: UIAlertAction) in
+                        selectedMetadatas.forEach({ NCOperationQueue.shared.delete(metadata: $0, onlyLocalCache: true) })
+                        completion?()
+                    })
+                }
                 alertController.addAction(UIAlertAction(title: NSLocalizedString("_no_delete_", comment: ""), style: .default) { (_: UIAlertAction) in })
                 viewController.present(alertController, animated: true, completion: nil)
             }

--- a/iOSClient/Menu/NCTrash+Menu.swift
+++ b/iOSClient/Menu/NCTrash+Menu.swift
@@ -28,6 +28,31 @@ import FloatingPanel
 import NCCommunication
 
 extension NCTrash {
+    var selectActions: [NCMenuAction] {
+        [
+            NCMenuAction(
+                title: NSLocalizedString("_trash_restore_selected_", comment: ""),
+                icon: NCUtility.shared.loadImage(named: "restore"),
+                action: { _ in
+                    self.selectOcId.forEach(self.restoreItem)
+                    self.tapSelect()
+                }
+            ),
+            NCMenuAction(
+                title: NSLocalizedString("_trash_delete_selected_", comment: ""),
+                icon: NCUtility.shared.loadImage(named: "trash"),
+                action: { _ in
+                    let alert = UIAlertController(title: NSLocalizedString("_trash_delete_selected_", comment: ""), message: "", preferredStyle: .alert)
+                    alert.addAction(UIAlertAction(title: NSLocalizedString("_delete_", comment: ""), style: .destructive, handler: { _ in
+                        self.selectOcId.forEach(self.deleteItem)
+                        self.tapSelect()
+                    }))
+                    alert.addAction(UIAlertAction(title: NSLocalizedString("_cancel_", comment: ""), style: .cancel, handler: { _ in }))
+                    self.present(alert, animated: true, completion: nil)
+                }
+            )
+        ]
+    }
 
     func toggleMenuMoreHeader() {
 

--- a/iOSClient/Menu/NCViewer+Menu.swift
+++ b/iOSClient/Menu/NCViewer+Menu.swift
@@ -197,7 +197,7 @@ extension NCViewer {
         //
         // COPY
         //
-        actions.append(.copyAction(selectOcId: [metadata.ocId]))
+        actions.append(.copyAction(selectOcId: [metadata.ocId], hudView: viewController.view))
 
         //
         // VIEW IN FOLDER

--- a/iOSClient/Menu/NCViewer+Menu.swift
+++ b/iOSClient/Menu/NCViewer+Menu.swift
@@ -43,15 +43,6 @@ extension NCViewer {
             titleOffline = NSLocalizedString("_remove_available_offline_", comment: "")
         }
 
-        var titleDelete = NSLocalizedString("_delete_", comment: "")
-        if NCManageDatabase.shared.isMetadataShareOrMounted(metadata: metadata, metadataFolder: nil) {
-            titleDelete = NSLocalizedString("_leave_share_", comment: "")
-        } else if metadata.directory {
-            titleDelete = NSLocalizedString("_delete_folder_", comment: "")
-        } else {
-            titleDelete = NSLocalizedString("_delete_file_", comment: "")
-        }
-
         let isFolderEncrypted = CCUtility.isFolderEncrypted(metadata.serverUrl, e2eEncrypted: metadata.e2eEncrypted, account: metadata.account, urlBase: metadata.urlBase)
 
         //
@@ -109,15 +100,7 @@ extension NCViewer {
         // OPEN IN
         //
         if metadata.session == "" && !webView {
-            actions.append(
-                NCMenuAction(
-                    title: NSLocalizedString("_open_in_", comment: ""),
-                    icon: NCUtility.shared.loadImage(named: "square.and.arrow.up"),
-                    action: { _ in
-                        NCFunctionCenter.shared.openDownload(metadata: metadata, selector: NCGlobal.shared.selectorOpenIn)
-                    }
-                )
-            )
+            actions.append(.openInAction(selectedMetadatas: [metadata], viewController: viewController))
         }
 
         //
@@ -159,28 +142,7 @@ extension NCViewer {
         // SAVE IMAGE / VIDEO
         //
         if metadata.classFile == NCCommunicationCommon.typeClassFile.image.rawValue || metadata.classFile == NCCommunicationCommon.typeClassFile.video.rawValue {
-
-            var title: String = NSLocalizedString("_save_selected_files_", comment: "")
-            var icon = NCUtility.shared.loadImage(named: "square.and.arrow.down")
-            let metadataMOV = NCManageDatabase.shared.getMetadataLivePhoto(metadata: metadata)
-            if metadataMOV != nil {
-                title = NSLocalizedString("_livephoto_save_", comment: "")
-                icon = NCUtility.shared.loadImage(named: "livephoto")
-            }
-
-            actions.append(
-                NCMenuAction(
-                    title: title,
-                    icon: icon,
-                    action: { _ in
-                        if metadataMOV != nil {
-                            NCFunctionCenter.shared.saveLivePhoto(metadata: metadata, metadataMOV: metadataMOV!)
-                        } else {
-                            NCOperationQueue.shared.download(metadata: metadata, selector: NCGlobal.shared.selectorSaveAlbum)
-                        }
-                    }
-                )
-            )
+            actions.append(.saveMediaAction(selectedMediaMetadatas: [metadata]))
         }
 
         //
@@ -229,38 +191,13 @@ extension NCViewer {
         // COPY - MOVE
         //
         if !webView {
-            actions.append(
-                NCMenuAction(
-                    title: NSLocalizedString("_move_or_copy_", comment: ""),
-                    icon: NCUtility.shared.loadImage(named: "arrow.up.right.square"),
-                    action: { _ in
-
-                        let storyboard = UIStoryboard(name: "NCSelect", bundle: nil)
-                        let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController
-                        let viewController = navigationController.topViewController as! NCSelect
-
-                        viewController.delegate = NCViewer.shared
-                        viewController.typeOfCommandView = .copyMove
-                        viewController.items = [metadata]
-
-                        self.appDelegate.window?.rootViewController?.present(navigationController, animated: true, completion: nil)
-                    }
-                )
-            )
+            actions.append(.moveOrCopyAction(selectedMetadatas: [metadata]))
         }
 
         //
         // COPY
         //
-        actions.append(
-            NCMenuAction(
-                title: NSLocalizedString("_copy_file_", comment: ""),
-                icon: NCUtility.shared.loadImage(named: "doc.on.doc"),
-                action: { _ in
-                    NCFunctionCenter.shared.copyPasteboard(pasteboardOcIds: [metadata.ocId], hudView: viewController.view)
-                }
-            )
-        )
+        actions.append(.copyAction(selectOcId: [metadata.ocId]))
 
         //
         // VIEW IN FOLDER
@@ -365,29 +302,7 @@ extension NCViewer {
         // DELETE
         //
         if !webView {
-            actions.append(
-                NCMenuAction(
-                    title: titleDelete,
-                    icon: NCUtility.shared.loadImage(named: "trash"),
-                    action: { _ in
-
-                        let alertController = UIAlertController(title: "", message: NSLocalizedString("_want_delete_", comment: ""), preferredStyle: .alert)
-
-                        alertController.addAction(UIAlertAction(title: NSLocalizedString("_yes_delete_", comment: ""), style: .default) { (_: UIAlertAction) in
-
-                            NCNetworking.shared.deleteMetadata(metadata, onlyLocalCache: false) { errorCode, errorDescription in
-                                if errorCode != 0 {
-                                    NCContentPresenter.shared.messageNotification("_error_", description: errorDescription, delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, errorCode: errorCode)
-                                }
-                            }
-                        })
-
-                        alertController.addAction(UIAlertAction(title: NSLocalizedString("_no_delete_", comment: ""), style: .default) { (_: UIAlertAction) in })
-
-                        viewController.present(alertController, animated: true, completion: nil)
-                    }
-                )
-            )
+            actions.append(.deleteAction(selectedMetadatas: [metadata], metadataFolder: nil, viewController: viewController))
         }
 
         viewController.presentMenu(with: actions)

--- a/iOSClient/Menu/UIViewController+Menu.swift
+++ b/iOSClient/Menu/UIViewController+Menu.swift
@@ -106,6 +106,7 @@ extension UIViewController {
     }
 
     func presentMenu(with actions: [NCMenuAction]) {
+        guard !actions.isEmpty else { return }
         guard let menuViewController = NCMenu.makeNCMenu(with: actions) else {
             NCContentPresenter.shared.showError(description: "_internal_generic_error_")
             return


### PR DESCRIPTION
Fix #1786 
Refactor `NCSelectableNavigationView` and select-`NCMenuAction`s.
This reduces a lot of code duplication and makes the menus more modular and easier to re-use.