### PR TITLE
Fix #2577 : Added one second before `tipView` func call.

### DIFF
--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
@@ -223,8 +223,10 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        showTip()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.showTip()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
As stated in #2577, it fixes the tipView as it should be at the centre of the user icon/email.

I've just added 1 second before `tipView` func call, so that after data is fetched which obviously takes less time than 1 second(mostly), will show the tip at exact location. 

https://github.com/nextcloud/ios/assets/77538183/2c5658c6-41cd-4b7f-a989-4f42e734523f


**I'm just a beginner, so please any suggestions will be helpful.**