### PR TITLE
Improved PDF Viewer

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		F74E7720277A2EF40013B958 /* XLForm in Frameworks */ = {isa = PBXBuildFile; productRef = F74E771F277A2EF40013B958 /* XLForm */; };
 		F7501C322212E57500FB1415 /* NCMedia.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F7501C302212E57400FB1415 /* NCMedia.storyboard */; };
 		F7501C332212E57500FB1415 /* NCMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7501C312212E57400FB1415 /* NCMedia.swift */; };
+		F753BA93281FD8020015BFB6 /* EasyTipView in Frameworks */ = {isa = PBXBuildFile; productRef = F753BA92281FD8020015BFB6 /* EasyTipView */; };
 		F755BD9B20594AC7008C5FBB /* NCService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F755BD9A20594AC7008C5FBB /* NCService.swift */; };
 		F7581D1A25EFDA61004DC699 /* NCLoginWeb+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7581D1925EFDA60004DC699 /* NCLoginWeb+Menu.swift */; };
 		F7581D2425EFDDDF004DC699 /* NCMedia+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7581D2325EFDDDF004DC699 /* NCMedia+Menu.swift */; };
@@ -1000,6 +1001,7 @@
 				F758A01227A7F03E0069468B /* JGProgressHUD in Frameworks */,
 				F76DA96F277B78AE0082465B /* TLPhotoPicker in Frameworks */,
 				F76DA966277B76F30082465B /* UICKeyChainStore in Frameworks */,
+				F753BA93281FD8020015BFB6 /* EasyTipView in Frameworks */,
 				F76DA95B277B75A90082465B /* TOPasscodeViewController.xcframework in Frameworks */,
 				F76DA963277B760E0082465B /* Queuer in Frameworks */,
 				F75E57BD25BF0EC1002B72C2 /* SVGKit in Frameworks */,
@@ -2053,6 +2055,7 @@
 				F7233B3927835FA400F40A43 /* ChromaColorPicker */,
 				F7BB7E4627A18C56009B9F29 /* Parchment */,
 				F758A01127A7F03E0069468B /* JGProgressHUD */,
+				F753BA92281FD8020015BFB6 /* EasyTipView */,
 			);
 			productName = "Crypto Cloud";
 			productReference = F7CE8AFA1DC1F8D8009CAE48 /* Nextcloud.app */;
@@ -2180,6 +2183,7 @@
 				F7233B3827835FA300F40A43 /* XCRemoteSwiftPackageReference "ChromaColorPicker" */,
 				F7BB7E4527A18C56009B9F29 /* XCRemoteSwiftPackageReference "Parchment" */,
 				F72CD01027A7E92400E59476 /* XCRemoteSwiftPackageReference "JGProgressHUD" */,
+				F753BA91281FD8010015BFB6 /* XCRemoteSwiftPackageReference "EasyTipView" */,
 			);
 			productRefGroup = F7F67B9F1A24D27800EE80DA;
 			projectDirPath = "";
@@ -3169,6 +3173,14 @@
 				minimumVersion = 4.0.0;
 			};
 		};
+		F753BA91281FD8010015BFB6 /* XCRemoteSwiftPackageReference "EasyTipView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/marinofaggiana/EasyTipView";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 		F75E57A725BF0D61002B72C2 /* XCRemoteSwiftPackageReference "SVGKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SVGKit/SVGKit.git";
@@ -3352,6 +3364,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F74E771E277A2EF40013B958 /* XCRemoteSwiftPackageReference "XLForm" */;
 			productName = XLForm;
+		};
+		F753BA92281FD8020015BFB6 /* EasyTipView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F753BA91281FD8010015BFB6 /* XCRemoteSwiftPackageReference "EasyTipView" */;
+			productName = EasyTipView;
 		};
 		F758A01127A7F03E0069468B /* JGProgressHUD */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iOSClient/Data/NCDatabase.swift
+++ b/iOSClient/Data/NCDatabase.swift
@@ -493,6 +493,11 @@ class tableTag: Object {
     }
 }
 
