### PR TITLE
Update MobileVLCKit + other fixes

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "https://github.com/marinofaggiana/TOPasscodeViewController" "master"
-binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/MobileVLCKit.json" ~> 3.3.0
+binary "https://code.videolan.org/videolan/VLCKit/raw/master/Packaging/MobileVLCKit.json" ~> 3.5.1

--- a/iOSClient/Data/NCManageDatabase+Metadata.swift
+++ b/iOSClient/Data/NCManageDatabase+Metadata.swift
@@ -144,7 +144,7 @@ extension tableMetadata {
         sharePermissionsCollaborationServices == NCGlobal.shared.permissionReadShare && classFile == NKCommon.TypeClassFile.document.rawValue
     }
 
-    var isMovie: Bool {
+    var isAudioOrVideo: Bool {
         return classFile == NKCommon.TypeClassFile.audio.rawValue || classFile == NKCommon.TypeClassFile.video.rawValue
     }
 

--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
@@ -1303,10 +1303,10 @@ extension NCCollectionViewCommon: UICollectionViewDelegate {
             
             let imageIcon = UIImage(contentsOfFile: CCUtility.getDirectoryProviderStorageIconOcId(metadata.ocId, etag: metadata.etag))
 
-            if metadata.isImage || metadata.isMovie {
+            if metadata.isImage || metadata.isAudioOrVideo {
                 var metadatas: [tableMetadata] = []
                 for metadata in metadataSourceForAllSections {
-                    if metadata.isImage || metadata.isMovie {
+                    if metadata.isImage || metadata.isAudioOrVideo {
                         metadatas.append(metadata)
                     }
                 }

--- a/iOSClient/Main/NCActionCenter.swift
+++ b/iOSClient/Main/NCActionCenter.swift
@@ -217,7 +217,7 @@ class NCActionCenter: NSObject, UIDocumentInteractionControllerDelegate, NCSelec
                 let serverUrlFileName = metadata.serverUrl + "/" + metadata.fileName
                 let fileNameLocalPath = CCUtility.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView)!
 
-                if metadata.isMovie {
+                if metadata.isAudioOrVideo {
                     NCViewer.shared.view(viewController: viewController, metadata: metadata, metadatas: [metadata], imageIcon: nil)
                 } else {
                     hud.show(in: hudView)

--- a/iOSClient/Media/NCMedia.swift
+++ b/iOSClient/Media/NCMedia.swift
@@ -402,7 +402,7 @@ extension NCMedia: UICollectionViewDataSource {
             cell.fileObjectId = metadata.ocId
             cell.fileUser = metadata.ownerId
 
-            if metadata.isMovie {
+            if metadata.isAudioOrVideo {
                 cell.imageStatus.image = cacheImages.cellPlayImage
             } else if metadata.livePhoto && livePhoto {
                 cell.imageStatus.image = cacheImages.cellLivePhotoImage

--- a/iOSClient/Viewer/NCViewer.swift
+++ b/iOSClient/Viewer/NCViewer.swift
@@ -69,7 +69,7 @@ class NCViewer: NSObject {
         }
 
         // IMAGE AUDIO VIDEO
-        if metadata.isImage || metadata.isMovie {
+        if metadata.isImage || metadata.isAudioOrVideo {
 
             if let navigationController = viewController.navigationController {
 

--- a/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayer.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayer.swift
@@ -242,6 +242,7 @@ extension NCPlayer: VLCMediaPlayerDelegate {
             activityIndicator.stopAnimating()
         }
 
+        print (aNotification)
         switch player.state {
         case .stopped:
             playerToolBar?.playButtonPlay()
@@ -306,32 +307,9 @@ extension NCPlayer: VLCMediaPlayerDelegate {
     }
 
     func mediaPlayerTimeChanged(_ aNotification: Notification) {
+        print(player.position)
         activityIndicator.stopAnimating()
         playerToolBar?.update()
-    }
-
-    func mediaPlayerTitleChanged(_ aNotification: Notification) {
-        // Handle other states...
-    }
-
-    func mediaPlayerChapterChanged(_ aNotification: Notification) {
-        // Handle other states...
-    }
-
-    func mediaPlayerLoudnessChanged(_ aNotification: Notification) {
-        // Handle other states...
-    }
-
-    func mediaPlayerSnapshot(_ aNotification: Notification) {
-        // Handle other states...
-    }
-
-    func mediaPlayerStartedRecording(_ player: VLCMediaPlayer) {
-        // Handle other states...
-    }
-
-    func mediaPlayer(_ player: VLCMediaPlayer, recordingStoppedAtPath path: String) {
-        // Handle other states...
     }
 }
 

--- a/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayer.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayer.swift
@@ -242,7 +242,6 @@ extension NCPlayer: VLCMediaPlayerDelegate {
             activityIndicator.stopAnimating()
         }
 
-        print (aNotification)
         switch player.state {
         case .stopped:
             playerToolBar?.playButtonPlay()
@@ -307,7 +306,6 @@ extension NCPlayer: VLCMediaPlayerDelegate {
     }
 
     func mediaPlayerTimeChanged(_ aNotification: Notification) {
-        print(player.position)
         activityIndicator.stopAnimating()
         playerToolBar?.update()
     }

--- a/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.swift
@@ -161,8 +161,6 @@ class NCPlayerToolBar: UIView {
         let position = ncplayer.player.position
         let positionInSecond = position * Float(length / 1000)
 
-        print(position)
-
         // SLIDER & TIME
         if playbackSliderEvent == .ended {
             playbackSlider.value = position

--- a/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.swift
@@ -156,12 +156,12 @@ class NCPlayerToolBar: UIView {
 
     public func update() {
 
-        guard let ncplayer = self.ncplayer,
-              let length = ncplayer.player.media?.length.intValue
-        else { return }
+        guard let ncplayer = self.ncplayer, let length = ncplayer.player.media?.length.intValue else { return }
 
         let position = ncplayer.player.position
         let positionInSecond = position * Float(length / 1000)
+
+        print(position)
 
         // SLIDER & TIME
         if playbackSliderEvent == .ended {

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
@@ -87,7 +87,7 @@ class NCViewerMedia: UIViewController {
             statusLabel.text = ""
         }
         
-        if metadata.isMovie {
+        if metadata.isAudioOrVideo {
 
             playerToolBar = Bundle.main.loadNibNamed("NCPlayerToolBar", owner: self, options: nil)?.first as? NCPlayerToolBar
             if let playerToolBar = playerToolBar {
@@ -146,7 +146,7 @@ class NCViewerMedia: UIViewController {
 
         viewerMediaPage?.clearCommandCenter()
         
-        if metadata.isMovie {
+        if metadata.isAudioOrVideo {
             if let ncplayer = self.ncplayer {
                 if ncplayer.url == nil {
                     NCActivityIndicator.shared.startActivity(backgroundView: self.view, style: .medium)

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.swift
@@ -233,7 +233,7 @@ class NCViewerMediaPage: UIViewController {
                 progressView.isHidden = false
             }
 
-            if metadata.isMovie {
+            if metadata.isAudioOrVideo {
                 NCUtility.shared.colorNavigationController(navigationController, backgroundColor: .black, titleColor: .label, tintColor: nil, withoutShadow: false)
                 currentViewController.playerToolBar?.show()
                 view.backgroundColor = .black
@@ -250,7 +250,7 @@ class NCViewerMediaPage: UIViewController {
             hideStatusBar = true
             progressView.isHidden = true
 
-            if metadata.isMovie {
+            if metadata.isVideo {
                 currentViewController.playerToolBar?.hide()
             }
 
@@ -282,7 +282,7 @@ class NCViewerMediaPage: UIViewController {
     @objc func autoHide() {
 
         let metadata = currentViewController.metadata
-        if metadata.isMovie, viewerMediaScreenMode == .normal {
+        if metadata.isVideo, viewerMediaScreenMode == .normal {
             changeScreenMode(mode: .full)
         }
     }
@@ -301,7 +301,7 @@ class NCViewerMediaPage: UIViewController {
         let metadata = currentViewController.metadata
 
         if metadata.ocId == ocId,
-           metadata.isMovie,
+           metadata.isAudioOrVideo,
            CCUtility.fileProviderStorageExists(metadata),
            let ncplayer = currentViewController.ncplayer {
             let url = URL(fileURLWithPath: CCUtility.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView)!)


### PR DESCRIPTION
- Updates VLCKit to latest version
- Now, NCViewerMedia does not become fullscreen if the media is an audio file. There is no reason for it to go fullscreen, and in IMO it's annoying when it does that every 4 seconds.

<img width="300" alt="image" src="https://github.com/nextcloud/ios/assets/6960329/389063bc-1734-4b64-9e4f-b51248f2fc9f">

- Finally, some refactoring where it makes sense.