### PR TITLE
Fix external share with email 2 mails sent instead of 1 (Create share directly with note)

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		F343A4BF2A1E734600DDA874 /* Optional+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F343A4BA2A1E734600DDA874 /* Optional+Extension.swift */; };
 		F343A4C02A1E734600DDA874 /* Optional+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F343A4BA2A1E734600DDA874 /* Optional+Extension.swift */; };
 		F343A4C12A1E734600DDA874 /* Optional+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F343A4BA2A1E734600DDA874 /* Optional+Extension.swift */; };
+		F3953BD72A6E87E000EE03F9 /* BaseIntegrationXCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3953BD62A6E87E000EE03F9 /* BaseIntegrationXCTestCase.swift */; };
 		F3A7AFC62A41AA82001FC89C /* BaseUIXCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A7AFC52A41AA82001FC89C /* BaseUIXCTestCase.swift */; };
 		F700222C1EC479840080073F /* Custom.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F700222B1EC479840080073F /* Custom.xcassets */; };
 		F700222D1EC479840080073F /* Custom.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F700222B1EC479840080073F /* Custom.xcassets */; };
@@ -811,6 +812,7 @@
 		F31F69602A2F907800162F76 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		F343A4B22A1E01FF00DDA874 /* PHAsset+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PHAsset+Extension.swift"; sourceTree = "<group>"; };
 		F343A4BA2A1E734600DDA874 /* Optional+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extension.swift"; sourceTree = "<group>"; };
+		F3953BD62A6E87E000EE03F9 /* BaseIntegrationXCTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseIntegrationXCTestCase.swift; sourceTree = "<group>"; };
 		F3A7AFC52A41AA82001FC89C /* BaseUIXCTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUIXCTestCase.swift; sourceTree = "<group>"; };
 		F700222B1EC479840080073F /* Custom.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Custom.xcassets; sourceTree = "<group>"; };
 		F700510022DF63AC003A3356 /* NCShare.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = NCShare.storyboard; sourceTree = "<group>"; };
@@ -1541,6 +1543,7 @@
 		C04E2F212A17BB4D001BAD85 /* NextcloudIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				F3953BD62A6E87E000EE03F9 /* BaseIntegrationXCTestCase.swift */,
 				C04E2F222A17BB4D001BAD85 /* FilesIntegrationTests.swift */,
 			);
 			path = NextcloudIntegrationTests;