+class tableTip: Object {
+
+    @Persisted(primaryKey: true) var tipName = ""
+}
+
 class tableTrash: Object {
 
     @objc dynamic var account = ""

--- a/iOSClient/Data/NCManageDatabase.swift
+++ b/iOSClient/Data/NCManageDatabase.swift
@@ -245,6 +245,7 @@ class NCManageDatabase: NSObject {
         self.clearTable(tablePhotoLibrary.self, account: account)
         self.clearTable(tableShare.self, account: account)
         self.clearTable(tableTag.self, account: account)
+        self.clearTable(tableTip.self)
         self.clearTable(tableTrash.self, account: account)
         self.clearTable(tableUserStatus.self, account: account)
         self.clearTable(tableVideo.self, account: account)
@@ -1544,6 +1545,37 @@ class NCManageDatabase: NSObject {
         }
 
         return tableTag.init(value: result)
+    }
+
+    // MARK: -
+    // MARK: Table Tip
+
+    @objc func tipExists(_ tipName: String) -> Bool {
+
+        let realm = try! Realm()
+
+        guard (realm.objects(tableTip.self).where {
+            $0.tipName == tipName
+        }.first) == nil else {
+            return true
+        }
+
+        return false
+    }
+
+    @objc func addTip(_ tipName: String) {
+
+        let realm = try! Realm()
+
+        do {
+            try realm.safeWrite {
+                let addObject = tableTip()
+                addObject.tipName = tipName
+                realm.add(addObject, update: .all)
+            }
+        } catch let error {
+            NCCommunicationCommon.shared.writeLog("Could not write to database: \(error)")
+        }
     }
 
     // MARK: -

--- a/iOSClient/Menu/NCViewer+Menu.swift
+++ b/iOSClient/Menu/NCViewer+Menu.swift
@@ -226,31 +226,6 @@ extension NCViewer {
                 )
             )
 
