### PR TITLE
Fix QuickLook overriding files

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -135,7 +135,6 @@ excluded:
   - iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
   - iOSClient/Viewer/NCViewerPDF/NCViewerPDFSearch.swift
   - iOSClient/Viewer/NCViewerProviderContextMenu.swift
-  - iOSClient/Viewer/NCViewerQuickLook/NCViewerQuickLook.swift
   - iOSClient/Viewer/NCViewerRichdocument/NCViewerRichdocument.swift
 
 

--- a/iOSClient/Main/NCFunctionCenter.swift
+++ b/iOSClient/Main/NCFunctionCenter.swift
@@ -77,7 +77,7 @@ import SVGKit
                 editingMode = true
             }
 
-            let viewerQuickLook = NCViewerQuickLook(with: URL(fileURLWithPath: fileNamePath), editingMode: editingMode, metadata: metadata)
+            let viewerQuickLook = NCViewerQuickLook(with: URL(fileURLWithPath: fileNamePath), isEditingEnabled: editingMode, metadata: metadata)
             self.appDelegate.window?.rootViewController?.present(viewerQuickLook, animated: true)
 
         case NCGlobal.shared.selectorLoadFileView:

--- a/iOSClient/Main/NCFunctionCenter.swift
+++ b/iOSClient/Main/NCFunctionCenter.swift
@@ -78,10 +78,7 @@ import SVGKit
             }
 
             let viewerQuickLook = NCViewerQuickLook(with: URL(fileURLWithPath: fileNamePath), editingMode: editingMode, metadata: metadata)
-            let navigationController = UINavigationController(rootViewController: viewerQuickLook)
-            navigationController.modalPresentationStyle = .overFullScreen
-
-            self.appDelegate.window?.rootViewController?.present(navigationController, animated: true)
+            self.appDelegate.window?.rootViewController?.present(viewerQuickLook, animated: true)
 
         case NCGlobal.shared.selectorLoadFileView:
             guard UIApplication.shared.applicationState == UIApplication.State.active else { break }

--- a/iOSClient/Settings/CCAdvanced.m
+++ b/iOSClient/Settings/CCAdvanced.m
@@ -173,8 +173,7 @@
         row.action.formBlock = ^(XLFormRowDescriptor * sender) {
                     
             [self deselectFormRow:sender];
-            
-            NCViewerQuickLook *viewerQuickLook = [[NCViewerQuickLook alloc] initWith:[NSURL fileURLWithPath:NCCommunicationCommon.shared.filenamePathLog] editingMode:false metadata:nil];
+            NCViewerQuickLook *viewerQuickLook = [[NCViewerQuickLook alloc] initWith:[NSURL fileURLWithPath:NCCommunicationCommon.shared.filenamePathLog] isEditingEnabled:false metadata:nil];
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewerQuickLook];
             navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
             

--- a/iOSClient/Viewer/NCViewer.swift
+++ b/iOSClient/Viewer/NCViewer.swift
@@ -209,10 +209,7 @@ class NCViewer: NSObject {
         CCUtility.copyFile(atPath: CCUtility.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView), toPath: fileNamePath)
 
         let viewerQuickLook = NCViewerQuickLook(with: URL(fileURLWithPath: fileNamePath), editingMode: false, metadata: metadata)
-        let navigationController = UINavigationController(rootViewController: viewerQuickLook)
-        navigationController.modalPresentationStyle = .overFullScreen
-
-        viewController.present(navigationController, animated: true)
+        viewController.present(viewerQuickLook, animated: true)
     }
 }
 

--- a/iOSClient/Viewer/NCViewer.swift
+++ b/iOSClient/Viewer/NCViewer.swift
@@ -208,7 +208,7 @@ class NCViewer: NSObject {
 
         CCUtility.copyFile(atPath: CCUtility.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView), toPath: fileNamePath)
 