@@ -3301,6 +3304,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F3953BD72A6E87E000EE03F9 /* BaseIntegrationXCTestCase.swift in Sources */,
 				F30A96322A27AEDD00D7BCFE /* EnvVars.generated.swift in Sources */,
 				C04E2F232A17BB4D001BAD85 /* FilesIntegrationTests.swift in Sources */,
 			);

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -4937,8 +4937,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nextcloud/NextcloudKit";
 			requirement = {
-				kind = exactVersion;
-				version = 2.7.0;
+				branch = "2521-external-share-with-email-2-mails-sent-instead-of-1";
+				kind = branch;
 			};
 		};
 		F788ECC5263AAAF900ADC67F /* XCRemoteSwiftPackageReference "MarkdownKit" */ = {

--- a/Tests/NextcloudIntegrationTests/BaseIntegrationXCTestCase.swift
+++ b/Tests/NextcloudIntegrationTests/BaseIntegrationXCTestCase.swift
@@ -1,0 +1,38 @@
+//
+//  BaseIntegrationXCTestCase.swift
+//  
+// 
+//  Created by Milen Pivchev on 20.06.23.
+//  Copyright © 2023 Milen Pivchev. All rights reserved.
+//
+//  Author: Milen Pivchev <milen.pivchev@nextcloud.com>
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import NextcloudKit
+
+class BaseIntegrationXCTestCase: XCTestCase {
+    internal let baseUrl = EnvVars.testServerUrl
+    internal let user = EnvVars.testUser
+    internal let userId = EnvVars.testUser
+    internal let password = EnvVars.testAppPassword
+    internal lazy var account = "\(userId) \(baseUrl)"
+
+    internal var randomInt: Int {
+        get {
+            return Int.random(in: 1000...Int.max)
+        }
+    }
+}

--- a/Tests/NextcloudIntegrationTests/FilesIntegrationTests.swift
+++ b/Tests/NextcloudIntegrationTests/FilesIntegrationTests.swift
@@ -10,13 +10,7 @@ import XCTest
 import NextcloudKit
 @testable import Nextcloud
 
-final class FilesIntegrationTests: XCTestCase {
-    private let baseUrl = EnvVars.testServerUrl
-    private let user = EnvVars.testUser
-    private let userId = EnvVars.testUser
-    private let password = EnvVars.testAppPassword
-    private lazy var account = "\(userId) \(baseUrl)"
-
+final class FilesIntegrationTests: BaseIntegrationXCTestCase {
     private let appDelegate = (UIApplication.shared.delegate as? AppDelegate)!
 
     override func setUp() {
@@ -26,7 +20,7 @@ final class FilesIntegrationTests: XCTestCase {
     func test_createReadDeleteFolder_withProperParams_shouldCreateReadDeleteFolder() throws {
         let expectation = expectation(description: "Should finish last callback")
 
-        let folderName = "TestFolder10"
+        let folderName = "TestFolder\(randomInt)"
         let serverUrl = "\(baseUrl)/remote.php/dav/files/\(userId)"
         let serverUrlFileName = "\(serverUrl)/\(folderName)"
 

--- a/iOSClient/Extensions/UIToolbar+Extension.swift
+++ b/iOSClient/Extensions/UIToolbar+Extension.swift
@@ -24,7 +24,7 @@
 import UIKit
 
 extension UIToolbar {
-    static func toolbar(onClear: (() -> Void)?, completion: @escaping () -> Void) -> UIToolbar {
+    static func toolbar(onClear: (() -> Void)?, onDone: @escaping () -> Void) -> UIToolbar {
         let toolbar = UIToolbar()
         toolbar.sizeToFit()
         var buttons: [UIBarButtonItem] = []
@@ -37,7 +37,7 @@ extension UIToolbar {
         }
         buttons.append(UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: nil, action: nil))
         let doneButton = UIBarButtonItem(title: NSLocalizedString("_done_", comment: ""), style: .done) {
-            completion()
+            onDone()
         }
         buttons.append(doneButton)
         toolbar.setItems(buttons, animated: false)

--- a/iOSClient/Share/Advanced/NCShareCells.swift
+++ b/iOSClient/Share/Advanced/NCShareCells.swift
@@ -310,7 +310,7 @@ class NCShareDateCell: UITableViewCell {
             self.resignFirstResponder()
             share.expirationDate = nil
             self.onReload?()
-        } completion: {
+        } onDone: {
             self.resignFirstResponder()
             share.expirationDate = self.picker.date as NSDate
             self.onReload?()

--- a/iOSClient/Share/Advanced/NCShareNewUserAddComment.swift
+++ b/iOSClient/Share/Advanced/NCShareNewUserAddComment.swift
@@ -52,9 +52,10 @@ class NCShareNewUserAddComment: UIViewController, NCShareDetail {
             self.noteTextField.resignFirstResponder()
             self.noteTextField.text = ""
             self.share.note = ""
-        } completion: {
+        } onDone: {
             self.noteTextField.resignFirstResponder()
             self.share.note = self.noteTextField.text
+            self.navigationController?.popViewController(animated: true)
         }
 
         noteTextField.inputAccessoryView = toolbar.wrappedSafeAreaContainer

--- a/iOSClient/Share/NCShare.swift
+++ b/iOSClient/Share/NCShare.swift
@@ -70,6 +70,7 @@ class NCShare: UIViewController, NCShareNetworkingDelegate, NCSharePagingContent
         searchFieldTopConstraint.constant = 10
 
         searchField.placeholder = NSLocalizedString("_shareLinksearch_placeholder_", comment: "")
+        searchField.autocorrectionType = .no
 
         tableView.dataSource = self
         tableView.delegate = self

--- a/iOSClient/Share/NCShareNetworking.swift
+++ b/iOSClient/Share/NCShareNetworking.swift
@@ -75,14 +75,14 @@ class NCShareNetworking: NSObject {
         // NOTE: Permissions don't work for creating with file drop!
         // https://github.com/nextcloud/server/issues/17504
 
-        // NOTE: Can't save label, expirationDate, and note in same request.
+        // NOTE: Can't save label and expirationDate in the same request.
         // Library update needed:
         // https://github.com/nextcloud/ios-communication-library/pull/104
 
         NCActivityIndicator.shared.start(backgroundView: view)
         let filenamePath = CCUtility.returnFileNamePath(fromFileName: metadata.fileName, serverUrl: metadata.serverUrl, urlBase: metadata.urlBase, userId: metadata.userId, account: metadata.account)!
 
-        NextcloudKit.shared.createShare(path: filenamePath, shareType: option.shareType, shareWith: option.shareWith, password: option.password, permissions: option.permissions, attributes: option.attributes) { (account, share, data, error) in
+        NextcloudKit.shared.createShare(path: filenamePath, shareType: option.shareType, shareWith: option.shareWith, password: option.password, note: option.note, permissions: option.permissions, attributes: option.attributes) { (account, share, data, error) in
             NCActivityIndicator.shared.stop()
             if error == .success, let share = share {
                 option.idShare = share.idShare


### PR DESCRIPTION
Dependency: https://github.com/nextcloud/NextcloudKit/pull/39

Before, we would send an email that the share was created and a second email with the note. Now, only one email is sent with the note already included:

<img width="690" alt="image" src="https://github.com/nextcloud/ios/assets/6960329/cdfc4c99-7f73-4dd1-b6f5-f6b440fe8b60">

Also fixed:

- The search field had autocorrect enabled. Since we write usernames and emails in that field, it's probably good to have it disabled, since it always corrects to the wrong thing. This is fixed now:

<img width="320" alt="image" src="https://github.com/nextcloud/ios/assets/6960329/f5dff3e2-0b79-442f-9608-7fcd546e0e33">

- Pressing Done after writing a note did not bring you back to the previous screen, this is now fixed:

https://github.com/nextcloud/ios/assets/6960329/446ab5a3-50ab-4ed0-b468-f1a2b0d2099a