-            var title = ""
-            var icon = UIImage()
-
-            if CCUtility.getPDFDisplayDirection() == .horizontal {
-                title = NSLocalizedString("_pdf_vertical_", comment: "")
-                icon = UIImage(named: "pdf-vertical")!.image(color: NCBrandColor.shared.gray, size: 50)
-            } else {
-                title = NSLocalizedString("_pdf_horizontal_", comment: "")
-                icon = UIImage(named: "pdf-horizontal")!.image(color: NCBrandColor.shared.gray, size: 50)
-            }
-
-            actions.append(
-                NCMenuAction(
-                    title: title,
-                    icon: icon,
-                    action: { _ in
-                        if CCUtility.getPDFDisplayDirection() == .horizontal {
-                            NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterMenuPDFDisplayDirection, userInfo: ["direction": PDFDisplayDirection.vertical])
-                        } else {
-                            NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterMenuPDFDisplayDirection, userInfo: ["direction": PDFDisplayDirection.horizontal])
-                        }
-                    }
-                )
-            )
-
             actions.append(
                 NCMenuAction(
                     title: NSLocalizedString("_go_to_page_", comment: ""),

--- a/iOSClient/NCGlobal.swift
+++ b/iOSClient/NCGlobal.swift
@@ -112,7 +112,7 @@ class NCGlobal: NSObject {
     // Database Realm
     //
     let databaseDefault                             = "nextcloud.realm"
-    let databaseSchemaVersion: UInt64               = 217
+    let databaseSchemaVersion: UInt64               = 218
 
     // Intro selector
     //
@@ -361,4 +361,8 @@ class NCGlobal: NSObject {
     let notificationCenterReloadMediaPage                       = "reloadMediaPage"
     let notificationCenterPlayMedia                             = "playMedia"
     let notificationCenterPauseMedia                            = "pauseMedia"
+
+    // Tip
+    //
+    let tipNCViewerPDFThumbnail                                 = "tipncviewerpdfthumbnail"
 }

--- a/iOSClient/NCGlobal.swift
+++ b/iOSClient/NCGlobal.swift
@@ -344,7 +344,6 @@ class NCGlobal: NSObject {
     let notificationCenterFavoriteFile                          = "favoriteFile"                    // userInfo: ocId
 
     let notificationCenterMenuSearchTextPDF                     = "menuSearchTextPDF"
-    let notificationCenterMenuPDFDisplayDirection               = "menuPDFDisplayDirection"         // userInfo: direction
     let notificationCenterMenuGotToPageInPDF                    = "menuGotToPageInPDF"
     let notificationCenterMenuDetailClose                       = "menuDetailClose"
 

--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -850,4 +850,4 @@
 "_disable_"                 = "Disable";
 "_subtitle_not_dowloaded_"  = "There are subtitles not downloaded locally";
 // Tip
-"_tip_pdf_thumbnails_"      = "Swipe on left to open the thumbnails.";
+"_tip_pdf_thumbnails_"      = "Swipe left from the right edge of the screen to show the thumbnails.";

--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -849,4 +849,5 @@
 "_subtitle_not_found_"      = "Subtitle not found";
 "_disable_"                 = "Disable";
 "_subtitle_not_dowloaded_"  = "There are subtitles not downloaded locally";
-
+// Tip
+"_tip_pdf_thumbnails_"      = "Swipe on left to open the thumbnails.";

--- a/iOSClient/Utility/CCUtility.h
+++ b/iOSClient/Utility/CCUtility.h
@@ -180,9 +180,6 @@
 + (NSInteger)getCleanUpDay;
 + (void)setCleanUpDay:(NSInteger)days;
 
-+ (PDFDisplayDirection)getPDFDisplayDirection;
-+ (void)setPDFDisplayDirection:(PDFDisplayDirection)direction;
-
 + (BOOL)getPrivacyScreenEnabled;
 + (void)setPrivacyScreenEnabled:(BOOL)set;
 

--- a/iOSClient/Utility/CCUtility.m
+++ b/iOSClient/Utility/CCUtility.m
@@ -715,23 +715,6 @@
     [UICKeyChainStore setString:daysString forKey:@"cleanUpDay" service:NCGlobal.shared.serviceShareKeyChain];
 }
 
-+ (PDFDisplayDirection)getPDFDisplayDirection
-{
-    NSString *direction = [UICKeyChainStore stringForKey:@"PDFDisplayDirection" service:NCGlobal.shared.serviceShareKeyChain];
-    
-    if (direction == nil) {
-        return kPDFDisplayDirectionVertical;
-    } else {
-        return [direction integerValue];
-    }
-}
-
-+ (void)setPDFDisplayDirection:(PDFDisplayDirection)direction
-{
-    NSString *directionString = [@(direction) stringValue];
-    [UICKeyChainStore setString:directionString forKey:@"PDFDisplayDirection" service:NCGlobal.shared.serviceShareKeyChain];
-}
-
 + (BOOL)getPrivacyScreenEnabled
 {
     NSString *valueString = [UICKeyChainStore stringForKey:@"privacyScreen" service:NCGlobal.shared.serviceShareKeyChain];

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -47,10 +47,8 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
     private var defaultBackgroundColor: UIColor = .clear
 
-    private var pdfThumbnailScrollViewleadingAnchor: NSLayoutConstraint?
+    private var pdfThumbnailScrollViewTrailingAnchor: NSLayoutConstraint?
     private var pdfThumbnailScrollViewWidthAnchor: NSLayoutConstraint?
-    private var pdfThumbnailViewleadingAnchor: NSLayoutConstraint?
-    private var pageViewLeftAnchor: NSLayoutConstraint?
     private var pageViewWidthAnchor: NSLayoutConstraint?
 
     // MARK: - View Life Cycle
@@ -66,9 +64,6 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         let pageCount = CGFloat(pdfDocument?.pageCount ?? 0)
         defaultBackgroundColor = pdfView.backgroundColor
         view.backgroundColor = defaultBackgroundColor
-
-        navigationController?.interactivePopGestureRecognizer?.isEnabled = false
-        navigationController?.navigationBar.prefersLargeTitles = false
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "more")!.image(color: NCBrandColor.shared.label, size: 25), style: .plain, target: self, action: #selector(self.openMenuMore))
         navigationItem.title = metadata.fileNameView
@@ -88,12 +83,12 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         NSLayoutConstraint.activate([
             pdfView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             pdfView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            pdfView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+            pdfView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
         ])
         if UIDevice.current.userInterfaceIdiom == .pad {
-            pdfView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: thumbnailViewWidth).isActive = true
+            pdfView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -thumbnailViewWidth).isActive = true
         } else {
-            pdfView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+            pdfView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
         }
 
         // PDF THUMBNAIL
@@ -107,9 +102,9 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
             pdfThumbnailScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             pdfThumbnailScrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
-        pdfThumbnailScrollViewleadingAnchor = pdfThumbnailScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
-        pdfThumbnailScrollViewleadingAnchor?.isActive = true
-        pdfThumbnailScrollViewWidthAnchor = pdfThumbnailScrollView.widthAnchor.constraint(equalToConstant: 0)
+        pdfThumbnailScrollViewTrailingAnchor = pdfThumbnailScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        pdfThumbnailScrollViewTrailingAnchor?.isActive = true
+        pdfThumbnailScrollViewWidthAnchor = pdfThumbnailScrollView.widthAnchor.constraint(equalToConstant: thumbnailViewWidth)
         pdfThumbnailScrollViewWidthAnchor?.isActive = true
 
         pdfThumbnailView.translatesAutoresizingMaskIntoConstraints = false
@@ -127,11 +122,10 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         NSLayoutConstraint.activate([
             pdfThumbnailView.topAnchor.constraint(equalTo: pdfThumbnailScrollView.topAnchor),
             pdfThumbnailView.bottomAnchor.constraint(equalTo: pdfThumbnailScrollView.bottomAnchor),
-            pdfThumbnailView.trailingAnchor.constraint(equalTo: pdfThumbnailScrollView.trailingAnchor),
+            pdfThumbnailView.leadingAnchor.constraint(equalTo: pdfThumbnailScrollView.leadingAnchor),
+            pdfThumbnailView.leadingAnchor.constraint(equalTo: pdfThumbnailScrollView.trailingAnchor, constant: (UIApplication.shared.keyWindow?.safeAreaInsets.left ?? 0)),
             pdfThumbnailView.widthAnchor.constraint(equalToConstant: thumbnailViewWidth)
         ])
-        pdfThumbnailViewleadingAnchor = pdfThumbnailView.leadingAnchor.constraint(equalTo: pdfThumbnailScrollView.leadingAnchor)
-        pdfThumbnailViewleadingAnchor?.isActive = true
         let contentViewCenterY = pdfThumbnailView.centerYAnchor.constraint(equalTo: pdfThumbnailScrollView.centerYAnchor)
         contentViewCenterY.priority = .defaultLow
         let contentViewHeight = pdfThumbnailView.heightAnchor.constraint(equalToConstant: CGFloat(pageCount * thumbnailViewHeight) + CGFloat(pageCount * thumbnailPadding) + 30)
@@ -150,10 +144,9 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         NSLayoutConstraint.activate([
             pageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
-            pageView.heightAnchor.constraint(equalToConstant: 30)
+            pageView.heightAnchor.constraint(equalToConstant: 30),
+            pageView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 10)
         ])
