### PR TITLE
Reduce size of rotated/cropped images 

### DIFF
--- a/iOSClient/Viewer/NCViewerQuickLook/NCViewerQuickLook.swift
+++ b/iOSClient/Viewer/NCViewerQuickLook/NCViewerQuickLook.swift
@@ -76,7 +76,7 @@ private var hasChangesQuickLook: Bool = false
         }
 
         if let metadata = metadata, metadata.isImage {
-            let buttonDone = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismission))
+            let buttonDone = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismiss))
             let buttonCrop = UIBarButtonItem(image: UIImage(systemName: "crop"), style: .plain, target: self, action: #selector(crop))
             navigationItem.leftBarButtonItems = [buttonDone, buttonCrop]
             startTimer(navigationItem: navigationItem)
@@ -94,7 +94,7 @@ private var hasChangesQuickLook: Bool = false
         super.viewDidDisappear(animated)
 
         if let metadata = metadata, metadata.classFile != NKCommon.TypeClassFile.image.rawValue {
-            dismission()
+            dismiss()
         }
     }
 
@@ -116,7 +116,7 @@ private var hasChangesQuickLook: Bool = false
         })
     }
 
-    @objc func dismission() {
+    @objc func dismiss() {
 
         guard isEditingEnabled, hasChangesQuickLook, let metadata = metadata else {
             dismiss(animated: true)
@@ -256,12 +256,15 @@ extension NCViewerQuickLook: CropViewControllerDelegate {
 
     func cropViewControllerDidCrop(_ cropViewController: Mantis.CropViewController, cropped: UIImage, transformation: Mantis.Transformation, cropInfo: Mantis.CropInfo) {
         cropViewController.dismiss(animated: true)
-        guard let data = cropped.jpegData(compressionQuality: 1) else { return }
+        guard let data = cropped.jpegData(compressionQuality: 0.9) else { return }
+
         do {
             try data.write(to: self.url)
             hasChangesQuickLook = true
             reloadData()
-        } catch {  }
+        } catch {
+            print(error)
+        }
     }
 
     func cropViewControllerDidCancel(_ cropViewController: Mantis.CropViewController, original: UIImage) {


### PR DESCRIPTION
This fixes #2517 

Before, an original image of around 300 KB would become 2+ MB.
This fixes this by increasing the JPEG compression of the modified image.

It would never be the same size as the original, since `UIImage`, conversions and transformations add a lot of overhead, but this brings it much closer to the original size, without any noticeable sacrifice in quality.

Before:

<img width="333" alt="image" src="https://user-images.githubusercontent.com/6960329/251488591-48096c83-a968-4b45-ad68-a55bf1ac7751.png">

Now:

<img width="333" alt="image" src="https://github.com/nextcloud/ios/assets/6960329/75340486-1898-4d4c-9048-61a1e63616a8">
