### PR TITLE
Improve login polling 

### DIFF
--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -213,7 +213,7 @@
 "_copy_failed_"             = "Copy failed";
 "_certificate_installed_"   = "Certificate installed";
 "_remove_local_account_"    = "Remove local account";
-"_want_delete_account_"     = "Do you want to remove local account";
+"_want_delete_account_"     = "Do you want to remove local account?";
 "_prevent_http_redirection_"= "The redirection in HTTP is not permitted";
 "_pdf_vertical_"            = "PDF vertical display";
 "_pdf_horizontal_"          = "PDF horizontal display";


### PR DESCRIPTION
- Login poll actually polls now via a timer
- Remove didBecomeActive notification
- Now works with the Mac Catalyst app as well 
     - Reason: on Mac Catalyst `didBecomeActives` only gets called when you change virtual desktops, but not when you switch apps in the same virtual desktop