### PR TITLE
Fix Image geolocation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -130,7 +130,6 @@ excluded:
   - iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayer.swift
   - iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.swift
   - iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
-  - iOSClient/Viewer/NCViewerMedia/NCViewerMediaDetailView.swift
   - iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.swift
   - iOSClient/Viewer/NCViewerNextcloudText/NCViewerNextcloudText.swift
   - iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift

--- a/iOSClient/Utility/CCUtility.m
+++ b/iOSClient/Utility/CCUtility.m
@@ -1727,6 +1727,7 @@
             stringLatitude = [NSString stringWithFormat:@"+%.4f", latitude];
         } else {
             stringLatitude = [NSString stringWithFormat:@"-%.4f", latitude];
+            latitude *= -1;
         }
         
         // conversion 4 decimal +E -W
@@ -1736,10 +1737,10 @@
             stringLongitude = [NSString stringWithFormat:@"+%.4f", longitude];
         } else {
             stringLongitude = [NSString stringWithFormat:@"-%.4f", longitude];
+            longitude *= -1;
         }
         
         if (latitude == 0 || longitude == 0) {
-            
             stringLatitude = @"0";
             stringLongitude = @"0";
         }

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
@@ -439,8 +439,13 @@ extension NCViewerMedia {
                 self.detailViewHeighConstraint.constant = 170
             }
             self.view.layoutIfNeeded()
