### PR TITLE
- File specific shares delete when we update shares on share screen

### DIFF
--- a/iOSClient/Data/NCManageDatabase+Share.swift
+++ b/iOSClient/Data/NCManageDatabase+Share.swift
@@ -239,6 +239,24 @@ extension NCManageDatabase {
         }
     }
 
+    /// Delete shares of specific file
+    /// - Parameters:
+    ///   - account: account url for specific user
+    ///   - filePath: file path of media which shares need to delete
+    func deleteTableShare(account: String, filePath: String) {
+
+        do {
+            let realm = try Realm()
+
+            try realm.write {
+                let result = realm.objects(tableShare.self).filter("account == %@ AND path == %@", account, "/"+filePath)
+                realm.delete(result)
+            }
+        } catch let error as NSError {
+            NextcloudKit.shared.nkCommonInstance.writeLog("Could not write to database: \(error)")
+        }
+    }
+    
     // There is currently only one share attribute “download” from the scope “permissions”. This attribute is only valid for user and group shares, not for public link shares.
     func setAttibuteDownload(state: Bool) -> String? {
         if state {

--- a/iOSClient/Data/NCManageDatabase+Share.swift
+++ b/iOSClient/Data/NCManageDatabase+Share.swift
@@ -81,8 +81,6 @@ extension NCManageDatabase {
         do {
             let realm = try Realm()
             try realm.write {
-                let result = realm.objects(tableShare.self).filter("account == %@", account)
-                realm.delete(result)
                 for share in shares {
                     let serverUrlPath = home + share.path
                     guard let serverUrl = NCUtilityFileSystem.shared.deleteLastPath(serverUrlPath: serverUrlPath, home: home) else { continue }

--- a/iOSClient/Share/NCShareNetworking.swift
+++ b/iOSClient/Share/NCShareNetworking.swift
@@ -50,6 +50,7 @@ class NCShareNetworking: NSObject {
 
         NextcloudKit.shared.readShares(parameters: parameter) { account, shares, data, error in
             if error == .success, let shares = shares {
+                NCManageDatabase.shared.deleteTableShare(account: account, filePath: filenamePath)
                 let home = NCUtilityFileSystem.shared.getHomeServer(urlBase: self.metadata.urlBase, userId: self.metadata.userId)
                 NCManageDatabase.shared.addShare(account: self.metadata.account, home:home, shares: shares)
                 NextcloudKit.shared.getGroupfolders() { account, results, data, error in

--- a/iOSClient/Shares/NCShares.swift
+++ b/iOSClient/Shares/NCShares.swift
@@ -89,12 +89,11 @@ class NCShares: NCCollectionViewCommon {
             self.isReloadDataSourceNetworkInProgress = false
 
             if error == .success {
+                NCManageDatabase.shared.deleteTableShare(account: account)
                 if let shares = shares, !shares.isEmpty {
                     let home = NCUtilityFileSystem.shared.getHomeServer(urlBase: self.appDelegate.urlBase, userId: self.appDelegate.userId)
                     NCManageDatabase.shared.addShare(account: self.appDelegate.account, home: home, shares: shares)
-                } else {
-                    NCManageDatabase.shared.deleteTableShare(account: account)
-                }
+                } 
                 self.reloadDataSource()
 
             } else {


### PR DESCRIPTION
This PR Contains fix related to share update.

Expected behaviour
After unshare shares will not get removed and shows all share
Actual behaviour
after unshare all shares get removed

Steps to reproduce
- Launch the MagentaCLOUD app and login
- Do link or personal email share to some file/folder
- Tap on "More" tab and navigate to shares
- Click on person icon's of any file or folder
- Click on Unshare from its 3-dot menu option
- Now click on Cancel button from top left
- Check the Shares page

App version
4.8.6
Test flight version
4.9.0

Current Behaviour 

https://github.com/nextcloud/ios/assets/96108296/4cd15112-9301-41d8-9f67-9f517def865a

After Fix

https://github.com/nextcloud/ios/assets/96108296/d71e0b88-903f-4910-b378-8fc671b04672




