### PR TITLE
Fix photo library access + passcode window

### DIFF
--- a/iOSClient/AppDelegate.swift
+++ b/iOSClient/AppDelegate.swift
@@ -189,8 +189,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     // L' applicazione entrerà in primo piano (attivo sempre)
     func applicationDidBecomeActive(_ application: UIApplication) {
         
-        // Privacy
-        hidePrivacyProtectionWindow()
+        if !NCAskAuthorization.shared.isRequesting {
+            // Privacy
+            hidePrivacyProtectionWindow()
+        }
         
         NCSettingsBundleHelper.setVersionAndBuildNumber()
         
@@ -693,7 +695,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     // MARK: - Passcode
     
-    func presentPasscode(completion: @escaping ()->()) {
+    func presentPasscode(completion: @escaping () -> ()) {
 
         let laContext = LAContext()
         var error: NSError?
@@ -787,8 +789,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         privacyProtectionWindow?.makeKeyAndVisible()
     }
 
-    private func hidePrivacyProtectionWindow() {
-        
+    func hidePrivacyProtectionWindow() {
         privacyProtectionWindow?.isHidden = true
         privacyProtectionWindow = nil
     }

--- a/iOSClient/Brand/iOSClient.plist
+++ b/iOSClient/Brand/iOSClient.plist
@@ -85,6 +85,8 @@
 		<string>Inconsolata-ExtraBold.ttf</string>
 		<string>Inconsolata-Black.ttf</string>
 	</array>
+	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/iOSClient/Main/NCFunctionCenter.swift
+++ b/iOSClient/Main/NCFunctionCenter.swift
@@ -306,27 +306,18 @@ import SVGKit
     func saveAlbum(metadata: tableMetadata) {
 
         let fileNamePath = CCUtility.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView)!
-        let status = PHPhotoLibrary.authorizationStatus()
 
-        if metadata.classFile == NCCommunicationCommon.typeClassFile.image.rawValue && status == PHAuthorizationStatus.authorized {
-
-            if let image = UIImage(contentsOfFile: fileNamePath) {
-                UIImageWriteToSavedPhotosAlbum(image, self, #selector(saveAlbum(_:didFinishSavingWithError:contextInfo:)), nil)
+        NCAskAuthorization.shared.askAuthorizationPhotoLibrary(viewController: appDelegate.mainTabBar?.window?.rootViewController) { hasPermission in
+            guard hasPermission else {
+                return NCContentPresenter.shared.messageNotification("_access_photo_not_enabled_", description: "_access_photo_not_enabled_msg_", delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, errorCode: NCGlobal.shared.errorFileNotSaved)
+            }
+            if metadata.classFile == NCCommunicationCommon.typeClassFile.image.rawValue, let image = UIImage(contentsOfFile: fileNamePath) {
+                UIImageWriteToSavedPhotosAlbum(image, self, #selector(self.saveAlbum(_:didFinishSavingWithError:contextInfo:)), nil)
+            } else if metadata.classFile == NCCommunicationCommon.typeClassFile.video.rawValue, UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(fileNamePath) {
+                UISaveVideoAtPathToSavedPhotosAlbum(fileNamePath, self, #selector(self.saveAlbum(_:didFinishSavingWithError:contextInfo:)), nil)
             } else {
                 NCContentPresenter.shared.messageNotification("_save_selected_files_", description: "_file_not_saved_cameraroll_", delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, errorCode: NCGlobal.shared.errorFileNotSaved)
             }
-
-        } else if metadata.classFile == NCCommunicationCommon.typeClassFile.video.rawValue && status == PHAuthorizationStatus.authorized {
-
-            if UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(fileNamePath) {
-                UISaveVideoAtPathToSavedPhotosAlbum(fileNamePath, self, #selector(saveAlbum(_:didFinishSavingWithError:contextInfo:)), nil)
-            } else {
-                NCContentPresenter.shared.messageNotification("_save_selected_files_", description: "_file_not_saved_cameraroll_", delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, errorCode: NCGlobal.shared.errorFileNotSaved)
-            }
-
-        } else if status != PHAuthorizationStatus.authorized {
-
-            NCContentPresenter.shared.messageNotification("_access_photo_not_enabled_", description: "_access_photo_not_enabled_msg_", delay: NCGlobal.shared.dismissAfterSecond, type: NCContentPresenter.messageType.error, errorCode: NCGlobal.shared.errorFileNotSaved)
         }
     }
 

--- a/iOSClient/Settings/CCManageAutoUpload.m
+++ b/iOSClient/Settings/CCManageAutoUpload.m
@@ -219,20 +219,7 @@
     [super viewWillAppear:animated];
     
     appDelegate.activeViewController = self;
-    
-    // Request permission for camera roll access
-    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
-        switch (status) {
-            case PHAuthorizationStatusRestricted:
-                NSLog(@"[LOG] user can't grant access to camera roll");
-                break;
-            case PHAuthorizationStatusDenied:
-                NSLog(@"[LOG] user denied access to camera roll");
-                break;
-            default:
-                break;
-        }
-    }];
+    [[NCAskAuthorization shared] askAuthorizationPhotoLibraryWithViewController:self completion:^(BOOL status) { }];
 }
 
 - (void)initialize

--- a/iOSClient/Utility/NCAskAuthorization.swift
+++ b/iOSClient/Utility/NCAskAuthorization.swift
@@ -29,6 +29,8 @@ class NCAskAuthorization: NSObject {
         return instance
     }()
 
+    private(set) var isRequesting = false
+
     func askAuthorizationAudioRecord(viewController: UIViewController?, completion: @escaping (_ hasPermission: Bool) -> Void) {
 
         switch AVAudioSession.sharedInstance().recordPermission {
@@ -85,7 +87,12 @@ class NCAskAuthorization: NSObject {
             }
             break
         case PHAuthorizationStatus.notDetermined:
+            isRequesting = true
             PHPhotoLibrary.requestAuthorization { allowed in
+                self.isRequesting = false
+                DispatchQueue.main.async {
+                    (UIApplication.shared.delegate as? AppDelegate)?.hidePrivacyProtectionWindow()
+                }
                 DispatchQueue.main.async {
                     if allowed == PHAuthorizationStatus.authorized {
                         completion(true)

--- a/iOSClient/Utility/NCAskAuthorization.swift
+++ b/iOSClient/Utility/NCAskAuthorization.swift
@@ -67,7 +67,7 @@ class NCAskAuthorization: NSObject {
         }
     }
 
-    func askAuthorizationPhotoLibrary(viewController: UIViewController?, completion: @escaping (_ hasPermission: Bool) -> Void) {
+    @objc func askAuthorizationPhotoLibrary(viewController: UIViewController?, completion: @escaping (_ hasPermission: Bool) -> Void) {
 
         switch PHPhotoLibrary.authorizationStatus() {
         case PHAuthorizationStatus.authorized:


### PR DESCRIPTION
Fix #1952 
Always present passcode on top of privacy window:
+ increase privacy
+ let's us present it on top of anything (including alerts / system dialogs) without dismissing them first

`PHPhotoLibraryPreventAutomaticLimitedAccessAlert`: Don't ask to select more photos automatically. The photo picker provides such an option already.