### PR TITLE
Respect app locale in interface and when creating automatic subfolder / voice memos / scans if system locale not supported

### DIFF
--- a/iOSClient/Extensions/DateFormatter+Extension.swift
+++ b/iOSClient/Extensions/DateFormatter+Extension.swift
@@ -26,6 +26,8 @@ import Foundation
 extension DateFormatter {
     static let shareExpDate: DateFormatter = {
         let dateFormatter = DateFormatter()
+        let app_locale = Bundle.main.preferredLocalizations.first
+        dateFormatter.locale = Locale(identifier: app_locale ?? "en_US")
         dateFormatter.formatterBehavior = .behavior10_4
         dateFormatter.dateStyle = .medium
         return dateFormatter

--- a/iOSClient/Main/Create cloud/NCCreateFormUploadAssets.swift
+++ b/iOSClient/Main/Create cloud/NCCreateFormUploadAssets.swift
@@ -359,6 +359,8 @@ class NCCreateFormUploadAssets: XLFormViewController, NCSelectDelegate {
 
                 if useSubFolder {
                     let dateFormatter = DateFormatter()
+                    let app_locale = Bundle.main.preferredLocalizations.first
+                    dateFormatter.locale = Locale(identifier: app_locale ?? "en_US")
                     dateFormatter.dateFormat = "yyyy"
                     let yearString = dateFormatter.string(from: creationDate)
                     dateFormatter.dateFormat = "MM"

--- a/iOSClient/Networking/NCAutoUpload.swift
+++ b/iOSClient/Networking/NCAutoUpload.swift
@@ -108,6 +108,8 @@ class NCAutoUpload: NSObject {
                 var livePhoto = false
                 var session: String = ""
                 let dateFormatter = DateFormatter()
+                let app_locale = Bundle.main.preferredLocalizations.first
+                dateFormatter.locale = Locale(identifier: app_locale ?? "en_US")
                 let assetDate = asset.creationDate ?? Date()
                 dateFormatter.dateFormat = "yyyy"
                 let year = dateFormatter.string(from: assetDate)

--- a/iOSClient/Networking/NCNetworking.swift
+++ b/iOSClient/Networking/NCNetworking.swift
@@ -1102,7 +1102,9 @@ import Photos
 
             var datesSubFolder: [String] = []
             let dateFormatter = DateFormatter()
-
+            let app_locale = Bundle.main.preferredLocalizations.first
+            dateFormatter.locale = Locale(identifier: app_locale ?? "en_US")
+            
             for asset in assets {
                 let date = asset.creationDate ?? Date()
                 dateFormatter.dateFormat = "yyyy"

--- a/iOSClient/Utility/CCUtility.m
+++ b/iOSClient/Utility/CCUtility.m
@@ -782,6 +782,8 @@
     } else {
         // Older than one month
         NSDateFormatter *df = [[NSDateFormatter alloc] init];
+        NSString *app_locale = [[NSBundle mainBundle] preferredLocalizations].firstObject;
+        df.locale = [[NSLocale alloc] initWithLocaleIdentifier: app_locale];
         [df setFormatterBehavior:NSDateFormatterBehavior10_4];
         [df setDateStyle:NSDateFormatterMediumStyle];
         return [df stringFromDate:convertedDate];
@@ -834,6 +836,7 @@
 + (NSString *)createFileNameDate:(NSString *)fileName extension:(NSString *)extension
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
     [formatter setDateFormat:@"yy-MM-dd HH-mm-ss"];
     NSString *fileNameDate = [formatter stringFromDate:[NSDate date]];
     NSString *returnFileName;
@@ -1206,7 +1209,12 @@
         
     } else {
         
-        title = [NSDateFormatter localizedStringFromDate:date dateStyle:NSDateFormatterLongStyle timeStyle:0];
+        NSDateFormatter *df = [[NSDateFormatter alloc] init];
+        NSString *app_locale = [[NSBundle mainBundle] preferredLocalizations].firstObject;
+        df.locale = [[NSLocale alloc] initWithLocaleIdentifier: app_locale];
+        df.dateStyle = NSDateFormatterLongStyle;
+        df.timeStyle = 0;
+        title = [df stringFromDate:date];
         
         if ([date isEqualToDate:[CCUtility datetimeWithOutTime:today]])
             title = [NSString stringWithFormat:NSLocalizedString(@"_today_", nil)];


### PR DESCRIPTION
Related to #2302 
- Does fix the autoupload subfolders
- Does not fix the inconsistencies in the interface, not sure where to change...

Signed-off-by: Francesco Servida <git.fservida@gmail.com>