-        pageViewLeftAnchor = pageView.leftAnchor.constraint(equalTo: view.leftAnchor)
-        pageViewLeftAnchor?.isActive = true
         pageViewWidthAnchor = pageView.widthAnchor.constraint(equalToConstant: 10)
         pageViewWidthAnchor?.isActive = true
 
@@ -180,21 +173,21 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
             tapPdfView.require(toFail: gesture)
         }
 
-        let swipeLeftPdfView = UISwipeGestureRecognizer(target: self, action: #selector(gestureClosePdfThumbnail))
-        swipeLeftPdfView.direction = .left
-        pdfView.addGestureRecognizer(swipeLeftPdfView)
+        let swipePdfView = UISwipeGestureRecognizer(target: self, action: #selector(gestureClosePdfThumbnail))
+        swipePdfView.direction = .right
+        pdfView.addGestureRecognizer(swipePdfView)
 
-        let swipeLeftpdfThumbnailScrollView = UISwipeGestureRecognizer(target: self, action: #selector(gestureClosePdfThumbnail))
-        swipeLeftpdfThumbnailScrollView.direction = .left
-        pdfThumbnailScrollView.addGestureRecognizer(swipeLeftpdfThumbnailScrollView)
+        let swipePdfThumbnailScrollView = UISwipeGestureRecognizer(target: self, action: #selector(gestureClosePdfThumbnail))
+        swipePdfThumbnailScrollView.direction = .right
+        pdfThumbnailScrollView.addGestureRecognizer(swipePdfThumbnailScrollView)
 
-        let edgeLeftPdfView = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(gestureOpenPdfThumbnail))
-        edgeLeftPdfView.edges = .left
-        pdfView.addGestureRecognizer(edgeLeftPdfView)
+        let edgePdfView = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(gestureOpenPdfThumbnail))
+        edgePdfView.edges = .right
+        pdfView.addGestureRecognizer(edgePdfView)
 
-        let edgeLeftView = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(gestureOpenPdfThumbnail))
-        edgeLeftView.edges = .left
-        view.addGestureRecognizer(edgeLeftView)
+        let edgeView = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(gestureOpenPdfThumbnail))
+        edgeView.edges = .right
+        view.addGestureRecognizer(edgeView)
 
         NotificationCenter.default.addObserver(self, selector: #selector(favoriteFile(_:)), name: NSNotification.Name(rawValue: NCGlobal.shared.notificationCenterFavoriteFile), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deleteFile(_:)), name: NSNotification.Name(rawValue: NCGlobal.shared.notificationCenterDeleteFile), object: nil)
@@ -222,8 +215,8 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         coordinator.animate(alongsideTransition: { context in
             if UIDevice.current.userInterfaceIdiom == .phone {
-                self.pdfThumbnailScrollViewleadingAnchor?.constant = -self.thumbnailViewWidth
-                self.pageViewLeftAnchor?.constant = 10
+                // Close
+                self.pdfThumbnailScrollViewTrailingAnchor?.constant = self.thumbnailViewWidth + (UIApplication.shared.keyWindow?.safeAreaInsets.right ?? 0)
                 self.pdfThumbnailScrollView.isHidden = true
             }
         }, completion: { context in
@@ -362,13 +355,25 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
     @objc func gestureOpenPdfThumbnail(_ recognizer: UIScreenEdgePanGestureRecognizer) {
 
-        openPdfThumbnail()
+        if UIDevice.current.userInterfaceIdiom == .phone && self.pdfThumbnailScrollView.isHidden {
+            self.pdfThumbnailScrollView.isHidden = false
+            self.pdfThumbnailScrollViewWidthAnchor?.constant = thumbnailViewWidth + (UIApplication.shared.keyWindow?.safeAreaInsets.right ?? 0)
+            UIView.animate(withDuration: animateDuration, animations: {
+                self.pdfThumbnailScrollViewTrailingAnchor?.constant = 0
+                self.view.layoutIfNeeded()
+            })
+        }
     }
 
     @objc func gestureClosePdfThumbnail(_ recognizer: UIScreenEdgePanGestureRecognizer) {
 
-        if recognizer.state == .recognized {
-            closePdfThumbnail()
+        if recognizer.state == .recognized && UIDevice.current.userInterfaceIdiom == .phone && !self.pdfThumbnailScrollView.isHidden {
+            UIView.animate(withDuration: animateDuration) {
+                self.pdfThumbnailScrollViewTrailingAnchor?.constant = self.thumbnailViewWidth + (UIApplication.shared.keyWindow?.safeAreaInsets.right ?? 0)
+                self.view.layoutIfNeeded()
+            } completion: { _ in
+                self.pdfThumbnailScrollView.isHidden = true
+            }
         }
     }
 
@@ -380,49 +385,18 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         UIView.animate(withDuration: animateDuration, animations: {
             if UIDevice.current.userInterfaceIdiom == .phone {
+                // Close
                 self.pdfThumbnailScrollView.isHidden = true
-                self.pdfThumbnailScrollViewleadingAnchor?.constant = -widthThumbnail
+                self.pdfThumbnailScrollViewTrailingAnchor?.constant = widthThumbnail
                 self.pdfThumbnailScrollViewWidthAnchor?.constant = widthThumbnail
-                self.pageViewLeftAnchor?.constant = 10
             } else {
-                self.pdfThumbnailScrollViewleadingAnchor?.constant = 0
+                // Open
+                self.pdfThumbnailScrollViewTrailingAnchor?.constant = 0
                 self.pdfThumbnailScrollViewWidthAnchor?.constant = widthThumbnail
-                self.pageViewLeftAnchor?.constant = widthThumbnail + 10
             }
-            self.pdfThumbnailViewleadingAnchor?.constant = (UIApplication.shared.keyWindow?.safeAreaInsets.right ?? 0)
             self.view.layoutIfNeeded()
             self.pdfView.autoScales = true
         })
-    }
-
-    func openPdfThumbnail() {
-
-        let widthThumbnail = thumbnailViewWidth + (UIApplication.shared.keyWindow?.safeAreaInsets.right ?? 0)
-
-        if UIDevice.current.userInterfaceIdiom == .phone && self.pdfThumbnailScrollView.isHidden {
-            self.pdfThumbnailScrollView.isHidden = false
-            self.pdfThumbnailScrollViewWidthAnchor?.constant = widthThumbnail
-            UIView.animate(withDuration: animateDuration, animations: {
-                self.pdfThumbnailScrollViewleadingAnchor?.constant = 0
-                self.pageViewLeftAnchor?.constant = widthThumbnail + 10
-                self.view.layoutIfNeeded()
-            })
-        }
-    }
-
-    func closePdfThumbnail() {
-
-        let widthThumbnail = thumbnailViewWidth + (UIApplication.shared.keyWindow?.safeAreaInsets.right ?? 0)
-
-        if UIDevice.current.userInterfaceIdiom == .phone && !self.pdfThumbnailScrollView.isHidden {
-            UIView.animate(withDuration: animateDuration) {
-                self.pdfThumbnailScrollViewleadingAnchor?.constant = -widthThumbnail
-                self.pageViewLeftAnchor?.constant = 10
-                self.view.layoutIfNeeded()
-            } completion: { _ in
-                self.pdfThumbnailScrollView.isHidden = true
-            }
-        }
     }
 
     @objc func handlePageChange() {

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -97,7 +97,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         view.addSubview(pdfThumbnailScrollView)
 
         NSLayoutConstraint.activate([
-            pdfThumbnailScrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            pdfThumbnailScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             pdfThumbnailScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
         pdfThumbnailScrollViewleadingAnchor = pdfThumbnailScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
@@ -342,9 +342,9 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
     @objc func tapPdfView(_ recognizer: UITapGestureRecognizer) {
 
         if navigationController?.isNavigationBarHidden ?? false {
-            navigationController?.setNavigationBarHidden(false, animated: false)
+            navigationController?.setNavigationBarHidden(false, animated: true)
         } else {
-            navigationController?.setNavigationBarHidden(true, animated: false)
+            navigationController?.setNavigationBarHidden(true, animated: true)
         }
     }
 
@@ -427,15 +427,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         let endY = visibleRect.origin.y + visibleRect.height + thumbnailViewHeight
 
         if currentPageY < startY {
-            if gotoY < 0 {
-                let safeAreaInsetsTop = UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0
-                let statusBarFrameHeight = UIApplication.shared.statusBarFrame.height
-                if navigationController?.isNavigationBarHidden ?? true {
-                    gotoY = -statusBarFrameHeight
-                } else {
-                    gotoY = safeAreaInsetsTop == 0 ? -statusBarFrameHeight : -(safeAreaInsetsTop + statusBarFrameHeight)
-                }
-            }
+            if gotoY < 0 { gotoY = 0 }
             pdfThumbnailScrollView.setContentOffset(CGPoint(x: 0, y: gotoY), animated: true)
         } else if currentPageY > endY {
             if gotoY > pdfThumbnailView.frame.height - visibleRect.height {

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -333,6 +333,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
     // MARK: - Action
 
     @objc func openMenuMore() {
+        
         if imageIcon == nil { imageIcon = UIImage(named: "file_pdf") }
         NCViewer.shared.toggleMenu(viewController: self, metadata: metadata, webView: false, imageIcon: imageIcon)
     }

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -47,6 +47,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
     private var defaultBackgroundColor: UIColor = .clear
 
+    private var pdfThumbnailScrollViewTopAnchor: NSLayoutConstraint?
     private var pdfThumbnailScrollViewTrailingAnchor: NSLayoutConstraint?
     private var pdfThumbnailScrollViewWidthAnchor: NSLayoutConstraint?
     private var pageViewWidthAnchor: NSLayoutConstraint?
@@ -91,10 +92,9 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         pdfThumbnailScrollView.showsVerticalScrollIndicator = false
         view.addSubview(pdfThumbnailScrollView)
 
-        NSLayoutConstraint.activate([
-            pdfThumbnailScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            pdfThumbnailScrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-        ])
+        pdfThumbnailScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+        pdfThumbnailScrollViewTopAnchor = pdfThumbnailScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+        pdfThumbnailScrollViewTopAnchor?.isActive = true
         pdfThumbnailScrollViewTrailingAnchor = pdfThumbnailScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         pdfThumbnailScrollViewTrailingAnchor?.isActive = true
         pdfThumbnailScrollViewWidthAnchor = pdfThumbnailScrollView.widthAnchor.constraint(equalToConstant: thumbnailViewWidth)
@@ -366,11 +366,19 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
     @objc func tapPdfView(_ recognizer: UITapGestureRecognizer) {
 
+        pdfThumbnailScrollViewTopAnchor?.isActive = false
+
         if navigationController?.isNavigationBarHidden ?? false {
             navigationController?.setNavigationBarHidden(false, animated: true)
+            pdfThumbnailScrollViewTopAnchor = pdfThumbnailScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+
         } else {
             navigationController?.setNavigationBarHidden(true, animated: true)
+            pdfThumbnailScrollViewTopAnchor = pdfThumbnailScrollView.topAnchor.constraint(equalTo: view.topAnchor)
         }
+
+        pdfThumbnailScrollViewTopAnchor?.isActive = true
+
         handlePageChange()
     }
 

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -427,7 +427,13 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         let endY = visibleRect.origin.y + visibleRect.height + thumbnailViewHeight
 
         if currentPageY < startY {
-            if gotoY < 0 { gotoY = -UIApplication.shared.statusBarFrame.height }
+            if gotoY < 0 {
+                if navigationController?.isNavigationBarHidden ?? true {
+                    gotoY = -UIApplication.shared.statusBarFrame.height
+                } else {
+                    gotoY = (UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0) == 0 ? -UIApplication.shared.statusBarFrame.height : -((UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0) + UIApplication.shared.statusBarFrame.height)
+                }
+            }
             pdfThumbnailScrollView.setContentOffset(CGPoint(x: 0, y: gotoY), animated: true)
         } else if currentPageY > endY {
             if gotoY > pdfThumbnailView.frame.height - visibleRect.height { gotoY = pdfThumbnailView.frame.height - visibleRect.height}

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -23,7 +23,6 @@
 
 import UIKit
 import PDFKit
-import SwiftUI
 import EasyTipView
 
 class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecognizerDelegate {
@@ -31,7 +30,6 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
     var metadata = tableMetadata()
     var imageIcon: UIImage?
 
-    private let appDelegate = UIApplication.shared.delegate as! AppDelegate
     private var filePath = ""
 
     private var pdfView = PDFView()
@@ -72,8 +70,12 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         // PDF VIEW
 
-        pdfView = PDFView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: view.frame.height))
-        pdfView.translatesAutoresizingMaskIntoConstraints = false
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            pdfView = PDFView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: view.frame.height))
+        } else {
+            pdfView = PDFView(frame: CGRect(x: 0, y: 0, width: view.frame.width-thumbnailViewWidth, height: view.frame.height))
+        }
+        pdfView.autoresizingMask = [.flexibleWidth, .flexibleHeight, .flexibleTopMargin, .flexibleLeftMargin]
         pdfView.document = pdfDocument
         pdfView.autoScales = true
         pdfView.displayMode = .singlePageContinuous
@@ -81,17 +83,6 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         pdfView.maxScaleFactor = 4.0
         pdfView.minScaleFactor = pdfView.scaleFactorForSizeToFit
         view.addSubview(pdfView)
-
-        NSLayoutConstraint.activate([
-            pdfView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            pdfView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            pdfView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
-        ])
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            pdfView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -thumbnailViewWidth).isActive = true
-        } else {
-            pdfView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
-        }
 
         // PDF THUMBNAIL
 
@@ -114,10 +105,10 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         pdfThumbnailView.layoutMode = .vertical
         pdfThumbnailView.thumbnailSize = CGSize(width: thumbnailViewHeight, height: thumbnailViewHeight)
         pdfThumbnailView.backgroundColor = .clear
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            self.pdfThumbnailScrollView.isHidden = false
-        } else {
+        if UIDevice.current.userInterfaceIdiom == .phone {
             self.pdfThumbnailScrollView.isHidden = true
+        } else {
+            self.pdfThumbnailScrollView.isHidden = false
         }
         pdfThumbnailScrollView.addSubview(pdfThumbnailView)
 
@@ -380,6 +371,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         } else {
             navigationController?.setNavigationBarHidden(true, animated: true)
         }
+        handlePageChange()
     }
 
     @objc func gestureOpenPdfThumbnail(_ recognizer: UIScreenEdgePanGestureRecognizer) {

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -78,6 +78,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         pdfView = PDFView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: view.frame.height))
         pdfView.translatesAutoresizingMaskIntoConstraints = false
         pdfView.document = pdfDocument
