### PR TITLE
Set default and max value to chunkSize

### DIFF
--- a/iOSClient/Settings/CCAdvanced.m
+++ b/iOSClient/Settings/CCAdvanced.m
@@ -116,7 +116,7 @@
     [row.cellConfigAtConfigure setObject:@YES forKey:@"stepControl.wraps"];
     [row.cellConfigAtConfigure setObject:@1 forKey:@"stepControl.stepValue"];
     [row.cellConfigAtConfigure setObject:@0 forKey:@"stepControl.minimumValue"];
-    [row.cellConfigAtConfigure setObject:@100 forKey:@"stepControl.maximumValue"];
+    [row.cellConfigAtConfigure setObject:@1000 forKey:@"stepControl.maximumValue"];
     [section addFormRow:row];
 
     // Section : Privacy --------------------------------------------------------------

--- a/iOSClient/Utility/CCUtility.m
+++ b/iOSClient/Utility/CCUtility.m
@@ -672,7 +672,7 @@
     NSString *size = [UICKeyChainStore stringForKey:@"chunkSize" service:NCGlobal.shared.serviceShareKeyChain];
     
     if (size == nil) {
-        return 0;
+        return 100;
     } else {
         return [size integerValue];
     }


### PR DESCRIPTION
* Resolve: #2490 

Hi team,
as described on issue above, I set default value for chunks to 100MB and increase the max limit to 1000MB.

Actually is not see any "flow" to check the best chunksize with nextcloud server, but this minor fix, for sure help a lot all people that have timeout issue or limit on nextcloud server.

I can increate max value for chunks, but to me is not much sense (is a mobile, so not much usefull).


Let me know if it's ok for you.