### PR TITLE
Allow user to choose granularity of Autoupload subfolders (year/month/day)

### DIFF
--- a/iOSClient/Data/NCManageDatabase+Account.swift
+++ b/iOSClient/Data/NCManageDatabase+Account.swift
@@ -342,7 +342,7 @@ extension NCManageDatabase {
                 }
             }
         } catch let error {
-            NKCommon.shared.writeLog("Could not write to database: \(error)")
+            NextcloudKit.shared.nkCommonInstance.writeLog("Could not write to database: \(error)")
         }
     }
     

--- a/iOSClient/Data/NCManageDatabase+Account.swift
+++ b/iOSClient/Data/NCManageDatabase+Account.swift
@@ -33,6 +33,7 @@ class tableAccount: Object, NCUserBaseUrl {
     @objc dynamic var alias = ""
     @objc dynamic var autoUpload: Bool = false
     @objc dynamic var autoUploadCreateSubfolder: Bool = false
+    @objc dynamic var autoUploadSubfolderGranularity: Int64 = 1
     @objc dynamic var autoUploadDirectory = ""
     @objc dynamic var autoUploadFileName = ""
     @objc dynamic var autoUploadFull: Bool = false
@@ -259,6 +260,17 @@ extension NCManageDatabase {
         return folderPhotos
     }
 
+    @objc func getAccountAutoUploadSubfolderGranularity() -> Int64 {
+
+        let realm = try! Realm()
+
+        guard let result = realm.objects(tableAccount.self).filter("active == true").first else {
+            return 1
+        }
+
+        return result.autoUploadSubfolderGranularity
+    }
+    
     @discardableResult
     @objc func setAccountActive(_ account: String) -> tableAccount? {
 
@@ -319,6 +331,21 @@ extension NCManageDatabase {
         }
     }
 
+    @objc func setAccountAutoUploadGranularity(_ property: String, state: Int64) {
+
+        let realm = try! Realm()
+
+        do {
+            try realm.write {
+                if let result = realm.objects(tableAccount.self).filter("active == true").first {
+                    result.autoUploadSubfolderGranularity = state
+                }
+            }
+        } catch let error {
+            NKCommon.shared.writeLog("Could not write to database: \(error)")
+        }
+    }
+    
     @objc func setAccountAutoUploadFileName(_ fileName: String?) {
 
         let realm = try! Realm()

--- a/iOSClient/Main/Create cloud/NCUploadAssets.swift
+++ b/iOSClient/Main/Create cloud/NCUploadAssets.swift
@@ -71,6 +71,7 @@ class NCUploadAssets: NSObject, ObservableObject, NCCreateFormUploadConflictDele
         self.assets = assets
         self.serverUrl = serverUrl
         self.userBaseUrl = userBaseUrl
+        
     }
 
     func loadImages() {
@@ -249,6 +250,8 @@ struct UploadAssetsView: View {
         var metadatasUploadInConflict: [tableMetadata] = []
         let autoUploadPath = NCManageDatabase.shared.getAccountAutoUploadPath(urlBase: uploadAssets.userBaseUrl.urlBase, userId: uploadAssets.userBaseUrl.userId, account: uploadAssets.userBaseUrl.account)
         var serverUrl = uploadAssets.isUseAutoUploadFolder ? autoUploadPath : uploadAssets.serverUrl
+        let autoUploadSubfolderGranularity = NCManageDatabase.shared.getAccountAutoUploadSubfolderGranularity()
+
 
         for tlAsset in uploadAssets.assets {
             guard let asset = tlAsset.phAsset,
@@ -279,7 +282,17 @@ struct UploadAssetsView: View {
                 let yearString = dateFormatter.string(from: creationDate)
                 dateFormatter.dateFormat = "MM"
                 let monthString = dateFormatter.string(from: creationDate)
-                serverUrl = autoUploadPath + "/" + yearString + "/" + monthString
+                dateFormatter.dateFormat = "dd"
+                let dayString = dateFormatter.string(from: creationDate)
+                if (autoUploadSubfolderGranularity == 0) {
+                    serverUrl = autoUploadPath + "/" + yearString
+                }
+                else if (autoUploadSubfolderGranularity == 2) {
+                    serverUrl = autoUploadPath + "/" + yearString + "/" + monthString + "/" + dayString
+                }
+                else {  // Month Granularity is default
+                    serverUrl = autoUploadPath + "/" + yearString + "/" + monthString
+                }
             }
 
             // Check if is in upload

--- a/iOSClient/Networking/NCAutoUpload.swift
+++ b/iOSClient/Networking/NCAutoUpload.swift
@@ -83,6 +83,7 @@ class NCAutoUpload: NSObject {
         }
 
         let autoUploadPath = NCManageDatabase.shared.getAccountAutoUploadPath(urlBase: account.urlBase, userId: account.userId, account: account.account)
+        let autoUploadSubfolderGranularity = NCManageDatabase.shared.getAccountAutoUploadSubfolderGranularity()
         var metadatas: [tableMetadata] = []
 
         self.getCameraRollAssets(viewController: viewController, account: account, selector: selector, alignPhotoLibrary: false) { assets in
@@ -113,6 +114,8 @@ class NCAutoUpload: NSObject {
                 let year = dateFormatter.string(from: assetDate)
                 dateFormatter.dateFormat = "MM"
                 let month = dateFormatter.string(from: assetDate)
+                dateFormatter.dateFormat = "dd"
+                let day = dateFormatter.string(from: assetDate)
                 let assetMediaType = asset.mediaType
                 var serverUrl: String = ""
                 let fileName = CCUtility.createFileName(asset.value(forKey: "filename") as? String, fileDate: assetDate, fileType: assetMediaType, keyFileName: NCGlobal.shared.keyFileNameAutoUploadMask, keyFileNameType: NCGlobal.shared.keyFileNameAutoUploadType, keyFileNameOriginal: NCGlobal.shared.keyFileNameOriginalAutoUpload, forcedNewFileName: false)!
@@ -136,7 +139,15 @@ class NCAutoUpload: NSObject {
                 }
 
                 if account.autoUploadCreateSubfolder {
-                    serverUrl = autoUploadPath + "/" + year + "/" + month
+                    if (autoUploadSubfolderGranularity == 0) {
+                        serverUrl = autoUploadPath + "/" + year
+                    }
+                    else if (autoUploadSubfolderGranularity == 2) {
+                        serverUrl = autoUploadPath + "/" + year + "/" + month + "/" + day
+                    }
+                    else {  // Month Granularity is default
+                        serverUrl = autoUploadPath + "/" + year + "/" + month
+                    }
                 } else {
                     serverUrl = autoUploadPath
                 }

--- a/iOSClient/Networking/NCNetworking.swift
+++ b/iOSClient/Networking/NCNetworking.swift
@@ -1102,7 +1102,8 @@ class NCNetworking: NSObject, NKCommonDelegate {
         let autoUploadPath = NCManageDatabase.shared.getAccountAutoUploadPath(urlBase: urlBase, userId: userId, account: account)
         let serverUrlBase = NCManageDatabase.shared.getAccountAutoUploadDirectory(urlBase: urlBase, userId: userId, account: account)
         let fileNameBase =  NCManageDatabase.shared.getAccountAutoUploadFileName()
-
+        let autoUploadSubfolderGranularity = NCManageDatabase.shared.getAccountAutoUploadSubfolderGranularity()
+        
         func createFolder(fileName: String, serverUrl: String) -> Bool {
             var result: Bool = false
             let semaphore = DispatchSemaphore(value: 0)
@@ -1125,7 +1126,17 @@ class NCNetworking: NSObject, NKCommonDelegate {
                 let year = dateFormatter.string(from: date)
                 dateFormatter.dateFormat = "MM"
                 let month = dateFormatter.string(from: date)
-                datesSubFolder.append("\(year)/\(month)")
+                dateFormatter.dateFormat = "dd"
+                let day = dateFormatter.string(from: date)
+                if (autoUploadSubfolderGranularity == 0) {
+                    datesSubFolder.append("\(year)")
+                }
+                else if (autoUploadSubfolderGranularity == 2) {
+                    datesSubFolder.append("\(year)/\(month)/\(day)")
+                }
+                else {  // Month Granularity is default
+                    datesSubFolder.append("\(year)/\(month)")
+                }
             }
 
             return Array(Set(datesSubFolder))
@@ -1135,14 +1146,19 @@ class NCNetworking: NSObject, NKCommonDelegate {
 
         if useSubFolder && result {
             for dateSubFolder in createNameSubFolder() {
-                let yearMonth = dateSubFolder.split(separator: "/")
-                guard let year = yearMonth.first else { break }
-                guard let month = yearMonth.last else { break }
+                let subfolderArray = dateSubFolder.split(separator: "/")
+                let year = subfolderArray[0]
                 let serverUrlYear = autoUploadPath
-                let serverUrlMonth = autoUploadPath + "/" + year
-                result = createFolder(fileName: String(year), serverUrl: serverUrlYear)
-                if result {
+                result = createFolder(fileName: String(year), serverUrl: serverUrlYear)  // Year always present independently of preference value
+                if result && (autoUploadSubfolderGranularity >= 1) {
+                    let month = subfolderArray[1]
+                    let serverUrlMonth = autoUploadPath + "/" + year
                     result = createFolder(fileName: String(month), serverUrl: serverUrlMonth)
+                    if result && (autoUploadSubfolderGranularity == 2) {
+                        let day = subfolderArray[2]
+                        let serverUrlDay = autoUploadPath + "/" + year + "/" + month
+                        result = createFolder(fileName: String(day), serverUrl: serverUrlDay)
+                    }
                 }
                 if !result { break }
             }

--- a/iOSClient/Settings/CCManageAutoUpload.m
+++ b/iOSClient/Settings/CCManageAutoUpload.m
@@ -147,6 +147,20 @@
     [row.cellConfig setObject:UIColor.labelColor forKey:@"textLabel.textColor"];
     [section addFormRow:row];
     
+    row = [XLFormRowDescriptor formRowDescriptorWithTag:@"autoUploadSubfolderGranularity" rowType:XLFormRowDescriptorTypeSelectorPush title:NSLocalizedString(@"_autoupload_subfolder_granularity_", nil)];
+    row.cellConfigAtConfigure[@"backgroundColor"] = UIColor.secondarySystemGroupedBackgroundColor;
+    row.hidden = [NSString stringWithFormat:@"$%@==0", @"autoUpload"];
+    row.selectorOptions = @[
+        [XLFormOptionsObject formOptionsObjectWithValue:@(0) displayText:NSLocalizedString(@"_yearly_", nil)],
+        [XLFormOptionsObject formOptionsObjectWithValue:@(1) displayText:NSLocalizedString(@"_monthly_", nil)],
+        [XLFormOptionsObject formOptionsObjectWithValue:@(2) displayText:NSLocalizedString(@"_daily_", nil)]
+        ];
+    row.value = row.selectorOptions[activeAccount.autoUploadSubfolderGranularity];
+    row.required = true;
+    [row.cellConfig setObject:[UIFont systemFontOfSize:15.0] forKey:@"textLabel.font"];
+    [row.cellConfig setObject:UIColor.labelColor forKey:@"textLabel.textColor"];
+    [section addFormRow:row];
+    
     // Auto Upload file name
     
     section = [XLFormSectionDescriptor formSection];
@@ -286,6 +300,11 @@
         
         [[NCManageDatabase shared] setAccountAutoUploadProperty:@"autoUploadCreateSubfolder" state:[[rowDescriptor.value valueData] boolValue]];
     }
+    
+    if ([rowDescriptor.tag isEqualToString:@"autoUploadSubfolderGranularity"]) {
+
+        [[NCManageDatabase shared] setAccountAutoUploadGranularity:@"autoUploadSubfolderGranularity" state:[[rowDescriptor.value valueData] integerValue]];
+    }
 }
 
 - (void)done:(XLFormRowDescriptor *)sender
@@ -308,6 +327,8 @@
     XLFormRowDescriptor *rowAutoUploadFull = [self.form formRowWithTag:@"autoUploadFull"];
     
     XLFormRowDescriptor *rowAutoUploadCreateSubfolder = [self.form formRowWithTag:@"autoUploadCreateSubfolder"];
+    
+    XLFormRowDescriptor *rowAutoUploadSubfolderGranularity = [self.form formRowWithTag:@"autoUploadSubfolderGranularity"];
     
     XLFormRowDescriptor *rowAutoUploadFileName = [self.form formRowWithTag:@"autoUploadFileName"];
         
@@ -335,6 +356,8 @@
     if (activeAccount.autoUploadCreateSubfolder)
         [rowAutoUploadCreateSubfolder setValue:@1]; else [rowAutoUploadCreateSubfolder setValue:@0];
 
+    [rowAutoUploadSubfolderGranularity setValue:rowAutoUploadSubfolderGranularity.selectorOptions[activeAccount.autoUploadSubfolderGranularity]];
+    
     // - HIDDEN --------------------------------------------------------------------------
     
     rowAutoUploadImage.hidden = [NSString stringWithFormat:@"$%@==0", @"autoUpload"];
@@ -346,6 +369,8 @@
     rowAutoUploadFull.hidden = [NSString stringWithFormat:@"$%@==0", @"autoUpload"];
     
     rowAutoUploadCreateSubfolder.hidden = [NSString stringWithFormat:@"$%@==0", @"autoUpload"];
+    
+    rowAutoUploadSubfolderGranularity.hidden = [NSString stringWithFormat:@"$%@==0", @"autoUpload"];
     
     rowAutoUploadFileName.hidden = [NSString stringWithFormat:@"$%@==0", @"autoUpload"];
         

--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -390,6 +390,7 @@
 "_autoupload_fullphotos_footer_"    = "Adjust the options above before uploading";
 "_autoupload_create_subfolder_"     = "Use subfolders";
 "_autoupload_create_subfolder_footer_" = "Store in subfolders based on year and month";
+"_autoupload_subfolder_granularity_" = "Subfolder Granularity";
 "_autoupload_filenamemask_"         = "Change filename mask";
 "_autoupload_filenamemask_footer_"  = "Change the automatic filename mask";
 "_autoupload_current_folder_"       = "Currently selected folder";
@@ -863,6 +864,7 @@
 "_monthly_"                 = "Monthly";
 "_yearly_"                  = "Yearly";
 "_weekly_"                  = "Weekly";
+"_daily_"                   = "Daily";
 "_day_"                     = "Day";
 "_used_space_"              = "Used space";
 "_open_in_onlyoffice_"      = "Open in ONLYOFFICE";


### PR DESCRIPTION
Hello Marino,
I've updated the pull request with your new code, any chance to get this merged?

Pretty much the same as https://github.com/nextcloud/ios/pull/2305 but rebased on current app version.
Tested without problems on simulator, both for manual upload with new form and automatic background upload.

Solves #2283  

![image](https://user-images.githubusercontent.com/501958/229365813-ee0deab6-2aee-49a9-b220-0e50b8cadee2.png)

Signed-off-by: Francesco Servida [git.fservida@gmail.com](mailto:git.fservida@gmail.com)