### PR TITLE
Tab bar - fixes

### DIFF
--- a/iOSClient/Data/NCManageDatabase+Metadata.swift
+++ b/iOSClient/Data/NCManageDatabase+Metadata.swift
@@ -210,7 +210,7 @@ extension tableMetadata {
         return true
     }
 
-    var isSettableOnOffline: Bool {
+    var canSetAsAvailableOffline: Bool {
         return session.isEmpty && !isDocumentViewableOnly && !isDirectoryE2EE && !e2eEncrypted
     }
 
@@ -218,11 +218,11 @@ extension tableMetadata {
         return session.isEmpty && !isDocumentViewableOnly && !directory && !NCBrandOptions.shared.disable_openin_file
     }
 
-    var isDirectoySettableE2EE: Bool {
+    var canSetDirectoryAsE2EE: Bool {
         return directory && size == 0 && !e2eEncrypted && NCKeychain().isEndToEndEnabled(account: account)
     }
 
-    var isDirectoryUnsettableE2EE: Bool {
+    var canUnsetDirectoryAsE2EE: Bool {
         return !isDirectoryE2EE && directory && size == 0 && e2eEncrypted && NCKeychain().isEndToEndEnabled(account: account)
     }
 

--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
@@ -1194,6 +1194,9 @@ extension NCCollectionViewCommon: UICollectionViewDataSource {
 
         let numberItems = dataSource.numberOfItemsInSection(section)
         emptyDataSet?.numberOfItemsInSection(numberItems, section: section)
+
+        setNavigationRightItems()
+
         return numberItems
     }
 
@@ -1798,7 +1801,7 @@ extension NCCollectionViewCommon: NCSelectableNavigationView, NCCollectionViewCo
     func createMenuActions() -> [UIMenuElement] {
         guard let layoutForView = NCManageDatabase.shared.getLayoutForView(account: appDelegate.account, key: layoutKey, serverUrl: serverUrl) else { return [] }
 
-        let select = UIAction(title: NSLocalizedString("_select_", comment: ""), image: .init(systemName: "checkmark.circle")) { _ in self.toggleSelect() }
+        let select = UIAction(title: NSLocalizedString("_select_", comment: ""), image: .init(systemName: "checkmark.circle"), attributes: selectableDataSource.isEmpty ? .disabled : []) { _ in self.toggleSelect() }
 
         let list = UIAction(title: NSLocalizedString("_list_", comment: ""), image: .init(systemName: "list.bullet"), state: layoutForView.layout == NCGlobal.shared.layoutList ? .on : .off) { _ in
             self.onListSelected()

--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon.swift
@@ -1617,6 +1617,7 @@ extension NCCollectionViewCommon: NCSelectableNavigationView, NCCollectionViewCo
         var isAllDirectory = true
         var isAnyLocked = false
         var canUnlock = true
+        var canSetAsOffline = true
 
         for ocId in selectOcId {
             guard let metadata = NCManageDatabase.shared.getMetadataFromOcId(ocId) else { continue }
@@ -1626,6 +1627,10 @@ extension NCCollectionViewCommon: NCSelectableNavigationView, NCCollectionViewCo
                 isAnyDirectory = true
             } else {
                 isAllDirectory = false
+            }
+
+            if !metadata.canSetAsAvailableOffline {
+                canSetAsOffline = false
             }
 
             if metadata.lock {
@@ -1647,6 +1652,7 @@ extension NCCollectionViewCommon: NCSelectableNavigationView, NCCollectionViewCo
         guard let tabBarSelect = tabBarSelect as? NCCollectionViewCommonSelectTabBar else { return }
 
         tabBarSelect.isAnyOffline = isAnyOffline
+        tabBarSelect.canSetAsOffline = canSetAsOffline
         tabBarSelect.isAnyDirectory = isAnyDirectory
         tabBarSelect.isAllDirectory = isAllDirectory
         tabBarSelect.isAnyLocked = isAnyLocked
@@ -1768,10 +1774,12 @@ extension NCCollectionViewCommon: NCSelectableNavigationView, NCCollectionViewCo
 
     func move(selectedMetadatas: [tableMetadata]) {
         NCActionCenter.shared.openSelectView(items: selectedMetadatas, indexPath: self.selectIndexPath)
+        self.toggleSelect()
     }
 
     func share(selectedMetadatas: [tableMetadata]) {
         NCActionCenter.shared.openActivityViewController(selectedMetadata: selectedMetadatas)
+        self.toggleSelect()
     }
 
     func saveAsAvailableOffline(selectedMetadatas: [tableMetadata], isAnyOffline: Bool) {
@@ -1796,6 +1804,8 @@ extension NCCollectionViewCommon: NCSelectableNavigationView, NCCollectionViewCo
         for metadata in selectedMetadatas where metadata.lock == isAnyLocked {
             NCNetworking.shared.lockUnlockFile(metadata, shoulLock: !isAnyLocked)
         }
+
+        self.toggleSelect()
     }
 
     func createMenuActions() -> [UIMenuElement] {

--- a/iOSClient/Main/Collection Common/NCCollectionViewCommonSelectTabBar.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommonSelectTabBar.swift
@@ -26,6 +26,7 @@ class NCCollectionViewCommonSelectTabBar: NCSelectableViewTabBar, ObservableObje
     var selectedMetadatas: [tableMetadata] = []
 
     @Published var isAnyOffline = false
+    @Published var canSetAsOffline = false
     @Published var isAnyDirectory = false
     @Published var isAllDirectory = false
     @Published var isAnyLocked = false
@@ -118,8 +119,12 @@ struct NCCollectionViewCommonSelectTabBarView: View {
                         tabBarSelect.delegate?.saveAsAvailableOffline(selectedMetadatas: tabBarSelect.selectedMetadatas, isAnyOffline: tabBarSelect.isAnyOffline)
                     }, label: {
                         Label(NSLocalizedString(tabBarSelect.isAnyOffline ? "_remove_available_offline_" : "_set_available_offline_", comment: ""), systemImage: tabBarSelect.isAnyOffline ? "icloud.slash" : "icloud.and.arrow.down")
+
+                        if !tabBarSelect.canSetAsOffline && !tabBarSelect.isAnyOffline {
+                            Text(NSLocalizedString("_e2ee_set_as_offline_", comment: ""))
+                        }
                     })
-                    .disabled(tabBarSelect.isSelectedEmpty)
+                    .disabled(!tabBarSelect.isAnyOffline && (!tabBarSelect.canSetAsOffline || tabBarSelect.isSelectedEmpty))
 
                     Button(action: {
                         tabBarSelect.delegate?.lock(selectedMetadatas: tabBarSelect.selectedMetadatas, isAnyLocked: tabBarSelect.isAnyLocked)

--- a/iOSClient/Main/Collection Common/NCSelectableNavigationView.swift
+++ b/iOSClient/Main/Collection Common/NCSelectableNavigationView.swift
@@ -33,7 +33,10 @@ extension RealmSwiftObject {
     }
 }
 
-public protocol NCSelectableViewTabBar {}
+public protocol NCSelectableViewTabBar {
+    var tabBarController: UITabBarController? { get }
+    var hostingController: UIViewController? { get }
+}
 
 protocol NCSelectableNavigationView: AnyObject {
     var viewController: UIViewController { get }

--- a/iOSClient/Menu/NCCollectionViewCommon+Menu.swift
+++ b/iOSClient/Menu/NCCollectionViewCommon+Menu.swift
@@ -149,7 +149,7 @@ extension NCCollectionViewCommon {
         //
         // SET FOLDER E2EE
         //
-        if metadata.isDirectoySettableE2EE {
+        if metadata.canSetDirectoryAsE2EE {
             actions.append(
                 NCMenuAction(
                     title: NSLocalizedString("_e2e_set_folder_encrypted_", comment: ""),
@@ -170,7 +170,7 @@ extension NCCollectionViewCommon {
         //
         // UNSET FOLDER E2EE
         //
-        if metadata.isDirectoryUnsettableE2EE {
+        if metadata.canUnsetDirectoryAsE2EE {
             actions.append(
                 NCMenuAction(
                     title: NSLocalizedString("_e2e_remove_folder_encrypted_", comment: ""),
@@ -217,7 +217,7 @@ extension NCCollectionViewCommon {
         //
         // OFFLINE
         //
-        if metadata.isSettableOnOffline {
+        if metadata.canSetAsAvailableOffline {
             actions.append(.setAvailableOfflineAction(selectedMetadatas: [metadata], isAnyOffline: isOffline, viewController: self, order: 60, completion: {
                 self.reloadDataSource()
             }))

--- a/iOSClient/Menu/NCViewer+Menu.swift
+++ b/iOSClient/Menu/NCViewer+Menu.swift
@@ -89,7 +89,7 @@ extension NCViewer {
         //
         // OFFLINE
         //
-        if !webView, metadata.isSettableOnOffline {
+        if !webView, metadata.canSetAsAvailableOffline {
             actions.append(.setAvailableOfflineAction(selectedMetadatas: [metadata], isAnyOffline: isOffline, viewController: viewController))
         }
 

--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "_unlock_selected_files_"           = "Unlock files";
 "_locked_by_"                       = "Locked by %@";
 "_file_locked_no_override_"         = "This file is locked. It cannot be overridden.";
-"_lock_no_permissions_selected_"    = "Not permitted for some selected files";
+"_lock_no_permissions_selected_"    = "Not permitted for some selected files or directories";
 
 /* Remove a file from a list, don't delete it entirely */
 "_remove_file_"             = "Remove file";
@@ -919,6 +919,7 @@
 "_status_e2ee_on_server_"   = "The end-to-end encryption is already configured in the server but not yet enabled on this device";
 "_status_e2ee_not_setup_"   = "The end-to-end encryption is not yet configured on the server";
 "_status_e2ee_configured_"  = "The end-to-end encryption is correctly configured";
+"_e2ee_set_as_offline_"     = "Not permitted for encrypted directories";
 "_change_upload_filename_"  = "Do you want to save the file with a different name?";
 "_save_file_as_"            = "Save file as %@";
 "_password_ascii_"          = "The password cannot contain special characters";

--- a/iOSClient/Trash/NCTrash+CollectionView.swift
+++ b/iOSClient/Trash/NCTrash+CollectionView.swift
@@ -55,6 +55,9 @@ extension NCTrash: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         emptyDataSet?.numberOfItemsInSection(datasource.count, section: section)
+        
+        setNavigationRightItems()
+
         return datasource.count
     }
 

--- a/iOSClient/Trash/NCTrash.swift
+++ b/iOSClient/Trash/NCTrash.swift
@@ -386,7 +386,7 @@ extension NCTrash: NCSelectableNavigationView, NCTrashSelectTabBarDelegate {
     func createMenuActions() -> [UIMenuElement] {
         guard let layoutForView = NCManageDatabase.shared.getLayoutForView(account: appDelegate.account, key: layoutKey, serverUrl: serverUrl) else { return [] }
 
-        let select = UIAction(title: NSLocalizedString("_select_", comment: ""), image: .init(systemName: "checkmark.circle")) { _ in self.toggleSelect() }
+        let select = UIAction(title: NSLocalizedString("_select_", comment: ""), image: .init(systemName: "checkmark.circle"), attributes: selectableDataSource.isEmpty ? .disabled : []) { _ in self.toggleSelect() }
 
         let list = UIAction(title: NSLocalizedString("_list_", comment: ""), image: .init(systemName: "list.bullet"), state: layoutForView.layout == NCGlobal.shared.layoutList ? .on : .off) { _ in
             self.onListSelected()


### PR DESCRIPTION
1. Prevent E2EE directories from being set as offline:

![image](https://github.com/nextcloud/ios/assets/6960329/6f5a3fec-64ad-4411-92c7-b878332bc262)

2. Sharing and other actions now hide the selection after

3. Selection is greyed out with 0 items