### PR TITLE
Adjusted imageView Constraints for proper display of small images

### DIFF
--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
@@ -486,7 +486,7 @@ extension NCViewerMedia {
         statusLabel.isHidden = true
         statusViewImage.isHidden = true
 
-        NCUtility.shared.getExif(metadata: metadata) { exif in
+        NCUtility.shared.getExif(metadata: metadata) { [self] exif in
             self.view.layoutIfNeeded()
             self.showDetailView(exif: exif)
 
@@ -495,10 +495,17 @@ extension NCViewerMedia {
                 let ratioH = self.imageVideoContainer.frame.height / image.size.height
                 let ratio = min(ratioW, ratioH)
                 let imageHeight = image.size.height * ratio
-                let imageContainerHeight = self.imageVideoContainer.frame.height * ratio
+                print("detailView.frame.height : \(self.detailView.frame.height)")
+                var imageContainerHeight = self.imageVideoContainer.frame.height * ratio
+                print("imageContainerHeight : \(imageContainerHeight)")
                 let height = max(imageHeight, imageContainerHeight)
                 self.imageViewConstraint = self.detailView.frame.height - ((self.view.frame.height - height) / 2) + self.view.safeAreaInsets.bottom
                 if self.imageViewConstraint < 0 { self.imageViewConstraint = 0 }
+                print("imageViewConstraints : \(self.imageViewConstraint)")
+                self.imageViewConstraint = min(self.imageViewConstraint, self.detailView.frame.height+30)
+                imageContainerHeight = self.imageViewConstraint.truncatingRemainder(dividingBy: 1000)
+                print("imageContainerHeight : \(imageContainerHeight)")
+                print("imageViewConstraints : \(self.imageViewConstraint)")
             }
 
             UIView.animate(withDuration: animate ? 0.3 : 0) {

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
@@ -493,19 +493,22 @@ extension NCViewerMedia {
             if let image = self.imageVideoContainer.image {
                 let ratioW = self.imageVideoContainer.frame.width / image.size.width
                 let ratioH = self.imageVideoContainer.frame.height / image.size.height
+                
                 let ratio = min(ratioW, ratioH)
+                
                 let imageHeight = image.size.height * ratio
-                print("detailView.frame.height : \(self.detailView.frame.height)")
                 var imageContainerHeight = self.imageVideoContainer.frame.height * ratio
-                print("imageContainerHeight : \(imageContainerHeight)")
+                
                 let height = max(imageHeight, imageContainerHeight)
                 self.imageViewConstraint = self.detailView.frame.height - ((self.view.frame.height - height) / 2) + self.view.safeAreaInsets.bottom
-                if self.imageViewConstraint < 0 { self.imageViewConstraint = 0 }
-                print("imageViewConstraints : \(self.imageViewConstraint)")
-                self.imageViewConstraint = min(self.imageViewConstraint, self.detailView.frame.height+30)
+                
+                if self.imageViewConstraint < 0 {
+                    self.imageViewConstraint = 0
+                }
+                
+                self.imageViewConstraint = min(self.imageViewConstraint, self.detailView.frame.height + 30)
                 imageContainerHeight = self.imageViewConstraint.truncatingRemainder(dividingBy: 1000)
-                print("imageContainerHeight : \(imageContainerHeight)")
-                print("imageViewConstraints : \(self.imageViewConstraint)")
+                
             }
 
             UIView.animate(withDuration: animate ? 0.3 : 0) {


### PR DESCRIPTION
I checked the image preview in media for smaller files of 8x8, 16x16,... upto 180x180 (including location also), the `imageContainerHeight` turns out to be very high, thus increasing `imageViewConstraint` to a very large number and making the imageView going out of view. Photos app works fine for such scenarios.

Here are the image test files :
<img width="4" alt="Screenshot 2023-09-09 at 6 19 47 PM" src="https://github.com/nextcloud/ios/assets/77538183/1f99049f-b8b0-4ffc-8f72-cc97b4372da1">
<img width="8" alt="Screenshot 2023-09-11 at 2 02 58 PM" src="https://github.com/nextcloud/ios/assets/77538183/57abed6b-95bc-47f6-aa11-9c80e5798ed7">
<img width="14" alt="Screenshot 2023-09-11 at 11 04 11 AM" src="https://github.com/nextcloud/ios/assets/77538183/8765d331-b8f2-42bc-9eef-696a60b2fec3">
<img width="30" alt="Screenshot 2023-09-11 at 11 06 18 AM" src="https://github.com/nextcloud/ios/assets/77538183/5b994ec1-600c-4376-9c4a-94107caf2294">
<img width="90" alt="Screenshot 2023-09-11 at 11 09 33 AM" src="https://github.com/nextcloud/ios/assets/77538183/f35cfc23-b362-4a23-85d4-21c537ef0650">

Before:

https://github.com/nextcloud/ios/assets/77538183/ba492ecf-5f6a-4a17-8837-ca185eb4d700

After:

https://github.com/nextcloud/ios/assets/77538183/65d82688-7a6f-47fe-a8b6-8a722acacdd3

✅Tested for both iPad & iPhone.