-            
-            self.detailView.show(metadata:self.metadata, image: self.image, textColor: self.viewerMediaPage?.textColor, latitude: latitude, longitude: longitude, location: location, date: date, lensModel: lensModel, ncplayer: self.ncplayer ,delegate: self)
+            self.detailView.show(
+                metadata: self.metadata,
+                image: self.image,
+                textColor: self.viewerMediaPage?.textColor,
+                mediaMetadata: (latitude: latitude, longitude: longitude, location: location, date: date, lensModel: lensModel),
+                ncplayer: self.ncplayer,
+                delegate: self)
                 
             if let image = self.imageVideoContainer.image {
                 let ratioW = self.imageVideoContainer.frame.width / image.size.width
@@ -487,7 +492,13 @@ extension NCViewerMedia {
 
         if self.detailView.isShow() {
             CCUtility.setExif(metadata) { (latitude, longitude, location, date, lensModel) in
-                self.detailView.show(metadata:self.metadata, image: self.image, textColor: self.viewerMediaPage?.textColor, latitude: latitude, longitude: longitude, location: location, date: date, lensModel: lensModel, ncplayer: self.ncplayer ,delegate: self)
+                self.detailView.show(
+                    metadata: self.metadata,
+                    image: self.image,
+                    textColor: self.viewerMediaPage?.textColor,
+                    mediaMetadata: (latitude: latitude, longitude: longitude, location: location, date: date, lensModel: lensModel),
+                    ncplayer: self.ncplayer,
+                    delegate: self)
             }
         }
     }

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMediaDetailView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMediaDetailView.swift
@@ -25,6 +25,8 @@ import UIKit
 import MapKit
 import NCCommunication
 
+typealias NCImageMetadata = (latitude: Double, longitude: Double, location: String?, date: Date?, lensModel: String?)
+
 public protocol NCViewerMediaDetailViewDelegate: AnyObject {
     func downloadFullResolution()
 }
@@ -52,8 +54,8 @@ class NCViewerMediaDetailView: UIView {
     var metadata: tableMetadata?
     var mapView: MKMapView?
     var ncplayer: NCPlayer?
-    var delegate: NCViewerMediaDetailViewDelegate?
-        
+    weak var delegate: NCViewerMediaDetailViewDelegate?
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -76,15 +78,15 @@ class NCViewerMediaDetailView: UIView {
         self.mapView?.removeFromSuperview()
         self.mapView = nil
     }
-    
-    func show(metadata: tableMetadata, image: UIImage?, textColor: UIColor?, latitude: Double, longitude: Double, location: String?, date: Date?, lensModel: String?, ncplayer: NCPlayer?, delegate: NCViewerMediaDetailViewDelegate?) {
-                        
+
+    func show(metadata: tableMetadata, image: UIImage?, textColor: UIColor?, mediaMetadata: NCImageMetadata, ncplayer: NCPlayer?, delegate: NCViewerMediaDetailViewDelegate?) {
+
         self.metadata = metadata
-        self.latitude = latitude
-        self.longitude = longitude
-        self.location = location
-        self.date = date
-        self.lensModel = lensModel
+        self.latitude = mediaMetadata.latitude
+        self.longitude = mediaMetadata.longitude
+        self.location = mediaMetadata.location
+        self.date = mediaMetadata.date
+        self.lensModel = mediaMetadata.lensModel
         self.ncplayer = ncplayer
         self.delegate = delegate
 
@@ -93,25 +95,24 @@ class NCViewerMediaDetailView: UIView {
             let annotation = MKPointAnnotation()
             annotation.coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
 
-            self.mapView = MKMapView()
-            if let mapView = self.mapView {
-                mapView.translatesAutoresizingMaskIntoConstraints = false
-                self.mapContainer.addSubview(mapView)
+            let mapView = MKMapView()
+            self.mapView = mapView
+            self.mapContainer.addSubview(mapView)
 
-                NSLayoutConstraint.activate([
-                    mapView.topAnchor.constraint(equalTo: self.mapContainer.topAnchor),
-                    mapView.bottomAnchor.constraint(equalTo: self.mapContainer.bottomAnchor),
-                    mapView.leadingAnchor.constraint(equalTo: self.mapContainer.leadingAnchor),
-                    mapView.trailingAnchor.constraint(equalTo: self.mapContainer.trailingAnchor)
-                ])
+            mapView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                mapView.topAnchor.constraint(equalTo: self.mapContainer.topAnchor),
+                mapView.bottomAnchor.constraint(equalTo: self.mapContainer.bottomAnchor),
+                mapView.leadingAnchor.constraint(equalTo: self.mapContainer.leadingAnchor),
+                mapView.trailingAnchor.constraint(equalTo: self.mapContainer.trailingAnchor)
+            ])
 
-                mapView.layer.cornerRadius = 6
-                mapView.isZoomEnabled = true
-                mapView.isScrollEnabled = false
-                mapView.isUserInteractionEnabled = false
-                mapView.addAnnotation(annotation)
-                mapView.setRegion(MKCoordinateRegion(center: annotation.coordinate, latitudinalMeters: 500, longitudinalMeters: 500), animated: false)
-            }
+            mapView.layer.cornerRadius = 6
+            mapView.isZoomEnabled = true
+            mapView.isScrollEnabled = false
+            mapView.isUserInteractionEnabled = false
+            mapView.addAnnotation(annotation)
+            mapView.setRegion(MKCoordinateRegion(center: annotation.coordinate, latitudinalMeters: 500, longitudinalMeters: 500), animated: false)
         }
 
         // Size
@@ -156,7 +157,7 @@ class NCViewerMediaDetailView: UIView {
         }
 
         // Message
-        if metadata.classFile == NCCommunicationCommon.typeClassFile.image.rawValue && !CCUtility.fileProviderStorageExists(metadata) && metadata.session == "" {
+        if metadata.classFile == NCCommunicationCommon.typeClassFile.image.rawValue && !CCUtility.fileProviderStorageExists(metadata) && metadata.session.isEmpty {
             messageButton.setTitle(NSLocalizedString("_try_download_full_resolution_", comment: ""), for: .normal)
             messageButton.isHidden = false
         } else {
@@ -188,23 +189,22 @@ class NCViewerMediaDetailView: UIView {
 
     @IBAction func touchLocation(_ sender: Any) {
 
-        if latitude != -1 && latitude != 0 && longitude != -1 && longitude != 0 {
+        guard latitude != -1, latitude != 0, longitude != -1, longitude != 0 else { return }
 
-            let latitude: CLLocationDegrees = self.latitude
-            let longitude: CLLocationDegrees = self.longitude
+        let latitude: CLLocationDegrees = self.latitude
+        let longitude: CLLocationDegrees = self.longitude
 
-            let regionDistance: CLLocationDistance = 10000
-            let coordinates = CLLocationCoordinate2DMake(latitude, longitude)
-            let regionSpan = MKCoordinateRegion(center: coordinates, latitudinalMeters: regionDistance, longitudinalMeters: regionDistance)
-            let options = [
-                MKLaunchOptionsMapCenterKey: NSValue(mkCoordinate: regionSpan.center),
-                MKLaunchOptionsMapSpanKey: NSValue(mkCoordinateSpan: regionSpan.span)
-            ]
-            let placemark = MKPlacemark(coordinate: coordinates, addressDictionary: nil)
-            let mapItem = MKMapItem(placemark: placemark)
-            mapItem.name = location
-            mapItem.openInMaps(launchOptions: options)
-        }
+        let regionDistance: CLLocationDistance = 10000
+        let coordinates = CLLocationCoordinate2DMake(latitude, longitude)
+        let regionSpan = MKCoordinateRegion(center: coordinates, latitudinalMeters: regionDistance, longitudinalMeters: regionDistance)
+        let options = [
+            MKLaunchOptionsMapCenterKey: NSValue(mkCoordinate: regionSpan.center),
+            MKLaunchOptionsMapSpanKey: NSValue(mkCoordinateSpan: regionSpan.span)
+        ]
+        let placemark = MKPlacemark(coordinate: coordinates, addressDictionary: nil)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = location
+        mapItem.openInMaps(launchOptions: options)
     }
 
     @IBAction func touchFavorite(_ sender: Any) {
@@ -212,12 +212,6 @@ class NCViewerMediaDetailView: UIView {
     }
 
     @IBAction func touchMessage(_ sender: Any) {
-
         delegate?.downloadFullResolution()
-    }
-
-    // MARK: -
-    func secondsToHoursMinutesSeconds (seconds: Int) -> (Int, Int, Int) {
-      return (seconds / 3600, (seconds % 3600) / 60, (seconds % 3600) % 60)
     }
 }

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.storyboard
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.storyboard
@@ -109,6 +109,10 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dJP-ZX-iug">
                                                 <rect key="frame" x="15" y="150" width="384" height="222"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <gestureRecognizers/>
+                                                <connections>
+                                                    <outletCollection property="gestureRecognizers" destination="fvW-pC-4g1" appends="YES" id="gVL-xL-CmY"/>
+                                                </connections>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="size" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WXS-Lw-DkI">
                                                 <rect key="frame" x="15" y="36" width="80" height="16"/>
@@ -443,6 +447,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fbE-Jv-mLH" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer id="fvW-pC-4g1">
+                    <connections>
+                        <action selector="touchLocation:" destination="P8R-4f-zAl" id="qyd-d2-RyB"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="4547.826086956522" y="776.9021739130435"/>
         </scene>


### PR DESCRIPTION
Fix #1896 

- Display correct coordinates on the map
- Wrong addresses (`location`) that are saved in the GPS database will still be used and display the wrong address for the correct image location
  - To fix this, simply Clear cache in the settings
  - Alternatively we could clear the GPS table automatically on the first start of a new version.. 
- Make the map tappable, so use can tap the map or the address to open the location in the Maps.app