-        let viewerQuickLook = NCViewerQuickLook(with: URL(fileURLWithPath: fileNamePath), editingMode: false, metadata: metadata)
+        let viewerQuickLook = NCViewerQuickLook(with: URL(fileURLWithPath: fileNamePath), isEditingEnabled: false, metadata: metadata)
         viewController.present(viewerQuickLook, animated: true)
     }
 }

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
@@ -41,7 +41,7 @@ class NCViewerMedia: UIViewController {
     private var _autoPlay: Bool = false
 
     let appDelegate = UIApplication.shared.delegate as! AppDelegate
-    var viewerMediaPage: NCViewerMediaPage?
+    weak var viewerMediaPage: NCViewerMediaPage?
     var ncplayer: NCPlayer?
     var image: UIImage?
     var metadata: tableMetadata = tableMetadata()

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.swift
@@ -104,9 +104,8 @@ class NCViewerMediaPage: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive(_:)), name: NSNotification.Name(rawValue: NCGlobal.shared.notificationCenterApplicationDidBecomeActive), object: nil)
     }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-
+    deinit {
+        print("#deinit NCViewerMediaPage")
         // Clear
         if let ncplayer = currentViewController.ncplayer, ncplayer.isPlay() {
             ncplayer.playerPause()
@@ -117,11 +116,11 @@ class NCViewerMediaPage: UIViewController {
 
         metadatas.removeAll()
         ncplayerLivePhoto = nil
-        
+
         #if MFFFLIB
         MFFF.shared.dismissMessage()
         #endif
-        
+
         // Remove Observer
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: NCGlobal.shared.notificationCenterDeleteFile), object: nil)
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name(rawValue: NCGlobal.shared.notificationCenterRenameFile), object: nil)
@@ -341,19 +340,19 @@ class NCViewerMediaPage: UIViewController {
         if metadata.classFile == NCCommunicationCommon.typeClassFile.video.rawValue || metadata.classFile == NCCommunicationCommon.typeClassFile.audio.rawValue {
 
             MPRemoteCommandCenter.shared().skipForwardCommand.isEnabled = true
-            skipForwardCommand = MPRemoteCommandCenter.shared().skipForwardCommand.addTarget { event in
+            skipForwardCommand = MPRemoteCommandCenter.shared().skipForwardCommand.addTarget { [weak self] event in
 
                 let seconds = Float64((event as! MPSkipIntervalCommandEvent).interval)
-                self.currentViewController.playerToolBar.skip(seconds: seconds)
-                return.success
+                self?.currentViewController.playerToolBar.skip(seconds: seconds)
+                return .success
             }
 
             MPRemoteCommandCenter.shared().skipBackwardCommand.isEnabled = true
-            skipBackwardCommand = MPRemoteCommandCenter.shared().skipBackwardCommand.addTarget { event in
+            skipBackwardCommand = MPRemoteCommandCenter.shared().skipBackwardCommand.addTarget { [weak self] event in
 
                 let seconds = Float64((event as! MPSkipIntervalCommandEvent).interval)
-                self.currentViewController.playerToolBar.skip(seconds: -seconds)
-                return.success
+                self?.currentViewController.playerToolBar.skip(seconds: -seconds)
+                return .success
             }
         }
 
@@ -474,15 +473,15 @@ extension NCViewerMediaPage: UIPageViewControllerDelegate, UIPageViewControllerD
 
         if currentIndex == 0 { return nil }
 
-        let viewerMedia = getViewerMedia(index: currentIndex-1, metadata: metadatas[currentIndex-1])
+        let viewerMedia = getViewerMedia(index: currentIndex - 1, metadata: metadatas[currentIndex - 1])
         return viewerMedia
     }
 
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
 
-        if currentIndex == metadatas.count-1 { return nil }
+        if currentIndex == metadatas.count - 1 { return nil }
 
-        let viewerMedia = getViewerMedia(index: currentIndex+1, metadata: metadatas[currentIndex+1])
+        let viewerMedia = getViewerMedia(index: currentIndex + 1, metadata: metadatas[currentIndex + 1])
         return viewerMedia
     }
 

--- a/iOSClient/Viewer/NCViewerQuickLook/NCViewerQuickLook.swift
+++ b/iOSClient/Viewer/NCViewerQuickLook/NCViewerQuickLook.swift
@@ -4,8 +4,10 @@
 //
 //  Created by Marino Faggiana on 03/05/2020.
 //  Copyright © 2020 Marino Faggiana. All rights reserved.
+//  Copyright © 2022 Henrik Storch. All rights reserved.
 //
 //  Author Marino Faggiana <marino.faggiana@nextcloud.com>
+//  Author Henrik Storch <henrik.storch@nextcloud.com>
 //
 //  This program is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -64,29 +66,6 @@ import NCCommunication
         super.viewDidLoad()
         guard isEditingEnabled else { return }
 
-        if metadata?.classFile == NCCommunicationCommon.typeClassFile.image.rawValue {
-            Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true, block: { t in
-                if self.navigationItem.rightBarButtonItems?.count ?? 0 > 1 || !(self.navigationController?.isToolbarHidden ?? false) {
-                    if #available(iOS 14.0, *) {
-                        if self.navigationItem.rightBarButtonItems?.count ?? 0 > 1 {
-                            if let buttonItem = self.navigationItem.rightBarButtonItems?.last {
-                                _ = buttonItem.target?.perform(buttonItem.action, with: buttonItem)
-                            }
-                        } else {
-                            if let buttonItem = self.navigationItem.rightBarButtonItems?.first {
-                                _ = buttonItem.target?.perform(buttonItem.action, with: buttonItem)
-                            }
-                        }
-                    } else {
-                        if let buttonItem = self.navigationItem.rightBarButtonItems?.filter({$0.customView != nil}).first?.customView as? UIButton {
-                            buttonItem.sendActions(for: .touchUpInside)
-                        }
-                    }
-                    t.invalidate()
-                }
-            })
-        }
-
         if metadata?.livePhoto == true {
             NCContentPresenter.shared.messageNotification(
                 "", description: "_message_disable_overwrite_livephoto_",
@@ -98,6 +77,7 @@ import NCCommunication
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        // needs to be saved bc in didDisappear presentingVC is already nil
         self.parentVC = presentingViewController
     }
 

--- a/iOSClient/Viewer/NCViewerQuickLook/NCViewerQuickLook.swift
+++ b/iOSClient/Viewer/NCViewerQuickLook/NCViewerQuickLook.swift
@@ -60,8 +60,6 @@ import NCCommunication
         self.dataSource = self
         self.delegate = self
         self.currentPreviewItemIndex = 0
-
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissPreviewController))
     }
 
     override func viewDidLoad() {
@@ -95,8 +93,8 @@ import NCCommunication
         }
     }
 
