### PR TITLE
Fix Open-In download

### DIFF
--- a/iOSClient/Main/NCFunctionCenter.swift
+++ b/iOSClient/Main/NCFunctionCenter.swift
@@ -222,8 +222,7 @@ import JGProgressHUD
         let processor = ParallelWorker(n: 5, titleKey: "_downloading_", totalTasks: selectedMetadata.count, hudView: self.appDelegate.window?.rootViewController?.view)
         var items: [URL] = []
 
-        for metadata in selectedMetadata {
-            guard !metadata.directory else { continue }
+        for metadata in selectedMetadata where !metadata.directory {
             let fileURL = URL(fileURLWithPath: CCUtility.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView))
             guard !CCUtility.fileProviderStorageExists(metadata) else {
                 items.append(fileURL)


### PR DESCRIPTION
Fix #1902 

- show cancelable download indicator
- download multiple files (but not all) at once
- don't abort if only one (or a few) files fail to download. Continue with the ones that succeeded