### PR TITLE
Share add/update

### DIFF
--- a/iOSClient/Data/NCManageDatabase+Share.swift
+++ b/iOSClient/Data/NCManageDatabase+Share.swift
@@ -81,8 +81,6 @@ extension NCManageDatabase {
         do {
             let realm = try Realm()
             try realm.write {
-                let result = realm.objects(tableShare.self).filter("account == %@", account)
-                realm.delete(result)
                 for share in shares {
                     let serverUrlPath = home + share.path
                     guard let serverUrl = NCUtilityFileSystem.shared.deleteLastPath(serverUrlPath: serverUrlPath, home: home) else { continue }

--- a/iOSClient/Share/NCShareNetworking.swift
+++ b/iOSClient/Share/NCShareNetworking.swift
@@ -50,6 +50,7 @@ class NCShareNetworking: NSObject {
 
         NextcloudKit.shared.readShares(parameters: parameter) { account, shares, data, error in
             if error == .success, let shares = shares {
+                NCManageDatabase.shared.deleteTableShare(account: account)
                 let home = NCUtilityFileSystem.shared.getHomeServer(urlBase: self.metadata.urlBase, userId: self.metadata.userId)
                 NCManageDatabase.shared.addShare(account: self.metadata.account, home:home, shares: shares)
                 NextcloudKit.shared.getGroupfolders() { account, results, data, error in

--- a/iOSClient/Shares/NCShares.swift
+++ b/iOSClient/Shares/NCShares.swift
@@ -89,11 +89,10 @@ class NCShares: NCCollectionViewCommon {
             self.isReloadDataSourceNetworkInProgress = false
 
             if error == .success {
+                NCManageDatabase.shared.deleteTableShare(account: account)
                 if let shares = shares, !shares.isEmpty {
                     let home = NCUtilityFileSystem.shared.getHomeServer(urlBase: self.appDelegate.urlBase, userId: self.appDelegate.userId)
                     NCManageDatabase.shared.addShare(account: self.appDelegate.account, home: home, shares: shares)
-                } else {
-                    NCManageDatabase.shared.deleteTableShare(account: account)
                 }
                 self.reloadDataSource()
 


### PR DESCRIPTION
This PR Contains fix related to share update.

Expected behaviour
New share get update and existing also keep in list
Actual behaviour
Existing shares get removed and only new share visible 
Steps to reproduce
create new 2 or more share 
App version
4.8.6

Current behaviour 
https://github.com/nextcloud/ios/assets/96108296/8b95ada3-0af6-4378-8936-41ea18032648

After Fix

https://github.com/nextcloud/ios/assets/96108296/8f8f0942-338e-42d6-8317-90a30ab97ce6


