### PR TITLE
Fix light and dark color sensitivity

### DIFF
--- a/iOSClient/Extensions/UIColor+Extension.swift
+++ b/iOSClient/Extensions/UIColor+Extension.swift
@@ -117,7 +117,7 @@ extension UIColor {
 
         guard let components = cgColor.components, components.count > 2 else {return false}
         let brightness = ((components[0] * 299) + (components[1] * 587) + (components[2] * 114)) / 1000
-        return (brightness > 0.95)
+        return (brightness > 0.90)
     }
 
     @objc func isTooDark() -> Bool {
@@ -128,7 +128,7 @@ extension UIColor {
 
         guard let components = cgColor.components, components.count > 2 else {return false}
         let brightness = ((components[0] * 299) + (components[1] * 587) + (components[2] * 114)) / 1000
-        return (brightness < 0.05)
+        return (brightness < 0.10)
     }
 
     func isLight(threshold: Float = 0.7) -> Bool {


### PR DESCRIPTION
There were cases where some colors would not be considered too light or dark, leading to this:

![image](https://github.com/nextcloud/ios/assets/6960329/91f990a7-1248-4128-8e5c-44b25dd7043b)

Adjusted values to catch those.

Now:

![image](https://github.com/nextcloud/ios/assets/6960329/5d1e23c6-89d6-4127-8fff-2b6c32e73885)