-    @objc func dismissPreviewController() {
-
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         if editingMode {
 
             let alertController = UIAlertController(title: NSLocalizedString("_save_", comment: ""), message: "", preferredStyle: .alert)
@@ -104,27 +102,19 @@ import NCCommunication
             if metadata?.livePhoto == false {
                 alertController.addAction(UIAlertAction(title: NSLocalizedString("_overwrite_original_", comment: ""), style: .default) { (_: UIAlertAction) in
                     self.saveMode = .overwrite
-                    self.dismiss(animated: true)
                 })
             }
 
             alertController.addAction(UIAlertAction(title: NSLocalizedString("_save_as_copy_", comment: ""), style: .default) { (_: UIAlertAction) in
                 self.saveMode = .copy
-                self.dismiss(animated: true)
             })
 
             alertController.addAction(UIAlertAction(title: NSLocalizedString("_discard_changes_", comment: ""), style: .destructive) { (_: UIAlertAction) in
                 self.saveMode = .discard
-                self.dismiss(animated: true)
             })
 
             alertController.addAction(UIAlertAction(title: NSLocalizedString("_cancel_", comment: ""), style: .cancel) { (_: UIAlertAction) in })
 
-            self.present(alertController, animated: true)
-
-        } else {
-
-            self.dismiss(animated: true)
         }
     }
 }


### PR DESCRIPTION
Fix #1629 

[Flow Diagram](https://user-images.githubusercontent.com/18512366/158338242-280fffdb-4588-4733-92ba-c82d500bdce9.png)

- ask for saving option after view dismisses in order to catch all last changes
- remove cancel option, because view is already dismissed, can't cancel anymore
  - Alternative: Add option "Keep Editing" to re-open the temporary copy
 - remove auto-selecting the edit button for images
   - it's too hacky and doesn't work when the VC is not customly hosted in a NavVC. So either have the auto-select or have saving files work correctly. Imo it's better to have a slightly more complex UX than to have users loose their work or edits they made.

### Debugging / Testing Note
As mentioned in the issue, there seems to be a bug with the Xcode iOS Simulator where the file at `modifiedContentsURL` doesn't exist or was deleted.