### PR TITLE
Fix files/favorites/search view cut off in compact height

### DIFF
--- a/iOSClient/EmptyView/NCEmptyDataSet.swift
+++ b/iOSClient/EmptyView/NCEmptyDataSet.swift
@@ -49,36 +49,33 @@ class NCEmptyDataSet: NSObject {
     init(view: UIView, offset: CGFloat = 0, delegate: NCEmptyDataSetDelegate?) {
         super.init()
 
-        if let emptyView = UINib(nibName: "NCEmptyView", bundle: nil).instantiate(withOwner: self, options: nil).first as? NCEmptyView {
+        guard let emptyView = NCEmptyView.fromNib().instantiate(withOwner: self, options: nil).first as? NCEmptyView else { return }
 
-            self.delegate = delegate
-            self.emptyView = emptyView
+        self.delegate = delegate
+        self.emptyView = emptyView
 
-            emptyView.isHidden = true
-            emptyView.translatesAutoresizingMaskIntoConstraints = false
+        emptyView.isHidden = true
+        emptyView.translatesAutoresizingMaskIntoConstraints = false
 
-//            emptyView.backgroundColor = .red
-//            emptyView.isHidden = false
+        emptyView.emptyTitle.sizeToFit()
+        emptyView.emptyDescription.sizeToFit()
 
-            emptyView.emptyTitle.sizeToFit()
-            emptyView.emptyDescription.sizeToFit()
+        view.addSubview(emptyView)
 
-            view.addSubview(emptyView)
+        emptyView.widthAnchor.constraint(equalToConstant: 350).isActive = true
+        emptyView.heightAnchor.constraint(equalToConstant: 250).isActive = true
 
-            emptyView.widthAnchor.constraint(equalToConstant: 350).isActive = true
-            emptyView.heightAnchor.constraint(equalToConstant: 250).isActive = true
-
-            if let view = view.superview {
-                centerXAnchor = emptyView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
-                centerYAnchor = emptyView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: offset)
-            } else {
-                centerXAnchor = emptyView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
-                centerYAnchor = emptyView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: offset)
-            }
-
-            centerXAnchor?.isActive = true
-            centerYAnchor?.isActive = true
+        if let view = view.superview {
+            centerXAnchor = emptyView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            centerYAnchor = emptyView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: offset)
+        } else {
+            centerXAnchor = emptyView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            centerYAnchor = emptyView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: offset)
         }
+
+        centerXAnchor?.isActive = true
+        centerYAnchor?.isActive = true
+
     }
 
     func setOffset(_ offset: CGFloat) {
@@ -123,6 +120,10 @@ public class NCEmptyView: UIView {
     @IBOutlet weak var emptyImage: UIImageView!
     @IBOutlet weak var emptyTitle: UILabel!
     @IBOutlet weak var emptyDescription: UILabel!
+
+    static func fromNib() -> UINib {
+        return UINib(nibName: "NCEmptyView", bundle: nil)
+    }
 
     public override func awakeFromNib() {
         super.awakeFromNib()

--- a/iOSClient/EmptyView/NCEmptyView.xib
+++ b/iOSClient/EmptyView/NCEmptyView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina3_5" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_72" orientation="landscape" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,24 +12,20 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="NCEmptyView" customModule="Nextcloud" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="350" height="250"/>
+            <rect key="frame" x="0.0" y="0.0" width="422" height="475"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="W3d-Us-kU4">
-                    <rect key="frame" x="100" y="0.0" width="150" height="150"/>
+                    <rect key="frame" x="136" y="20" width="150" height="75"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="150" id="A8B-y7-Fre"/>
+                        <constraint firstAttribute="height" constant="150" id="A8B-y7-Fre">
+                            <variation key="heightClass=compact" constant="75"/>
+                        </constraint>
                         <constraint firstAttribute="width" constant="150" id="g0C-P6-l3d"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="crs-DO-owR">
-                    <rect key="frame" x="20" y="180" width="310" height="24"/>
-                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
-                    <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D4p-sI-mNB">
-                    <rect key="frame" x="20" y="224" width="310" height="17"/>
+                    <rect key="frame" x="79" y="135" width="264" height="17"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="lessThanOrEqual" constant="50" id="u7B-jW-bWI"/>
                     </constraints>
@@ -37,18 +33,26 @@
                     <color key="textColor" systemColor="systemGrayColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="crs-DO-owR">
+                    <rect key="frame" x="79" y="103" width="264" height="24"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                    <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="crs-DO-owR" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="CMU-Tp-bUM"/>
-                <constraint firstItem="W3d-Us-kU4" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Fyb-so-iAw"/>
                 <constraint firstItem="D4p-sI-mNB" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="egV-G4-wax"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="crs-DO-owR" secondAttribute="trailing" constant="20" id="hHl-iN-Gev"/>
-                <constraint firstItem="crs-DO-owR" firstAttribute="top" secondItem="W3d-Us-kU4" secondAttribute="bottom" constant="30" id="hLN-L6-0gH"/>
+                <constraint firstItem="crs-DO-owR" firstAttribute="top" secondItem="W3d-Us-kU4" secondAttribute="bottom" constant="8" id="hLN-L6-0gH"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="D4p-sI-mNB" secondAttribute="trailing" constant="20" id="imv-AK-mqu"/>
                 <constraint firstItem="W3d-Us-kU4" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="kma-1Q-c3Q"/>
-                <constraint firstItem="D4p-sI-mNB" firstAttribute="top" secondItem="crs-DO-owR" secondAttribute="bottom" constant="20" id="zbi-5P-raN"/>
+                <constraint firstItem="W3d-Us-kU4" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="uOy-F7-KNu">
+                    <variation key="heightClass=compact" constant="20"/>
+                </constraint>
+                <constraint firstItem="D4p-sI-mNB" firstAttribute="top" secondItem="crs-DO-owR" secondAttribute="bottom" constant="8" id="zbi-5P-raN"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
@@ -56,7 +60,7 @@
                 <outlet property="emptyImage" destination="W3d-Us-kU4" id="xtd-nV-OUc"/>
                 <outlet property="emptyTitle" destination="crs-DO-owR" id="IkU-6d-P64"/>
             </connections>
-            <point key="canvasLocation" x="-146.25" y="32.5"/>
+            <point key="canvasLocation" x="-86.956521739130437" y="111.49553571428571"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
This will close #2498 
This fixes the cut off view in compact height by reducing the icon size (only in compact height) and reducing text margins:


https://github.com/nextcloud/ios/assets/6960329/474c1717-3dd0-4229-8b97-e7d576555aae


