### PR TITLE
Some minor fixes 🙃

### DIFF
--- a/Share/NCShareExtension.swift
+++ b/Share/NCShareExtension.swift
@@ -343,16 +343,16 @@ extension NCShareExtension {
         hud.show(in: self.view)
 
         NCNetworking.shared.upload(metadata: metadata) { } completion: { errorCode, _ in
-            if errorCode == 0 {
-                self.counterUploaded += 1
-                self.upload()
-            } else {
+            if errorCode != 0 {
                 let path = CCUtility.getDirectoryProviderStorageOcId(metadata.ocId)!
                 NCManageDatabase.shared.deleteMetadata(predicate: NSPredicate(format: "ocId == %@", metadata.ocId))
                 NCManageDatabase.shared.deleteChunks(account: metadata.account, ocId: metadata.ocId)
                 NCUtilityFileSystem.shared.deleteFile(filePath: path)
                 self.uploadErrors.append(metadata)
             }
+
+            self.counterUploaded += 1
+            self.upload()
         }
     }
 

--- a/iOSClient/Media/NCMedia.swift
+++ b/iOSClient/Media/NCMedia.swift
@@ -725,10 +725,11 @@ class NCMediaCommandView: UIView {
         moreView.layer.masksToBounds = true
         controlButtonView.layer.cornerRadius = 20
         controlButtonView.layer.masksToBounds = true
+        controlButtonView.effect = UIBlurEffect(style: .dark)
         gradient.frame = bounds
-        gradient.startPoint = CGPoint(x: 0, y: 0.50)
-        gradient.endPoint = CGPoint(x: 0, y: 0.9)
-        gradient.colors = [UIColor.black.withAlphaComponent(0.4).cgColor, UIColor.clear.cgColor]
+        gradient.startPoint = CGPoint(x: 0, y: 0.5)
+        gradient.endPoint = CGPoint(x: 0, y: 1)
+        gradient.colors = [UIColor.black.withAlphaComponent(UIAccessibility.isReduceTransparencyEnabled ? 0.8 : 0.4).cgColor, UIColor.clear.cgColor]
         layer.insertSublayer(gradient, at: 0)
         moreButton.setImage(UIImage(named: "more")!.image(color: .white, size: 25), for: .normal)
         title.text = ""
@@ -743,7 +744,7 @@ class NCMediaCommandView: UIView {
             }
         } else {
             UIView.animate(withDuration: 0.3) {
-                self.moreView.effect = UIBlurEffect(style: .regular)
+                self.moreView.effect = UIBlurEffect(style: .dark)
                 self.gradient.isHidden = false
                 self.controlButtonView.isHidden = false
             }

--- a/iOSClient/Networking/NCNetworking.swift
+++ b/iOSClient/Networking/NCNetworking.swift
@@ -523,8 +523,9 @@ import Queuer
         }) { _, ocId, etag, date, size, _, _, errorCode, errorDescription in
 
             self.uploadRequest[fileNameLocalPath] = nil
-            self.uploadComplete(fileName: metadata.fileName, serverUrl: metadata.serverUrl, ocId: ocId, etag: etag, date: date, size: size, description: description, task: uploadTask!, errorCode: errorCode, errorDescription: errorDescription)
-
+            if let uploadTask = uploadTask {
+                self.uploadComplete(fileName: metadata.fileName, serverUrl: metadata.serverUrl, ocId: ocId, etag: etag, date: date, size: size, description: description, task: uploadTask, errorCode: errorCode, errorDescription: errorDescription)
+            }
             completion(errorCode, errorDescription)
         }
     }

--- a/iOSClient/Settings/CCAdvanced.m
+++ b/iOSClient/Settings/CCAdvanced.m
@@ -174,10 +174,7 @@
                     
             [self deselectFormRow:sender];
             NCViewerQuickLook *viewerQuickLook = [[NCViewerQuickLook alloc] initWith:[NSURL fileURLWithPath:NCCommunicationCommon.shared.filenamePathLog] isEditingEnabled:false metadata:nil];
-            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewerQuickLook];
-            navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
-            
-            [self presentViewController:navigationController animated:YES completion:nil];
+            [self presentViewController:viewerQuickLook animated:YES completion:nil];
         };
         [section addFormRow:row];
         

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -79,7 +79,9 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate {
 
         pageView.translatesAutoresizingMaskIntoConstraints = false
         pageView.layer.cornerRadius = 10
-        pageView.backgroundColor = UIColor.gray.withAlphaComponent(0.3)
+        pageView.backgroundColor = NCBrandColor.shared.systemBackground.withAlphaComponent(
+            UIAccessibility.isReduceTransparencyEnabled ? 1 : 0.5
+        )
 
         view.addSubview(pageView)
 
@@ -91,7 +93,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate {
 
         pageViewLabel.translatesAutoresizingMaskIntoConstraints = false
         pageViewLabel.textAlignment = .center
-        pageViewLabel.textColor = .gray
+        pageViewLabel.textColor = NCBrandColor.shared.label
 
         pageView.addSubview(pageViewLabel)
 


### PR DESCRIPTION
### #1934
The Share extension should keep uploading even if an upload fails. If an upload has an error it should display all files that had errors in the end after all files have been processed. Currently, if an upload fails it will halt the entire process, forcing the user to cancel.

### #1926 
Fix QuickLook for the log file view. Shouldn't have a navigation controller hosting it, because we don't want a custom done button. Rather use the system done button as explains in the linked PR.

### Other
- fix race condition crash if completion handler is called before task handler (bc of concurrency)
- fix #1883 
- adjust NCMedia header transparency, for more contrasts and better a11y