### PR TITLE
Fix capabilities not decoding properly

### DIFF
--- a/iOSClient/Data/NCManageDatabase+Capabilities.swift
+++ b/iOSClient/Data/NCManageDatabase+Capabilities.swift
@@ -128,12 +128,12 @@ extension NCManageDatabase {
                             }
 
                             struct Public: Codable {
-                                let upload: Bool
                                 let enabled: Bool
+                                let upload: Bool?
                                 let password: Password?
-                                let sendmail: Bool
-                                let uploadfilesdrop: Bool
-                                let multiplelinks: Bool
+                                let sendmail: Bool?
+                                let uploadfilesdrop: Bool?
+                                let multiplelinks: Bool?
                                 let expiredate: ExpireDate?
                                 let expiredateinternal: ExpireDate?
                                 let expiredateremote: ExpireDate?


### PR DESCRIPTION
Fixes #2687 

Capabilities failed to decode as some optional bools were marked as non-optional.

The only non-nil flag we get for `public` is `enabled`:

```
"capabilities" : {
        "user_status" : {
          "enabled" : true,
          "supports_emoji" : true
        },
        "dav" : {
          "chunking" : "1.0",
          "bulkupload" : "1.0"
        },
        "bruteforce" : {
          "delay" : 0
        },
        "files_sharing" : {
          "public" : {
            "enabled" : false
          },
```

All other flags for `public` are optional, like `upload`:

```
"files_sharing" : {
          "public" : {
            "upload" : true,
            "password" : {
              "askForOptionalPassword" : false,
              "enforced" : false
            },
            "enabled" : true,
            "multiple_links" : true,
            "expire_date_internal" : {
              "enabled" : false
            },
            "expire_date_remote" : {
              "enabled" : false
            },
            "upload_files_drop" : true,
            "send_mail" : false,
            "expire_date" : {
              "enabled" : true,
              "days" : 31,
              "enforced" : false
            }
          },
```

Changing all the bools to optional fixed the issue:

```
                                let enabled: Bool
                                let upload: Bool?
                                let sendmail: Bool?
                                let uploadfilesdrop: Bool?
                                let multiplelinks: Bool?
```

I noticed that we don't seem to use those flags anyway; we use others:

```
 NCGlobal.shared.capabilityFileSharingPubPasswdEnforced = json.ocs.data.capabilities.filessharing?.ncpublic?.password?.enforced ?? false
            NCGlobal.shared.capabilityFileSharingPubExpireDateEnforced = json.ocs.data.capabilities.filessharing?.ncpublic?.expiredate?.enforced ?? false
            NCGlobal.shared.capabilityFileSharingPubExpireDateDays = json.ocs.data.capabilities.filessharing?.ncpublic?.expiredate?.days ?? 0
            NCGlobal.shared.capabilityFileSharingInternalExpireDateEnforced = json.ocs.data.capabilities.filessharing?.ncpublic?.expiredateinternal?.enforced ?? false
            NCGlobal.shared.capabilityFileSharingInternalExpireDateDays = json.ocs.data.capabilities.filessharing?.ncpublic?.expiredateinternal?.days ?? 0
            NCGlobal.shared.capabilityFileSharingRemoteExpireDateEnforced = json.ocs.data.capabilities.filessharing?.ncpublic?.expiredateremote?.enforced ?? false
            NCGlobal.shared.capabilityFileSharingRemoteExpireDateDays = json.ocs.data.capabilities.filessharing?.ncpublic?.expiredateremote?.days ?? 0
```

but I guess we keep them for future? @marinofaggiana.