### PR TITLE
Openssl new version 3.1.5004

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -5609,7 +5609,7 @@
 			repositoryURL = "https://github.com/krzyzanowskim/OpenSSL";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 3.1.5004;
 			};
 		};
 		F77BC3E9293E5268005F2B08 /* XCRemoteSwiftPackageReference "swifter" */ = {


### PR DESCRIPTION
Changes OpenSSL Version to 3.1.5004 to include apples privacy manifest which is now needed to upload the app to the App Store.