### PR TITLE
VisionKit - prevent iOS 16 crash

### DIFF
--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMedia+VisionKit.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMedia+VisionKit.swift
@@ -25,43 +25,24 @@ import Foundation
 import VisionKit
 
 extension NCViewerMedia {
-    @available(iOS 16.0, *)
+    @available(iOS 17.0, *)
     func analyzeCurrentImage() {
         if let image = image {
+            let interaction = ImageAnalysisInteraction()
+            let analyzer = ImageAnalyzer()
+            interaction.preferredInteractionTypes = []
+            interaction.analysis = nil
+
+            self.imageVideoContainer.addInteraction(interaction)
+            let configuration = ImageAnalyzer.Configuration([.text, .machineReadableCode, .visualLookUp])
+
             Task {
-                let configuration = ImageAnalyzer.Configuration([.text, .machineReadableCode, .visualLookUp])
-                let analysis = try? await analyzer.imageAnalyzer?.analyze(image, configuration: configuration)
+                let analysis = try? await analyzer.analyze(image, configuration: configuration)
                 if image == self.image {
-                    analyzer.imageInteraction?.analysis = analysis
-                    analyzer.imageInteraction?.preferredInteractionTypes = .automatic
+                    interaction.analysis = analysis
+                    interaction.preferredInteractionTypes = .automatic
                 }
             }
-        }
-    }
-}
-
-// TODO: Remove when min SDK is 16
-@MainActor
-struct Analyzer {
-    private var _imageAnalyzer: Any?
-    private var _imageInteraction: Any?
-
-    @available(iOS 16, *)
-    var imageAnalyzer: ImageAnalyzer? {
-        get { return _imageAnalyzer as? ImageAnalyzer }
-        set { _imageAnalyzer = newValue }
-    }
-
-    @available(iOS 16, *)
-    var imageInteraction: ImageAnalysisInteraction? {
-        get { return _imageInteraction as? ImageAnalysisInteraction }
-        set { _imageInteraction = newValue }
-    }
-
-    init() {
-        if #available(iOS 16, *) {
-            imageAnalyzer = ImageAnalyzer()
-            imageInteraction = ImageAnalysisInteraction()
         }
     }
 }

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
@@ -29,7 +29,6 @@ import SwiftUI
 import MobileVLCKit
 import JGProgressHUD
 import Alamofire
-import VisionKit
 
 public protocol NCViewerMediaViewDelegate: AnyObject {
     func didOpenDetail()
@@ -48,7 +47,6 @@ class NCViewerMedia: UIViewController {
 
     private let player = VLCMediaPlayer()
     private let appDelegate = (UIApplication.shared.delegate as? AppDelegate)!
-    let analyzer = Analyzer()
     let utilityFileSystem = NCUtilityFileSystem()
     let utility = NCUtility()
     weak var viewerMediaPage: NCViewerMediaPage?
@@ -56,9 +54,7 @@ class NCViewerMedia: UIViewController {
     var ncplayer: NCPlayer?
     var image: UIImage? {
         didSet {
-            if #available(iOS 16, *), metadata.isImage {
-                analyzer.imageInteraction?.preferredInteractionTypes = []
-                analyzer.imageInteraction?.analysis = nil
+            if #available(iOS 17.0, *), metadata.isImage {
                 analyzeCurrentImage()
             }
         }
@@ -126,12 +122,6 @@ class NCViewerMedia: UIViewController {
         self.imageVideoContainer.image = nil
 
         loadImage()
-
-        if #available(iOS 16, *) {
-            if let interaction = analyzer.imageInteraction {
-                self.imageVideoContainer.addInteraction(interaction)
-            }
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Seems iOS 16 partially supports VisionKit, and `.visualLookup` is not supported, leading to a crash.