### PR TITLE
Crash fix for info section

### DIFF
--- a/iOSClient/Share/NCSharePaging.swift
+++ b/iOSClient/Share/NCSharePaging.swift
@@ -89,7 +89,7 @@ class NCSharePaging: UIViewController {
 
         pagingViewController.dataSource = self
         pagingViewController.delegate = self
-        pagingViewController.select(index: page.rawValue)
+        pagingViewController.select(index: page.rawValue < pages.count ? page.rawValue : max(pages.count - 1, 0))
 
         (pagingViewController.view as? NCSharePagingView)?.setupConstraints()
         pagingViewController.reloadMenu()


### PR DESCRIPTION
Steps to reproduce:
Try to open `info` for any only shareable item. (video attached)

**Crash Reason**: When we are removing the pages which are not applicable (sharing / activity) we are reducing the pages count. However, we are passing page.rawValue to `pagingViewController` which can be 1 when page.count is 1 resulting in `outOfBoundsCrash`

**Solution**: Sets an upper limit for the index to be passed to `PagingViewController`

https://github.com/nextcloud/ios/assets/32197474/5b6d564c-9dfe-4a2d-9474-246c2cd24341



