### PR TITLE
Add passcode delegate method

### DIFF
--- a/iOSClient/AppDelegate.swift
+++ b/iOSClient/AppDelegate.swift
@@ -764,6 +764,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         return code == CCUtility.getPasscode()
     }
 
+    func didPerformBiometricValidationRequest(in passcodeViewController: TOPasscodeViewController) {
+        enableTouchFaceID()
+    }
+
     // MARK: - Privacy Protection
 
     private func showPrivacyProtectionWindow() {


### PR DESCRIPTION
Addendum to #1994 

- add missing `didPerformBiometricValidationRequest` delegate method from TOPasscodeViewController
- there is no default implementation. If not implemented the button won't do anything