### PR TITLE
Transition bug fix

### DIFF
--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
@@ -66,7 +66,7 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
     private var pushed: Bool = false
 
     private var tipView: EasyTipView?
-
+    private var isTransitioning: Bool = false
     // DECLARE
     internal var layoutKey = ""
     internal var titleCurrentFolder = ""
@@ -733,9 +733,12 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
     func accountRequestAddAccount() {
         appDelegate.openLogin(viewController: self, selector: NCGlobal.shared.introLogin, openLoginWeb: false)
     }
-
+    
     func tapButtonSwitch(_ sender: Any) {
-
+        
+        guard isTransitioning == false else { return }
+        isTransitioning = true
+        
         if layoutForView?.layout == NCGlobal.shared.layoutGrid {
 
             // list layout
@@ -749,8 +752,7 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
 
             self.collectionView.reloadData()
             self.collectionView.collectionViewLayout.invalidateLayout()
-            self.collectionView.setCollectionViewLayout(self.listLayout, animated: true)
-
+            self.collectionView.setCollectionViewLayout(self.listLayout, animated: true) {_ in self.isTransitioning = false }
         } else {
 
             // grid layout
@@ -768,7 +770,7 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
 
             self.collectionView.reloadData()
             self.collectionView.collectionViewLayout.invalidateLayout()
-            self.collectionView.setCollectionViewLayout(self.gridLayout, animated: true)
+            self.collectionView.setCollectionViewLayout(self.gridLayout, animated: true) {_ in self.isTransitioning = false }
         }
     }
 


### PR DESCRIPTION
Issue: When we double-tap on the layout switch button, the UI breaks
Reason: When a transition is ongoing, and we trigger a new transition request due to race conditions, UI breaks
Solution: Execute only one transition request at a time. When a transition is going on, block other requests.

ISSUE:

https://github.com/nextcloud/ios/assets/32197474/b7ad53ba-4be8-4a29-adf5-5678e63963c3



FIXED:


https://github.com/nextcloud/ios/assets/32197474/e25e7474-7484-4044-abbf-2dd963dfde20


Signed-off-by: Abhishek Dogra 