+        pdfView.autoScales = true
         pdfView.displayMode = .singlePageContinuous
         pdfView.displayDirection = .vertical
         pdfView.maxScaleFactor = 4.0

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -410,7 +410,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         var gotoY = currentPageY - centerPoint.y
 
         let startY = visibleRect.origin.y < 0 ? 0 : (visibleRect.origin.y + thumbnailViewHeight)
-        let endY = visibleRect.origin.y + visibleRect.height + thumbnailViewHeight
+        let endY = visibleRect.origin.y + visibleRect.height
 
         if currentPageY < startY {
             if gotoY < 0 { gotoY = 0 }

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -75,19 +75,25 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         // PDF VIEW
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
-            pdfView = PDFView(frame: CGRect(x: thumbnailViewWidth, y: 0, width: view.frame.width - thumbnailViewWidth, height: view.frame.height))
-        } else {
-            pdfView = PDFView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: view.frame.height))
-        }
-        pdfView.autoresizingMask = [.flexibleWidth, .flexibleHeight, .flexibleTopMargin, .flexibleBottomMargin]
+        pdfView = PDFView(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: view.frame.height))
+        pdfView.translatesAutoresizingMaskIntoConstraints = false
         pdfView.document = pdfDocument
         pdfView.displayMode = .singlePageContinuous
