### PR TITLE
Fix tab bar items getting misaligned/disappearing

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -362,7 +362,7 @@
 		F73EF7ED2B0226B90087E6E9 /* NCManageDatabase+UserStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73EF7E62B0226B90087E6E9 /* NCManageDatabase+UserStatus.swift */; };
 		F73F537F1E929C8500F8678D /* NCMore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73F537E1E929C8500F8678D /* NCMore.swift */; };
 		F740BEF02A35C2AD00E9B6D5 /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7EE66AC2A20B226009AE765 /* UILabel+Extension.swift */; };
-		F741C2242B6B9FD600E849BB /* NCMediaTabbarSelect.swift in Sources */ = {isa = PBXBuildFile; fileRef = F741C2232B6B9FD600E849BB /* NCMediaTabbarSelect.swift */; };
+		F741C2242B6B9FD600E849BB /* NCMediaSelectTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F741C2232B6B9FD600E849BB /* NCMediaSelectTabBar.swift */; };
 		F7434B3620E23FE000417916 /* NCManageDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7BAADB51ED5A87C00B7EAD4 /* NCManageDatabase.swift */; };
 		F7434B3820E2400600417916 /* NCBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76B3CCD1EAE01BD00921AC9 /* NCBrand.swift */; };
 		F745B253222D88AE00346520 /* NCLoginQRCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F745B252222D88AE00346520 /* NCLoginQRCode.swift */; };
@@ -1148,7 +1148,7 @@
 		F73EF7DE2B02266C0087E6E9 /* NCManageDatabase+Trash.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+Trash.swift"; sourceTree = "<group>"; };
 		F73EF7E62B0226B90087E6E9 /* NCManageDatabase+UserStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+UserStatus.swift"; sourceTree = "<group>"; };
 		F73F537E1E929C8500F8678D /* NCMore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCMore.swift; sourceTree = "<group>"; };
-		F741C2232B6B9FD600E849BB /* NCMediaTabbarSelect.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCMediaTabbarSelect.swift; sourceTree = "<group>"; };
+		F741C2232B6B9FD600E849BB /* NCMediaSelectTabBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCMediaSelectTabBar.swift; sourceTree = "<group>"; };
 		F7421EAE2294044B00C4B7C1 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		F7434B5F20E2440600417916 /* FileProviderExtension-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FileProviderExtension-Bridging-Header.h"; sourceTree = "<group>"; };
 		F745B250222D871800346520 /* QRCodeReader.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QRCodeReader.framework; path = Carthage/Build/iOS/QRCodeReader.framework; sourceTree = "<group>"; };
@@ -2549,7 +2549,7 @@
 				F78B87E62B62527100C65ADC /* NCMediaDataSource.swift */,
 				F78B87E82B62550800C65ADC /* NCMediaDownloadThumbnaill.swift */,
 				F7BD50302B65216300D5AEF9 /* NCMediaGridLayout.swift */,
-				F741C2232B6B9FD600E849BB /* NCMediaTabbarSelect.swift */,
+				F741C2232B6B9FD600E849BB /* NCMediaSelectTabBar.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -3947,7 +3947,7 @@
 				F72944F52A8424F800246839 /* NCEndToEndMetadataV1.swift in Sources */,
 				F710D2022405826100A6033D /* NCViewer+Menu.swift in Sources */,
 				F765E9CD295C585800A09ED8 /* NCUploadScanDocument.swift in Sources */,
-				F741C2242B6B9FD600E849BB /* NCMediaTabbarSelect.swift in Sources */,
+				F741C2242B6B9FD600E849BB /* NCMediaSelectTabBar.swift in Sources */,
 				F77A697D250A0FBC00FF1708 /* NCCollectionViewCommon+Menu.swift in Sources */,
 				F7BF9D822934CA21009EE9A6 /* NCManageDatabase+LayoutForView.swift in Sources */,
 				AF7E504E27A2D8FF00B5E4AF /* UIBarButton+Extension.swift in Sources */,

--- a/iOSClient/Main/Collection Common/NCCollectionViewCommonSelectTabBar.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommonSelectTabBar.swift
@@ -42,7 +42,7 @@ class NCCollectionViewCommonSelectTabBar: NCSelectableViewTabBar, ObservableObje
 
         guard let tabBarController, let hostingController else { return }
 
-        tabBarController.addChild(hostingController)
+        
         tabBarController.view.addSubview(hostingController.view)
 
         hostingController.view.frame = tabBarController.tabBar.frame

