### PR TITLE
Give hint for non-appearing Nextcloud in Files Locations on initial install

### DIFF
--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -371,7 +371,7 @@
 "_advanced_"                    = "Advanced";
 "_permissions_"                 = "Permissions";
 "_disable_files_app_"           = "Disable Files App integration";
-"_disable_files_app_footer_"    = "Do not permit the access of files via the iOS Files application";
+"_disable_files_app_footer_"    = "Do not permit the access of files via the iOS Files application. Note that on initial install Nextcloud will not appear in Files' Locations list until manually added via More > Edit";
 "_trial_"                       = "Trial";
 "_trial_expired_day_"           = "Days remaining";
 "_time_remaining_"              = "%@ remaining";


### PR DESCRIPTION
Hi everyone,

**Note this is incomplete since the proposed hint solution would require localization in all languages.** However this seems like a low-cost way to potential work around an iOS-imposed problem.

# Problem

Unfortunately when installing Nextcloud for the first time on a device, it will not appear in the Files app Locations list until manually added to the list through the app's more icon + Edit:

![IMG_31385ED7A320-1](https://github.com/itsthejb/nextcloud-ios/assets/557391/89123897-22e1-4c80-8e83-4faba8c8c472)

I've been using the app happily for many years, however have been repeatedly tripped up by this after each device upgrade. From web search, it appears many people are misled by this problem:

- https://help.nextcloud.com/t/ios-nextcloud-app-and-files-manager-integration-no-longer-works/136314
- https://help.nextcloud.com/t/solved-it-seems-nextcloud-ios-5-0-1-0-app-integration-not-working/181973
- https://github.com/nextcloud/ios/issues/2130
- https://help.nextcloud.com/t/ios-integration-does-not-work/140519

So it seems to me that something should be done to at least help hint users in the right direction.

# Proposed solution

This seems like something which could best be handled through onboarding. However the app doesn't have any right now. Instead, since there is already the "Disable Files App integration" button in Advanced setting with a hint footer text, perhaps this could at least be leveraged to hint the user into realising the problem.

So, I propose slightly extending the text here in the hope it leads users in the right direction