### PR TITLE
Fix SVG crash on iOS 12

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -3083,8 +3083,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SVGKit/SVGKit.git";
 			requirement = {
-				branch = 3.x;
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 3.0.0;
 			};
 		};
 		F75EAED626D2552E00F4320E /* XCRemoteSwiftPackageReference "MarqueeLabel" */ = {


### PR DESCRIPTION
### [SVGKit `3.x` does not support iOS 12](https://github.com/SVGKit/SVGKit/commit/024a0b2257ccf7e7c32ad87e6fb9163a18acb022#commitcomment-53974597)

This causes a runtime crash whenever an iOS 12 device tries to use SVGKit.

Alternatives:
- use another library
- increase the deployment target
- don't support SVGs on iOS <13
