### PR TITLE
New media view - loading indicators

### DIFF
--- a/iOSClient/AppDelegate.swift
+++ b/iOSClient/AppDelegate.swift
@@ -56,6 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private var privacyProtectionWindow: UIWindow?
 
     let downloadQueue = Queuer(name: "downloadQueue", maxConcurrentOperationCount: NCGlobal.shared.maxConcurrentOperationCountDownload, qualityOfService: .default)
+    //TODO: Remove this
     let downloadThumbnailQueue = Queuer(name: "downloadThumbnailQueue", maxConcurrentOperationCount: 10, qualityOfService: .default)
     let downloadThumbnailActivityQueue = Queuer(name: "downloadThumbnailActivityQueue", maxConcurrentOperationCount: 10, qualityOfService: .default)
     let downloadAvatarQueue = Queuer(name: "downloadAvatarQueue", maxConcurrentOperationCount: 10, qualityOfService: .default)

--- a/iOSClient/Media/NCMediaNew.swift
+++ b/iOSClient/Media/NCMediaNew.swift
@@ -13,36 +13,8 @@ import Combine
 @_spi(Advanced) import SwiftUIIntrospect
 import Queuer
 
-//struct Test: View {
-//    var metadatas: [[tableMetadata]]
-//    @EnvironmentObject var vm: NCMediaViewModel
-//    @EnvironmentObject var parent: NCMediaUIKitWrapper
-//    @State var isInSelectMode = true
-//    @Binding var columnCountStages: [Int]
-//    @Binding var columnCountStagesIndex: Int
-//    @State var title: String = ""
-//    internal let cache = UIImageLRUCache(countLimit: 1000)
-//
-//    var body: some View {
-//        let _ = Self._printChanges()
-//
-//        ScrollView {
-//            LazyVStack(alignment: .leading, spacing: 2) {
-//                ForEach(metadatas, id: \.self) { rowMetadatas in
-//                    Color.random.frame(width: 100, height: 100)
-//                }
-//                .background(GeometryReader { geometry in
-//                    Color.clear
-//                        .preference(key: ScrollOffsetPreferenceKey.self, value: geometry.frame(in: .named("scroll")).origin)
-//                })
-//            }
-//        }
-//        .coordinateSpace(name: "scroll")
-//    }
-//}
-
 struct NCMediaNew: View {
-    let imageQueuer = Queuer(name: "downloadThumbnailQueue", maxConcurrentOperationCount: 10, qualityOfService: .default)
+    let downloadThumbnailQueue = Queuer(name: "downloadThumbnailQueue", maxConcurrentOperationCount: 10, qualityOfService: .background)
 
     @StateObject private var vm = NCMediaViewModel()
     @EnvironmentObject private var parent: NCMediaUIKitWrapper
@@ -67,10 +39,8 @@ struct NCMediaNew: View {
     @State private var isInSelectMode = false
 
     var body: some View {
-        let _ = Self._printChanges()
-
         ZStack(alignment: .top) {
-            NCMediaScrollView(metadatas: $vm.metadatas, isInSelectMode: $isInSelectMode, selectedMetadatas: $selectedMetadatas, columnCountStages: $columnCountStages, columnCountStagesIndex: $columnCountStagesIndex, title: $title, queuer: imageQueuer) { tappedThumbnail, isSelected in
+            NCMediaScrollView(metadatas: $vm.metadatas, isInSelectMode: $isInSelectMode, selectedMetadatas: $selectedMetadatas, columnCountStages: $columnCountStages, columnCountStagesIndex: $columnCountStagesIndex, title: $title, queuer: downloadThumbnailQueue) { tappedThumbnail, isSelected in
                 if isInSelectMode, isSelected {
                     selectedMetadatas.append(tappedThumbnail.metadata)
                 } else {

--- a/iOSClient/Media/NCMediaRowViewModel.swift
+++ b/iOSClient/Media/NCMediaRowViewModel.swift
@@ -30,17 +30,8 @@ struct ScaledThumbnail: Hashable {
     @Published private(set) var rowData = RowData()
 
     private var metadatas: [tableMetadata] = []
-
     private let cache = NCImageCache.shared
-
-//    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
-    //    private let queuer = (UIApplication.shared.delegate as? AppDelegate)?.downloadThumbnailQueue
     private var queuer: Queuer?
-
-    //    internal lazy var cache = manager.cache
-    //    internal lazy var thumbnailsQueue = manager.queuer
-
-    var operations: [ConcurrentOperation] = []
 
     func configure(metadatas: [tableMetadata], queuer: Queuer) {
         self.metadatas = metadatas
@@ -71,7 +62,6 @@ struct ScaledThumbnail: Hashable {
                 if let image = UIImage(contentsOfFile: thumbnailPath) {
                     let thumbnail = ScaledThumbnail(image: image, metadata: metadata)
                     cache.setMediaImage(ocId: metadata.ocId, image: .actual(image))
-                    //                    cache.setValue(thumbnail, forKey: metadata.ocId)
 
                     DispatchQueue.main.async {
                         thumbnails.append(thumbnail)
@@ -83,46 +73,7 @@ struct ScaledThumbnail: Hashable {
                 let fileNamePreviewLocalPath = NCUtilityFileSystem().getDirectoryProviderStoragePreviewOcId(metadata.ocId, etag: metadata.etag)
                 let fileNameIconLocalPath = NCUtilityFileSystem().getDirectoryProviderStorageIconOcId(metadata.ocId, etag: metadata.etag)
 
-                var etagResource: String?
-                if FileManager.default.fileExists(atPath: fileNameIconLocalPath) && FileManager.default.fileExists(atPath: fileNamePreviewLocalPath) {
-                    etagResource = metadata.etagResource
-                }
                 let options = NKRequestOptions(queue: NextcloudKit.shared.nkCommonInstance.backgroundQueue)
-
-                //                let concurrentOperation = ConcurrentOperation { operation in
-                //                    operation.execute()
-                //
-                //                    NextcloudKit.shared.downloadPreview(
-                //                        fileNamePathOrFileId: fileNamePath,
-                //                        fileNamePreviewLocalPath: fileNamePreviewLocalPath,
-                //                        widthPreview: Int(UIScreen.main.bounds.width) / 2,
-                //                        heightPreview: Int(UIScreen.main.bounds.height) / 2,
-                //                        fileNameIconLocalPath: fileNameIconLocalPath,
-                //                        sizeIcon: NCGlobal.shared.sizeIcon,
-                //                        etag: etagResource,
-                //                        options: options) { _, _, imageIcon, _, etag, error in
-                //                            NCManageDatabase.shared.setMetadataEtagResource(ocId: metadata.ocId, etagResource: etag)
-                //
-                //                            let thumbnail: ScaledThumbnail
-                //
-                //                            if error == .success, let image = imageIcon {
-                //                                thumbnail = ScaledThumbnail(image: image, metadata: metadata)
-                //                                self.cache.setMediaImage(ocId: metadata.ocId, image: image)
-                //                            } else {
-                //                                thumbnail = ScaledThumbnail(image: UIImage(systemName: metadata.isVideo ? "video.fill" : "photo.fill")!.withRenderingMode(.alwaysTemplate), isPlaceholderImage: true, metadata: metadata)
-                //                            }
-                //
-                ////                            self.cache.setValue(thumbnail, forKey: metadata.ocId)
-                //
-                //                            operation.finish()
-                //
-                //                            DispatchQueue.main.async {
-                //                                thumbnails.append(thumbnail)
-                //                                self.calculateShrinkRatio(thumbnails: &thumbnails, rowWidth: rowWidth, spacing: spacing)
-                //                            }
-                //
-                //                        }
-                //                }
 
                 if let queuer, queuer.operations.filter({ ($0 as? NCMediaDownloadThumbnaill)?.metadata.ocId == metadata.ocId }).isEmpty {
                     let concurrentOperation = NCMediaDownloadThumbnaill(metadata: metadata, cache: cache, rowWidth: rowWidth, spacing: spacing, maxWidth: UIScreen.main.bounds.width, maxHeight: UIScreen.main.bounds.height) { thumbnail in
@@ -132,18 +83,9 @@ struct ScaledThumbnail: Hashable {
                         }
                     }
 
-                    operations.append(concurrentOperation)
                     queuer.addOperation(concurrentOperation)
                     print(queuer.operationCount)
                 }
-
-                //                let concurrentOperation = NCMediaDownloadThumbnaill(metadata: metadata, cache: cache, thumbnails: &thumbnails, rowWidth: rowWidth, spacing: spacing, maxWidth: UIScreen.main.bounds.width, maxHeight: UIScreen.main.bounds.height)
-
-                //                operations.append(concurrentOperation)
-                //                appDelegate?.downloadThumbnailQueue.addOperation(concurrentOperation)
-                //                print(appDelegate!.downloadThumbnailQueue.operationCount)
-
-                //                concurrentOperation.start()
             }
         }
     }
@@ -168,22 +110,6 @@ struct ScaledThumbnail: Hashable {
             self.onThumbnailDownloaded = onThumbnailDownloaded
         }
 
-        //        var cell: NCCellProtocol?
-        //        var collectionView: UICollectionView?
-        //        var fileNamePath: String
-        //        var fileNamePreviewLocalPath: String
-        //        var fileNameIconLocalPath: String
-        //        let utilityFileSystem = NCUtilityFileSystem()
-
-        //        init(metadata: tableMetadata, cell: NCCellProtocol?, collectionView: UICollectionView?) {
-        //            self.metadata = tableMetadata.init(value: metadata)
-        ////            self.cell = cell
-        ////            self.collectionView = collectionView
-        ////            self.fileNamePath = utilityFileSystem.getFileNamePath(metadata.fileName, serverUrl: metadata.serverUrl, urlBase: metadata.urlBase, userId: metadata.userId)
-        ////            self.fileNamePreviewLocalPath = utilityFileSystem.getDirectoryProviderStoragePreviewOcId(metadata.ocId, etag: metadata.etag)
-        ////            self.fileNameIconLocalPath = utilityFileSystem.getDirectoryProviderStorageIconOcId(metadata.ocId, etag: metadata.etag)
-        //        }
-
         override func start() {
             guard !isCancelled else { return self.finish() }
 
@@ -197,7 +123,6 @@ struct ScaledThumbnail: Hashable {
             }
             let options = NKRequestOptions(queue: NextcloudKit.shared.nkCommonInstance.backgroundQueue)
 
-            //            let concurrentOperation = ConcurrentOperation { operation in
             NextcloudKit.shared.downloadPreview(
                 fileNamePathOrFileId: fileNamePath,
                 fileNamePreviewLocalPath: fileNamePreviewLocalPath,
@@ -222,21 +147,9 @@ struct ScaledThumbnail: Hashable {
 
                     self.onThumbnailDownloaded(thumbnail)
 
-                    //                            self.cache.setValue(thumbnail, forKey: metadata.ocId)
-
-                    //                        DispatchQueue.main.async {
-                    //                            self.thumbnails.append(thumbnail)
-                    //                            NCMediaRowViewModel.calculateShrinkRatio(metadatas: self.metadatas, rowData: &self.rowData, thumbnails: &self.thumbnails, rowWidth: self.rowWidth, spacing: self.spacing)
-                    //                        }
-
                     self.finish()
-                    //                    }
                 }
-
-
         }
-
-
     }
 
     private func calculateShrinkRatio(metadatas: [tableMetadata], rowData: inout RowData, thumbnails: inout [ScaledThumbnail], rowWidth: CGFloat, spacing: CGFloat) {
@@ -279,33 +192,13 @@ struct ScaledThumbnail: Hashable {
     }
 
     func cancelDownloadingThumbnails() {
-        //        operations.forEach {( $0.cancel() )}
-        //        operations.removeAll()
-    }
+        guard let queuer else { return }
 
-    //    private func getScaledThumbnailSize(of thumbnail: ScaledThumbnail, thumbnailsInRow thumbnails: [ScaledThumbnail]) -> CGSize {
-    //        let maxHeight = thumbnails.compactMap { CGFloat($0.image.size.height) }.max() ?? 0
-    //
-    //        let height = thumbnail.image.size.height
-    //        let width = thumbnail.image.size.width
-    //
-    //        let scaleFactor = maxHeight / height
-    //        let newHeight = height * scaleFactor
-    //        let newWidth = width * scaleFactor
-    //
-    //        return .init(width: newWidth, height: newHeight)
-    //    }
-    //
-    //    private func getShrinkRatio(thumbnailsInRow thumbnails: [ScaledThumbnail], fullWidth: CGFloat, spacing: CGFloat) -> CGFloat {
-    //        var newSummedWidth: CGFloat = 0
-    //
-    //        for thumbnail in thumbnails {
-    //            newSummedWidth += CGFloat(thumbnail.scaledSize.width)
-    //        }
-    //
-    //        let spacingWidth = spacing * CGFloat(thumbnails.count - 1)
-    //        let shrinkRatio: CGFloat = (fullWidth - spacingWidth) / newSummedWidth
-    //
-    //        return shrinkRatio
-    //    }
+        metadatas.forEach { metadata in
+            for case let operation as NCMediaDownloadThumbnaill in queuer.operations where operation.metadata.ocId == metadata.ocId {
+                operation.cancel()
+                print(queuer.operationCount)
+            }
+        }
+    }
 }

--- a/iOSClient/Media/NCMediaRowViewModel.swift
+++ b/iOSClient/Media/NCMediaRowViewModel.swift
@@ -84,7 +84,6 @@ struct ScaledThumbnail: Hashable {
                     }
 
                     queuer.addOperation(concurrentOperation)
-                    print(queuer.operationCount)
                 }
             }
         }

--- a/iOSClient/Media/NCMediaScrollView.swift
+++ b/iOSClient/Media/NCMediaScrollView.swift
@@ -14,9 +14,9 @@ struct NCMediaScrollView: View, Equatable {
         return lhs.metadatas == rhs.metadatas
     }
 
-    var metadatas: [[tableMetadata]]
-    @EnvironmentObject var vm: NCMediaViewModel
-    @EnvironmentObject var parent: NCMediaUIKitWrapper
+    @Binding var metadatas: [tableMetadata]
+    //    @EnvironmentObject var vm: NCMediaViewModel
+    //    @EnvironmentObject var parent: NCMediaUIKitWrapper
     @Binding var isInSelectMode: Bool
     @Binding var selectedMetadatas: [tableMetadata]
     @Binding var columnCountStages: [Int]
@@ -25,6 +25,10 @@ struct NCMediaScrollView: View, Equatable {
 
     let queuer: Queuer
 
+    let onCellSelected: (ScaledThumbnail, Bool) -> Void
+    let onCellContextMenuItemSelected: (ScaledThumbnail, ContextMenuSelection) -> Void
+    let onRefresh: () async -> Void
+
     var body: some View {
         let _ = Self._printChanges()
 
@@ -32,38 +36,11 @@ struct NCMediaScrollView: View, Equatable {
             //            Spacer(minLength: 50).listRowSeparator(.hidden)
 
             LazyVStack(alignment: .leading, spacing: 2) {
-                ForEach(metadatas, id: \.self) { rowMetadatas in
+                ForEach(metadatas.chunked(into: columnCountStages[columnCountStagesIndex]), id: \.self) { rowMetadatas in
                     NCMediaRow(metadatas: rowMetadatas, isInSelectMode: $isInSelectMode, queuer: queuer) { tappedThumbnail, isSelected in
-                        if isInSelectMode, isSelected {
-                            selectedMetadatas.append(tappedThumbnail.metadata)
-                        } else {
-                            selectedMetadatas.removeAll(where: { $0.ocId == tappedThumbnail.metadata.ocId })
-                        }
-
-                        if !isInSelectMode {
-                            let selectedMetadata = tappedThumbnail.metadata
-                            vm.onCellTapped(metadata: selectedMetadata)
-                            NCViewer().view(viewController: parent, metadata: selectedMetadata, metadatas: vm.metadatas, imageIcon: tappedThumbnail.image)
-                        }
+                        onCellSelected(tappedThumbnail, isSelected)
                     } onCellContextMenuItemSelected: { thumbnail, selection in
-                        let selectedMetadata = thumbnail.metadata
-
-                        switch selection {
-                        case .addToFavorites:
-                            vm.addToFavorites(metadata: selectedMetadata)
-                        case .details:
-                            NCActionCenter.shared.openShare(viewController: parent, metadata: selectedMetadata, page: .activity)
-                        case .openIn:
-                            vm.openIn(metadata: selectedMetadata)
-                        case .saveToPhotos:
-                            vm.saveToPhotos(metadata: selectedMetadata)
-                        case .viewInFolder:
-                            vm.viewInFolder(metadata: selectedMetadata)
-                        case .modify:
-                            vm.modify(metadata: selectedMetadata)
-                        case .delete:
-                            vm.delete(metadatas: selectedMetadata)
-                        }
+                        onCellContextMenuItemSelected(thumbnail, selection)
                     }
                     .equatable()
                     .onAppear {
@@ -74,13 +51,12 @@ struct NCMediaScrollView: View, Equatable {
                     //                .listRowInsets(.init(top: 2, leading: 0, bottom: 0, trailing: 0))
                 }
 
-                // TODO: 3. Here we load old media (happens immediately since progress view appears in the beginning, should fix)
-                if vm.needsLoadingMoreItems {
-                    ProgressView()
-                        .frame(maxWidth: .infinity)
-                        .onAppear { vm.loadMoreItems() }
-                        .padding(.top, 10)
-                }
+                //                if vm.needsLoadingMoreItems {
+                //                    ProgressView()
+                //                        .frame(maxWidth: .infinity)
+                //                        .onAppear { vm.loadMoreItems() }
+                //                        .padding(.top, 10)
+                //                }
 
                 //                Spacer(minLength: 40).listRowSeparator(.hidden)
             }.background(GeometryReader { geometry in
@@ -116,8 +92,11 @@ struct NCMediaScrollView: View, Equatable {
             //                                }
             //        }
             //        .preference(key: TitlePreferenceKey.self, value: title)
-        }.refreshable {
-            await vm.onPullToRefresh()
+        }
+        .refreshable {
+            await onRefresh()
+            //            await vm.onPullToRefresh()
         }
     }
 }
+//}

--- a/iOSClient/Media/NCMediaViewModel.swift
+++ b/iOSClient/Media/NCMediaViewModel.swift
@@ -82,7 +82,7 @@ import LRUCache
                     self.loadMediaFromDB(showPhotos: false, showVideos: true)
                 }
 
-                self.cancelSelection()
+//                self.cancelSelection()
             }
             .store(in: &cancellables)
     }
@@ -286,10 +286,10 @@ import LRUCache
         NCActionCenter.shared.copyPasteboard(pasteboardOcIds: metadatas.compactMap({ $0.ocId }))
     }
 
-    private func cancelSelection() {
-//        self.isInSelectMode = false
-//        self.selectedMetadatas.removeAll()
-    }
+//    private func cancelSelection() {
+////        self.isInSelectMode = false
+////        self.selectedMetadatas.removeAll()
+//    }
 
     private func updateLoadingMedia() {
         isLoadingMetadata = isLoadingNewMetadata || isLoadingOldMetadata
@@ -346,6 +346,8 @@ extension NCMediaViewModel {
     }
 
     @objc func userChanged(_ notification: NSNotification) {
+            self.loadMediaFromDB()
+
         Task {
             await loadNewMedia()
         }

--- a/iOSClient/NCImageCache.swift
+++ b/iOSClient/NCImageCache.swift
@@ -33,7 +33,7 @@ import NextcloudKit
 
     // MARK: -
 
-    private let limit: Int = 1000
+    private let limit: Int = 1500
 
     enum ImageType {
         case placeholder
@@ -51,7 +51,6 @@ import NextcloudKit
     override private init() {}
 
     func createMediaCache(account: String) {
-
         ocIdEtag.removeAll()
         metadatas.removeAll()
         getMediaMetadatas(account: account)
@@ -128,7 +127,6 @@ import NextcloudKit
     }
 
     func getMediaMetadatas(account: String, predicate: NSPredicate? = nil) {
-
         guard let account = NCManageDatabase.shared.getAccount(predicate: NSPredicate(format: "account == %@", account)) else { return }
         let startServerUrl = NCUtilityFileSystem().getHomeServer(urlBase: account.urlBase, userId: account.userId) + account.mediaPath
 
@@ -195,7 +193,6 @@ import NextcloudKit
     }
 
     func createImagesCache() {
-
         let brandElement = NCBrandColor.shared.brandElement
         let yellowFavorite = NCBrandColor.shared.yellowFavorite
         let utility = NCUtility()

--- a/iOSClient/Select/NCSelect.swift
+++ b/iOSClient/Select/NCSelect.swift
@@ -26,6 +26,7 @@ import SwiftUI
 import NextcloudKit
 
 @objc protocol NCSelectDelegate {
+    @objc optional func dismissCancelled()
     @objc func dismissSelect(serverUrl: String?, metadata: tableMetadata?, type: String, items: [Any], indexPath: [IndexPath], overwrite: Bool, copy: Bool, move: Bool)
 }
 
@@ -219,6 +220,7 @@ class NCSelect: UIViewController, UIGestureRecognizerDelegate, UIAdaptivePresent
     // MARK: ACTION
 
     @IBAction func actionCancel(_ sender: UIBarButtonItem) {
+        delegate?.dismissCancelled?()
         self.dismiss(animated: true, completion: nil)
     }
 


### PR DESCRIPTION
This adds a loading indicator to the navigation bar:


![](https://user-images.githubusercontent.com/6960329/280004463-97c8ac9c-608a-4e9f-a9c8-be6be638c036.png)


It shows when:
- New or old media metadata is being loaded (thumbnail loading uses shimmering placeholders)
- Moving, copying, downloading or deleting media metadata

Additional things:
- Added Queuer to limit how many thumbnails are downloaded at a time
- Decoupled the main view model from the scroll view