### PR TITLE
Translucent bars

### DIFF
--- a/iOSClient/Activity/NCActivity.swift
+++ b/iOSClient/Activity/NCActivity.swift
@@ -100,7 +100,7 @@ class NCActivity: UIViewController, NCSharePagingContent {
 
         appDelegate.activeViewController = self
 
-        navigationController?.setFileAppreance()
+        navigationController?.setNavigationBarAppearance()
 
         fetchAll(isInitial: true)
     }

--- a/iOSClient/Extensions/UINavigationController+Extension.swift
+++ b/iOSClient/Extensions/UINavigationController+Extension.swift
@@ -30,7 +30,7 @@ extension UINavigationController {
         return self.visibleViewController!.topMostViewController()
     }
 
-    func setFileAppreance() {
+    func setNavigationBarAppearance() {
 
         navigationBar.tintColor = .systemBlue
 
@@ -39,7 +39,6 @@ extension UINavigationController {
 
         standardAppearance.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.label]
         standardAppearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.label]
-        standardAppearance.backgroundColor = .systemGray6
         navigationBar.standardAppearance = standardAppearance
 
         let scrollEdgeAppearance = UINavigationBarAppearance()

--- a/iOSClient/Files/NCFiles.storyboard
+++ b/iOSClient/Files/NCFiles.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="EFX-fO-Oip">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="EFX-fO-Oip">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Zaz-Cl-qpZ">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="862"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="fF1-wd-0xN">
                                     <size key="itemSize" width="0.0" height="0.0"/>
@@ -37,7 +37,7 @@
                         <constraints>
                             <constraint firstItem="Zaz-Cl-qpZ" firstAttribute="leading" secondItem="Meh-VD-wWh" secondAttribute="leading" id="1bp-sm-u0X"/>
                             <constraint firstItem="Meh-VD-wWh" firstAttribute="trailing" secondItem="Zaz-Cl-qpZ" secondAttribute="trailing" id="aNd-UL-hmu"/>
-                            <constraint firstItem="Meh-VD-wWh" firstAttribute="bottom" secondItem="Zaz-Cl-qpZ" secondAttribute="bottom" constant="-34" id="aNr-tf-2AH"/>
+                            <constraint firstItem="Meh-VD-wWh" firstAttribute="bottom" secondItem="Zaz-Cl-qpZ" secondAttribute="bottom" constant="-84" id="aNr-tf-2AH"/>
                             <constraint firstItem="Zaz-Cl-qpZ" firstAttribute="top" secondItem="QEs-gO-Cmp" secondAttribute="top" id="tji-wt-R7s"/>
                         </constraints>
                     </view>

--- a/iOSClient/Files/NCFiles.swift
+++ b/iOSClient/Files/NCFiles.swift
@@ -71,7 +71,7 @@ class NCFiles: NCCollectionViewCommon {
                 }
 
                 self.titleCurrentFolder = self.getNavigationTitle()
-                self.setNavigationItem()
+                self.setNavigationItems()
 
                 self.reloadDataSource()
                 self.reloadDataSourceNetwork()

--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
@@ -209,8 +209,8 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
 
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationController?.setNavigationBarHidden(false, animated: true)
-        navigationController?.setFileAppreance()
-        setNavigationItem()
+        navigationController?.setNavigationBarAppearance()
+        setNavigationItems()
 
         // FIXME: iPAD PDF landscape mode iOS 16
         DispatchQueue.main.async {
@@ -305,7 +305,7 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
               let error = userInfo["error"] as? NKError,
               error.errorCode != NCGlobal.shared.errorNotModified else { return }
 
-        setNavigationItem()
+        setNavigationItems()
     }
 
     @objc func changeTheming() {
@@ -575,7 +575,7 @@ class NCCollectionViewCommon: UIViewController, UIGestureRecognizerDelegate, UIS
 
     // MARK: - Layout
 
-    func setNavigationItem() {
+    func setNavigationItems() {
 
         self.setNavigationRightItems()
         navigationItem.title = titleCurrentFolder

--- a/iOSClient/Main/Collection Common/NCSelectableNavigationView.swift
+++ b/iOSClient/Main/Collection Common/NCSelectableNavigationView.swift
@@ -48,7 +48,7 @@ protocol NCSelectableNavigationView: AnyObject {
     var selectActions: [NCMenuAction] { get }
 
     func reloadDataSource(withQueryDB: Bool)
-    func setNavigationItem()
+    func setNavigationItems()
 
     func tapSelectMenu()
     func tapSelect()
@@ -56,7 +56,7 @@ protocol NCSelectableNavigationView: AnyObject {
 
 extension NCSelectableNavigationView {
 
-    func setNavigationItem() {
+    func setNavigationItems() {
         setNavigationRightItems()
     }
 
@@ -79,7 +79,7 @@ extension NCSelectableNavigationView {
         isEditMode = !isEditMode
         selectOcId.removeAll()
         selectIndexPath.removeAll()
-        self.setNavigationItem()
+        self.setNavigationItems()
         self.collectionView.reloadData()
     }
 

--- a/iOSClient/Main/Main.storyboard
+++ b/iOSClient/Main/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FkP-Lh-8zt">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FkP-Lh-8zt">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>

--- a/iOSClient/Main/NCMainTabBar.swift
+++ b/iOSClient/Main/NCMainTabBar.swift
@@ -48,9 +48,6 @@ class NCMainTabBar: UITabBar {
 
         let timerNotificationCenter = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(updateBadgeNumber), userInfo: nil, repeats: true)
 
-        barTintColor = .secondarySystemBackground
-        backgroundColor = .secondarySystemBackground
-
         changeTheming()
     }
 
@@ -80,117 +77,31 @@ class NCMainTabBar: UITabBar {
         }
     }
 
-//    override func viewWillLayoutSubviews() {
-//
-//        if let tabBar = self.tabBar as? CustomTabBar {
-
-//            let maskLayer = CAShapeLayer()
-//            maskLayer.path = tabBar.createPath()
-//            maskLayer.fillRule = .evenOdd
-//
-//            let blurEffect = UIBlurEffect(style: .light)
-//            let blurEffectView = UIVisualEffectView(effect: blurEffect)
-//            blurEffectView.frame = self.tabBar.frame
-//            blurEffectView.layer.mask = maskLayer
-//
-//            addSubview(blurEffectView)
-//            bringSubviewToFront(tabBar)
-//        }
-//    }
-
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-//        layer.shadowPath = createPath()
-//        layer.shadowRadius = 5
-//        layer.shadowOffset = .zero
-//        layer.shadowOpacity = 0.25
-
-//        let maskLayer = CAShapeLayer()
-//        maskLayer.path = createPath()
-//        maskLayer.fillRule = .evenOdd
-//
-//        let blurEffect = UIBlurEffect(style: .light)
-//        let blurEffectView = UIVisualEffectView(effect: blurEffect)
-//        blurEffectView.frame = frame
-//        blurEffectView.layer.mask = maskLayer
-
-//        addSubview(blurEffectView)
-//        bringSubviewToFront(self)
-    }
-
     override func draw(_ rect: CGRect) {
-//        addShape()
-//        createButtons()
+        self.subviews.forEach({ $0.removeFromSuperview() })
+
+        addShape()
+        createButtons()
     }
 
     private func addShape() {
+        let blurEffect = UIBlurEffect(style: .systemThinMaterial)
 
-//        let shapeLayer = CAShapeLayer()
-//        shapeLayer.path = createPath()
-//        shapeLayer.fillColor = backgroundColor?.cgColor
-//        shapeLayer.strokeColor = UIColor.clear.cgColor
-//
-//        if let oldShapeLayer = self.shapeLayer {
-//            self.layer.replaceSublayer(oldShapeLayer, with: shapeLayer)
-//        } else {
-//            self.layer.insertSublayer(shapeLayer, at: 0)
-//        }
+        let blurView = UIVisualEffectView(effect: blurEffect)
+        blurView.frame = self.bounds
 
-//        let maskLayer = CAShapeLayer()
-//        maskLayer.path = createPath()
-//        maskLayer.fillRule = .evenOdd
-//
-//        let blurEffect = UIBlurEffect(style: .light)
-//        let blurEffectView = UIVisualEffectView(effect: blurEffect)
-////        blurEffectView.frame = self.tabBar.frame
-//        blurEffectView.layer.mask = maskLayer
-//
-//        addSubview(blurEffectView)
-//        bringSubviewToFront(tabBar)
+        let maskLayer = CAShapeLayer()
+        maskLayer.path = createPath()
 
-//        var blur: UIView!
-//        blur = UIVisualEffectView (effect: UIBlurEffect (style: .light))
-//        blur.frame = frame
-//
-//        let maskLayer = CAShapeLayer()
-//        maskLayer.path = createPath()
-//        maskLayer.fillRule = .evenOdd
-//
-//        let borderLayer = CAShapeLayer()
-//        borderLayer.path = createPath()
-//        borderLayer.strokeColor = UIColor.white.cgColor
-//        borderLayer.fillColor = UIColor.clear.cgColor //Remember this line, it caused me some issues
-//        borderLayer.lineWidth = 10
-//
-//        let maskView = UIView(frame: frame)
-//        maskView.backgroundColor = UIColor.black
-//        maskView.layer.mask = maskLayer
-//
-//        blur.layer.addSublayer(borderLayer)
-//        blur.mask = maskView
-//
-//        self.shapeLayer = maskLayer
+        blurView.layer.mask = maskLayer
 
-//        private func addBlurEffect() {
-            // Create a UIBlurEffect
-            let blurEffect = UIBlurEffect(style: .systemMaterial)
+        var border = CALayer()
+        border.backgroundColor = UIColor.separator.cgColor
+        border.frame = CGRect(x: 0, y: 0, width: blurView.frame.width, height: 0.5)
 
-            // Create a UIVisualEffectView with the UIBlurEffect
-            let blurView = UIVisualEffectView(effect: blurEffect)
-            blurView.frame = self.bounds
+        blurView.layer.addSublayer(border)
 
-            // Create your shape layer (reuse your existing method)
-            let maskLayer = CAShapeLayer()
-            maskLayer.path = createPath()
-
-            // Set the mask of the blurView's layer to be the shape layer
-            blurView.layer.mask = maskLayer
-
-            // Add the blurView to your view hierarchy
-            self.addSubview(blurView)
-//        }
+        self.addSubview(blurView)
     }
 
     private func createPath() -> CGPath {

--- a/iOSClient/Main/NCMainTabBar.swift
+++ b/iOSClient/Main/NCMainTabBar.swift
@@ -80,34 +80,117 @@ class NCMainTabBar: UITabBar {
         }
     }
 
+//    override func viewWillLayoutSubviews() {
+//
+//        if let tabBar = self.tabBar as? CustomTabBar {
+
+//            let maskLayer = CAShapeLayer()
+//            maskLayer.path = tabBar.createPath()
+//            maskLayer.fillRule = .evenOdd
+//
+//            let blurEffect = UIBlurEffect(style: .light)
+//            let blurEffectView = UIVisualEffectView(effect: blurEffect)
+//            blurEffectView.frame = self.tabBar.frame
+//            blurEffectView.layer.mask = maskLayer
+//
+//            addSubview(blurEffectView)
+//            bringSubviewToFront(tabBar)
+//        }
+//    }
+
+
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        layer.shadowPath = createPath()
-        layer.shadowRadius = 5
-        layer.shadowOffset = .zero
-        layer.shadowOpacity = 0.25
+//        layer.shadowPath = createPath()
+//        layer.shadowRadius = 5
+//        layer.shadowOffset = .zero
+//        layer.shadowOpacity = 0.25
+
+//        let maskLayer = CAShapeLayer()
+//        maskLayer.path = createPath()
+//        maskLayer.fillRule = .evenOdd
+//
+//        let blurEffect = UIBlurEffect(style: .light)
+//        let blurEffectView = UIVisualEffectView(effect: blurEffect)
+//        blurEffectView.frame = frame
+//        blurEffectView.layer.mask = maskLayer
+
+//        addSubview(blurEffectView)
+//        bringSubviewToFront(self)
     }
 
     override func draw(_ rect: CGRect) {
-        addShape()
-        createButtons()
+//        addShape()
+//        createButtons()
     }
 
     private func addShape() {
 
-        let shapeLayer = CAShapeLayer()
-        shapeLayer.path = createPath()
-        shapeLayer.fillColor = backgroundColor?.cgColor
-        shapeLayer.strokeColor = UIColor.clear.cgColor
+//        let shapeLayer = CAShapeLayer()
+//        shapeLayer.path = createPath()
+//        shapeLayer.fillColor = backgroundColor?.cgColor
+//        shapeLayer.strokeColor = UIColor.clear.cgColor
+//
+//        if let oldShapeLayer = self.shapeLayer {
+//            self.layer.replaceSublayer(oldShapeLayer, with: shapeLayer)
+//        } else {
+//            self.layer.insertSublayer(shapeLayer, at: 0)
+//        }
 
-        if let oldShapeLayer = self.shapeLayer {
-            self.layer.replaceSublayer(oldShapeLayer, with: shapeLayer)
-        } else {
-            self.layer.insertSublayer(shapeLayer, at: 0)
-        }
+//        let maskLayer = CAShapeLayer()
+//        maskLayer.path = createPath()
+//        maskLayer.fillRule = .evenOdd
+//
+//        let blurEffect = UIBlurEffect(style: .light)
+//        let blurEffectView = UIVisualEffectView(effect: blurEffect)
+////        blurEffectView.frame = self.tabBar.frame
+//        blurEffectView.layer.mask = maskLayer
+//
+//        addSubview(blurEffectView)
+//        bringSubviewToFront(tabBar)
 
-        self.shapeLayer = shapeLayer
+//        var blur: UIView!
+//        blur = UIVisualEffectView (effect: UIBlurEffect (style: .light))
+//        blur.frame = frame
+//
+//        let maskLayer = CAShapeLayer()
+//        maskLayer.path = createPath()
+//        maskLayer.fillRule = .evenOdd
+//
+//        let borderLayer = CAShapeLayer()
+//        borderLayer.path = createPath()
+//        borderLayer.strokeColor = UIColor.white.cgColor
+//        borderLayer.fillColor = UIColor.clear.cgColor //Remember this line, it caused me some issues
+//        borderLayer.lineWidth = 10
+//
+//        let maskView = UIView(frame: frame)
+//        maskView.backgroundColor = UIColor.black
+//        maskView.layer.mask = maskLayer
+//
+//        blur.layer.addSublayer(borderLayer)
+//        blur.mask = maskView
+//
+//        self.shapeLayer = maskLayer
+
+//        private func addBlurEffect() {
+            // Create a UIBlurEffect
+            let blurEffect = UIBlurEffect(style: .systemMaterial)
+
+            // Create a UIVisualEffectView with the UIBlurEffect
+            let blurView = UIVisualEffectView(effect: blurEffect)
+            blurView.frame = self.bounds
+
+            // Create your shape layer (reuse your existing method)
+            let maskLayer = CAShapeLayer()
+            maskLayer.path = createPath()
+
+            // Set the mask of the blurView's layer to be the shape layer
+            blurView.layer.mask = maskLayer
+
+            // Add the blurView to your view hierarchy
+            self.addSubview(blurView)
+//        }
     }
 
     private func createPath() -> CGPath {

--- a/iOSClient/Main/Section Header Footer/NCSectionFooter.xib
+++ b/iOSClient/Main/Section Header Footer/NCSectionFooter.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,7 +16,7 @@
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TK1-KX-Qe0">
-                    <rect key="frame" x="10" y="0.0" width="355" height="30"/>
+                    <rect key="frame" x="10" y="20" width="355" height="30"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="30" id="Qvv-k4-hfY"/>
                     </constraints>
@@ -30,10 +30,10 @@
                     </connections>
                 </button>
                 <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="qWG-SR-Qly">
-                    <rect key="frame" x="177.5" y="5" width="20" height="20"/>
+                    <rect key="frame" x="177.5" y="25" width="20" height="20"/>
                 </activityIndicatorView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s2m-yO-4x0" userLabel="separator">
-                    <rect key="frame" x="10" y="30" width="365" height="1"/>
+                    <rect key="frame" x="10" y="50" width="365" height="1"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
@@ -74,7 +74,7 @@
     </objects>
     <resources>
         <systemColor name="linkColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOSClient/Main/Section Header Footer/NCSectionHeaderMenu.swift
+++ b/iOSClient/Main/Section Header Footer/NCSectionHeaderMenu.swift
@@ -320,9 +320,9 @@ class NCSectionFooter: UICollectionReusableView, NCSectionFooterDelegate {
         }
 
         if files > 1 {
-            filesText = "\(files) " + NSLocalizedString("_files_", comment: "") + " " + utilityFileSystem.transformedSize(size)
+            filesText = "\(files) " + NSLocalizedString("_files_", comment: "") + " • " + utilityFileSystem.transformedSize(size)
         } else if files == 1 {
-            filesText = "1 " + NSLocalizedString("_file_", comment: "") + " " + utilityFileSystem.transformedSize(size)
+            filesText = "1 " + NSLocalizedString("_file_", comment: "") + " • " + utilityFileSystem.transformedSize(size)
         }
 
         if foldersText.isEmpty {
@@ -330,7 +330,7 @@ class NCSectionFooter: UICollectionReusableView, NCSectionFooterDelegate {
         } else if filesText.isEmpty {
             labelSection.text = foldersText
         } else {
-            labelSection.text = foldersText + ", " + filesText
+            labelSection.text = foldersText + " • " + filesText
         }
     }
 

--- a/iOSClient/Media/NCMedia.storyboard
+++ b/iOSClient/Media/NCMedia.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Zaz-Cl-qpZ">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="828"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="862"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="fF1-wd-0xN">
                                     <size key="itemSize" width="0.0" height="0.0"/>
@@ -37,7 +37,7 @@
                         <constraints>
                             <constraint firstItem="Zaz-Cl-qpZ" firstAttribute="leading" secondItem="Meh-VD-wWh" secondAttribute="leading" id="1bp-sm-u0X"/>
                             <constraint firstItem="Meh-VD-wWh" firstAttribute="trailing" secondItem="Zaz-Cl-qpZ" secondAttribute="trailing" id="aNd-UL-hmu"/>
-                            <constraint firstItem="Meh-VD-wWh" firstAttribute="bottom" secondItem="Zaz-Cl-qpZ" secondAttribute="bottom" constant="-50" id="aNr-tf-2AH"/>
+                            <constraint firstItem="Meh-VD-wWh" firstAttribute="bottom" secondItem="Zaz-Cl-qpZ" secondAttribute="bottom" constant="-84" id="aNr-tf-2AH"/>
                             <constraint firstItem="Zaz-Cl-qpZ" firstAttribute="top" secondItem="QEs-gO-Cmp" secondAttribute="top" id="nIB-3t-o2I"/>
                         </constraints>
                     </view>

--- a/iOSClient/Media/NCMedia.storyboard
+++ b/iOSClient/Media/NCMedia.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="EFX-fO-Oip">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="EFX-fO-Oip">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Zaz-Cl-qpZ">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="813"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="828"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="fF1-wd-0xN">
                                     <size key="itemSize" width="0.0" height="0.0"/>
@@ -37,7 +37,7 @@
                         <constraints>
                             <constraint firstItem="Zaz-Cl-qpZ" firstAttribute="leading" secondItem="Meh-VD-wWh" secondAttribute="leading" id="1bp-sm-u0X"/>
                             <constraint firstItem="Meh-VD-wWh" firstAttribute="trailing" secondItem="Zaz-Cl-qpZ" secondAttribute="trailing" id="aNd-UL-hmu"/>
-                            <constraint firstItem="Meh-VD-wWh" firstAttribute="bottom" secondItem="Zaz-Cl-qpZ" secondAttribute="bottom" constant="-35" id="aNr-tf-2AH"/>
+                            <constraint firstItem="Meh-VD-wWh" firstAttribute="bottom" secondItem="Zaz-Cl-qpZ" secondAttribute="bottom" constant="-50" id="aNr-tf-2AH"/>
                             <constraint firstItem="Zaz-Cl-qpZ" firstAttribute="top" secondItem="QEs-gO-Cmp" secondAttribute="top" id="nIB-3t-o2I"/>
                         </constraints>
                     </view>

--- a/iOSClient/Networking/NCService.swift
+++ b/iOSClient/Networking/NCService.swift
@@ -338,7 +338,7 @@ class NCService: NSObject {
             @ThreadSafe var metadatas = metadatas
             let data = try JSONEncoder().encode(problems)
             data.printJson()
-            NextcloudKit.shared.sendClientDiagnosticsRemoteOperation(problems: data, options: NKRequestOptions(queue: NextcloudKit.shared.nkCommonInstance.backgroundQueue)) { _, error in
+            NextcloudKit.shared.sendClientDiagnosticsRemoteOperation(data: data, options: NKRequestOptions(queue: NextcloudKit.shared.nkCommonInstance.backgroundQueue)) { _, error in
                 if error == .success {
                     NCManageDatabase.shared.clearErrorCodeMetadatas(metadatas: metadatas)
                 }

--- a/iOSClient/Notification/NCNotification.swift
+++ b/iOSClient/Notification/NCNotification.swift
@@ -67,7 +67,7 @@ class NCNotification: UITableViewController, NCNotificationCellDelegate, NCEmpty
         super.viewWillAppear(animated)
 
         appDelegate.activeViewController = self
-        navigationController?.setFileAppreance()
+        navigationController?.setNavigationBarAppearance()
         getNetwokingNotification()
     }
 

--- a/iOSClient/Transfers/NCTransfers.swift
+++ b/iOSClient/Transfers/NCTransfers.swift
@@ -59,7 +59,7 @@ class NCTransfers: NCCollectionViewCommon, NCTransferCellDelegate {
         reloadDataSource()
     }
 
-    override func setNavigationItem() {
+    override func setNavigationItems() {
         self.navigationItem.rightBarButtonItem = nil
         self.navigationItem.leftBarButtonItem = nil
     }

--- a/iOSClient/Trash/NCTrash.swift
+++ b/iOSClient/Trash/NCTrash.swift
@@ -89,7 +89,7 @@ class NCTrash: UIViewController, NCSelectableNavigationView, NCTrashListCellDele
 
         appDelegate.activeViewController = self
 
-        navigationController?.setFileAppreance()
+        navigationController?.setNavigationBarAppearance()
         navigationItem.title = titleCurrentFolder
 
         layoutForView = NCManageDatabase.shared.getLayoutForView(account: appDelegate.account, key: NCGlobal.shared.layoutViewTrash, serverUrl: "")
@@ -101,7 +101,7 @@ class NCTrash: UIViewController, NCSelectableNavigationView, NCTrashListCellDele
             collectionView.collectionViewLayout = gridLayout
         }
 
-        setNavigationItem()
+        setNavigationItems()
         reloadDataSource()
     }
 


### PR DESCRIPTION
This makes the top and bottom bars on every `NCCollectionViewCommon` screen (Home, Trash, Favorites, etc) translucent.
Also makes the bottom bar in Media translucent. 

<img width="668" alt="image" src="https://github.com/nextcloud/ios/assets/6960329/4ba15bdf-e126-413c-b514-6d91e9fd966e">

Also changed the format of the footer text:

Before:
﻿
<img width="430" alt="image" src="https://github.com/nextcloud/ios/assets/6960329/c002f941-33dd-4745-a06c-81328e720a2a">


Now:

<img width="430" alt="image" src="https://github.com/nextcloud/ios/assets/6960329/4babc6bd-d9ff-4b1d-8407-fa21b953d87d">


Tested on iPhone, iPad, light and dark mode.