### PR TITLE
Add unique string to shared file names

### DIFF
--- a/Share/NCShareExtension+Files.swift
+++ b/Share/NCShareExtension+Files.swift
@@ -115,7 +115,7 @@ class NCFilesExtensionHandler {
                 var originalName = (dateFormatter.string(from: Date())) + String(ix)
 
                 if let url = item as? URL, url.isFileURL, !url.lastPathComponent.isEmpty {
-                    originalName = url.lastPathComponent
+                    originalName = url.deletingPathExtension().lastPathComponent + CCUtility.getIncrementalNumber() + "." + url.pathExtension
                 }
 
                 var fileName: String?
@@ -131,7 +131,9 @@ class NCFilesExtensionHandler {
                 default: return
                 }
 
-                if let fileName = fileName, !filesName.contains(fileName) { filesName.append(fileName) }
+                if let fileName, !filesName.contains(fileName) {
+                    filesName.append(fileName)
+                }
             }
         }
     }
@@ -140,8 +142,7 @@ class NCFilesExtensionHandler {
     func getItem(image: UIImage, fileName: String) -> String? {
         var fileUrl = URL(fileURLWithPath: NSTemporaryDirectory() + fileName)
         if fileUrl.pathExtension.isEmpty { fileUrl.appendPathExtension("png") }
-        guard let pngImageData = image.pngData(),
-              (try? pngImageData.write(to: fileUrl, options: [.atomic])) != nil
+        guard let pngImageData = image.pngData(), (try? pngImageData.write(to: fileUrl, options: [.atomic])) != nil
         else { return nil }
         return fileUrl.lastPathComponent
     }


### PR DESCRIPTION
Some files that are shared from other apps, like WhatsApp, might have the same names. For example photos that were captured at the same minute. To fix this, I added a unique string for those file names so they are always different.


Before the fix some files that are different photos would sometimes have the same name, like the 3 pictures captured at the same minute:
```
Name Optional("PHOTO-2023-03-31-20-46-01.jpg")
Name Optional("PHOTO-2023-03-31-20-46-01.jpg")
Name Optional("PHOTO-2023-03-31-20-46-01.jpg")
Name Optional("PHOTO-2023-04-04-19-11-44.jpg")
Name Optional("PHOTO-2023-04-04-19-12-04.jpg")
Name Optional("PHOTO-2023-04-07-11-41-11.jpg")
```

This would cause the app to ignore the files with the same name and the loaded files to be less than the selected ones (6 selected but 4 loaded):

![image](https://github.com/nextcloud/ios/assets/6960329/ecbc2498-d77b-49a1-a4f5-4623db4df5ff)

The fix adds a unique string:
```
Name Optional("PHOTO-2023-03-31-20-46-010054.jpg")
Name Optional("PHOTO-2023-03-31-20-46-010055.jpg")
Name Optional("PHOTO-2023-03-31-20-46-010056.jpg")
Name Optional("PHOTO-2023-04-04-19-11-440057.jpg")
Name Optional("PHOTO-2023-04-04-19-12-040058.jpg")
Name Optional("PHOTO-2023-04-07-11-41-110059.jpg")
```

Now loads all files, even the ones that are different photos but have the same name:

![image](https://github.com/nextcloud/ios/assets/6960329/ccd32ad8-0342-4bec-ba9a-38c8c5b54d1b)