-        pdfView.autoScales = true
         pdfView.displayDirection = .vertical
         pdfView.maxScaleFactor = 4.0
         pdfView.minScaleFactor = pdfView.scaleFactorForSizeToFit
         view.addSubview(pdfView)
+
+        NSLayoutConstraint.activate([
+            pdfView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            pdfView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            pdfView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            pdfView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: thumbnailViewWidth).isActive = true
+        } else {
+            pdfView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        }
 
         // PDF THUMBNAIL
 
@@ -98,7 +104,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         NSLayoutConstraint.activate([
             pdfThumbnailScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            pdfThumbnailScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            pdfThumbnailScrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
         pdfThumbnailScrollViewleadingAnchor = pdfThumbnailScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor)
         pdfThumbnailScrollViewleadingAnchor?.isActive = true
@@ -127,7 +133,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         pdfThumbnailViewleadingAnchor?.isActive = true
         let contentViewCenterY = pdfThumbnailView.centerYAnchor.constraint(equalTo: pdfThumbnailScrollView.centerYAnchor)
         contentViewCenterY.priority = .defaultLow
-        let contentViewHeight = pdfThumbnailView.heightAnchor.constraint(equalToConstant: CGFloat(pageCount * thumbnailViewHeight) + CGFloat(pageCount * thumbnailPadding) + (thumbnailPadding * 2))
+        let contentViewHeight = pdfThumbnailView.heightAnchor.constraint(equalToConstant: CGFloat(pageCount * thumbnailViewHeight) + CGFloat(pageCount * thumbnailPadding) + 30)
         contentViewHeight.priority = .defaultLow
         NSLayoutConstraint.activate([
             contentViewCenterY,
@@ -184,6 +190,10 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
         let edgeLeftPdfView = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(gestureOpenPdfThumbnail))
         edgeLeftPdfView.edges = .left
         pdfView.addGestureRecognizer(edgeLeftPdfView)
+
+        let edgeLeftView = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(gestureOpenPdfThumbnail))
+        edgeLeftView.edges = .left
+        view.addGestureRecognizer(edgeLeftView)
 
         NotificationCenter.default.addObserver(self, selector: #selector(favoriteFile(_:)), name: NSNotification.Name(rawValue: NCGlobal.shared.notificationCenterFavoriteFile), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(deleteFile(_:)), name: NSNotification.Name(rawValue: NCGlobal.shared.notificationCenterDeleteFile), object: nil)
@@ -333,7 +343,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
     // MARK: - Action
 
     @objc func openMenuMore() {
-        
+
         if imageIcon == nil { imageIcon = UIImage(named: "file_pdf") }
         NCViewer.shared.toggleMenu(viewController: self, metadata: metadata, webView: false, imageIcon: imageIcon)
     }

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -204,6 +204,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
             preferences.drawing.backgroundColor = NCBrandColor.shared.customer
             preferences.drawing.textAlignment = .left
             preferences.drawing.arrowPosition = .right
+            preferences.drawing.cornerRadius = 10
 
             preferences.positioning.bubbleInsets.right = UIApplication.shared.keyWindow?.safeAreaInsets.right ?? 0
 

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -428,15 +428,19 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         if currentPageY < startY {
             if gotoY < 0 {
+                let safeAreaInsetsTop = UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0
+                let statusBarFrameHeight = UIApplication.shared.statusBarFrame.height
                 if navigationController?.isNavigationBarHidden ?? true {
-                    gotoY = -UIApplication.shared.statusBarFrame.height
+                    gotoY = -statusBarFrameHeight
                 } else {
-                    gotoY = (UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0) == 0 ? -UIApplication.shared.statusBarFrame.height : -((UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0) + UIApplication.shared.statusBarFrame.height)
+                    gotoY = safeAreaInsetsTop == 0 ? -statusBarFrameHeight : -(safeAreaInsetsTop + statusBarFrameHeight)
                 }
             }
             pdfThumbnailScrollView.setContentOffset(CGPoint(x: 0, y: gotoY), animated: true)
         } else if currentPageY > endY {
-            if gotoY > pdfThumbnailView.frame.height - visibleRect.height { gotoY = pdfThumbnailView.frame.height - visibleRect.height}
+            if gotoY > pdfThumbnailView.frame.height - visibleRect.height {
+                gotoY = pdfThumbnailView.frame.height - visibleRect.height
+            }
             pdfThumbnailScrollView.setContentOffset(CGPoint(x: 0, y: gotoY), animated: true)
         } else {
             print("visible")

--- a/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
+++ b/iOSClient/Viewer/NCViewerPDF/NCViewerPDF.swift
@@ -132,7 +132,9 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         pageView.translatesAutoresizingMaskIntoConstraints = false
         pageView.layer.cornerRadius = 10
-        pageView.backgroundColor = UIColor.gray.withAlphaComponent(0.3)
+        pageView.backgroundColor = NCBrandColor.shared.systemBackground.withAlphaComponent(
+            UIAccessibility.isReduceTransparencyEnabled ? 1 : 0.5
+        )
         view.addSubview(pageView)
 
         NSLayoutConstraint.activate([
@@ -145,7 +147,7 @@ class NCViewerPDF: UIViewController, NCViewerPDFSearchDelegate, UIGestureRecogni
 
         pageViewLabel.translatesAutoresizingMaskIntoConstraints = false
         pageViewLabel.textAlignment = .center
-        pageViewLabel.textColor = .gray
+        pageViewLabel.textColor = NCBrandColor.shared.label
         pageView.addSubview(pageViewLabel)
 
         NSLayoutConstraint.activate([


### PR DESCRIPTION
Issue: A page that is not next in numbering has opened, the thumbnails overlap each other.
Result: Use the vertical preview with scrollview (always open on iPad, with edge swift gesture in iPhone)

- Remove option Horizontal / Vertical mode 
- Add Thumbnails on right open/close on iPhone, always open on iPad
- Add Tip

**IPHONE**

![Simulator Screen Shot - iPhone 13 - 2022-05-02 at 14 38 10](https://user-images.githubusercontent.com/8616947/166234989-c2bfff26-6cac-415f-a9e2-7d8e8a76b75f.png)

![Simulator Screen Shot - iPhone 13 - 2022-05-02 at 14 43 27](https://user-images.githubusercontent.com/8616947/166235553-b141f1e3-1f64-4266-b2b2-a03521fd5188.png)

**IPAD**

![Simulator Screen Shot - iPad mini (6th generation) - 2022-05-02 at 14 51 45](https://user-images.githubusercontent.com/8616947/166236624-b87b2c62-efc7-4b2d-93e8-66eb6eb2dfa5.png)

https://github.com/nextcloud/ios/issues/1944