--- a/iOSClient/Media/NCMedia.swift
+++ b/iOSClient/Media/NCMedia.swift
@@ -33,7 +33,7 @@ class NCMedia: UIViewController, NCEmptyDataSetDelegate {
     var mediaCommandView: NCMediaCommandView?
     var layout: NCMediaGridLayout!
     var documentPickerViewController: NCDocumentPickerViewController?
-    var tabBarSelect: NCMediaTabbarSelect?
+    var tabBarSelect: NCMediaSelectTabBar?
 
     let appDelegate = (UIApplication.shared.delegate as? AppDelegate)!
     let utilityFileSystem = NCUtilityFileSystem()
@@ -95,7 +95,7 @@ class NCMedia: UIViewController, NCEmptyDataSetDelegate {
         mediaCommandView?.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0).isActive = true
         mediaCommandView?.heightAnchor.constraint(equalToConstant: 150).isActive = true
 
-        tabBarSelect = NCMediaTabbarSelect(tabBarController: self.tabBarController, delegate: mediaCommandView)
+        tabBarSelect = NCMediaSelectTabBar(tabBarController: self.tabBarController, delegate: mediaCommandView)
 
         cacheImages.cellLivePhotoImage = utility.loadImage(named: "livephoto", color: .white)
         cacheImages.cellPlayImage = utility.loadImage(named: "play.fill", color: .white)

--- a/iOSClient/Media/NCMediaCommandView.swift
+++ b/iOSClient/Media/NCMediaCommandView.swift
@@ -216,7 +216,7 @@ class NCMediaCommandView: UIView {
 
 // MARK: - NCMediaTabBarSelectDelegate
 
-extension NCMediaCommandView: NCMediaTabBarSelectDelegate {
+extension NCMediaCommandView: NCMediaSelectTabBarDelegate {
 
     func delete() {
 

--- a/iOSClient/Media/NCMediaSelectTabBar.swift
+++ b/iOSClient/Media/NCMediaSelectTabBar.swift
@@ -24,17 +24,17 @@
 import UIKit
 import SwiftUI
 
-protocol NCMediaTabBarSelectDelegate: AnyObject {
+protocol NCMediaSelectTabBarDelegate: AnyObject {
     func delete()
 }
 
-class NCMediaTabbarSelect: ObservableObject {
+class NCMediaSelectTabBar: ObservableObject {
     var hostingController: UIViewController!
     var mediaTabBarController: UITabBarController?
-    open weak var delegate: NCMediaTabBarSelectDelegate?
+    open weak var delegate: NCMediaSelectTabBarDelegate?
     @Published var selectCount: Int = 0
 
-    init(tabBarController: UITabBarController? = nil, delegate: NCMediaTabBarSelectDelegate? = nil) {
+    init(tabBarController: UITabBarController? = nil, delegate: NCMediaSelectTabBarDelegate? = nil) {
         guard let tabBarController else { return }
         let mediaTabBarSelectView = MediaTabBarSelectView(tabBarSelect: self)
         hostingController = UIHostingController(rootView: mediaTabBarSelectView)
@@ -42,7 +42,6 @@ class NCMediaTabbarSelect: ObservableObject {
         self.mediaTabBarController = tabBarController
         self.delegate = delegate
 
-        tabBarController.addChild(hostingController)
         tabBarController.view.addSubview(hostingController.view)
 
         hostingController.view.frame = tabBarController.tabBar.frame
@@ -67,7 +66,7 @@ class NCMediaTabbarSelect: ObservableObject {
 }
 
 struct MediaTabBarSelectView: View {
-    @ObservedObject var tabBarSelect: NCMediaTabbarSelect
+    @ObservedObject var tabBarSelect: NCMediaSelectTabBar
     @Environment(\.verticalSizeClass) var sizeClass
 
     var body: some View {
@@ -105,5 +104,5 @@ struct MediaTabBarSelectView: View {
 }
 
 #Preview {
-    MediaTabBarSelectView(tabBarSelect: NCMediaTabbarSelect())
+    MediaTabBarSelectView(tabBarSelect: NCMediaSelectTabBar())
 }

--- a/iOSClient/Trash/NCTrashSelectTabBar.swift
+++ b/iOSClient/Trash/NCTrashSelectTabBar.swift
@@ -33,7 +33,6 @@ class NCTrashSelectTabBar: NCSelectableViewTabBar, ObservableObject {
 
         guard let tabBarController, let hostingController else { return }
 
-        tabBarController.addChild(hostingController)
         tabBarController.view.addSubview(hostingController.view)
 
         hostingController.view.frame = tabBarController.tabBar.frame


### PR DESCRIPTION
Turns out `addChild` is not supposed to be called on a tab bar controller, unless we override. It stops managing the previous child (aka. the Main Tab Bar)