### PR TITLE
Close #3184: Download Limit Support

### DIFF
--- a/Brand/Database.swift
+++ b/Brand/Database.swift
@@ -26,4 +26,4 @@ import Foundation
 // Database Realm
 //
 let databaseName                    = "nextcloud.realm"
-let databaseSchemaVersion: UInt64   = 367
+let databaseSchemaVersion: UInt64   = 368

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -5913,8 +5913,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nextcloud/NextcloudKit";
 			requirement = {
-				kind = exactVersion;
-				version = 5.0.2;
+				branch = files_downloadlimit;
+				kind = branch;
 			};
 		};
 		F788ECC5263AAAF900ADC67F /* XCRemoteSwiftPackageReference "MarkdownKit" */ = {

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -1168,11 +1168,6 @@
 		8491B1CC273BBA82001C8C5B /* UIViewController+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Menu.swift"; sourceTree = "<group>"; };
 		AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+DownloadLimit.swift"; sourceTree = "<group>"; };
 		AAAC0A112CEE346A0001949E /* NCShareDownloadLimitNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDownloadLimitNetworking.swift; sourceTree = "<group>"; };
-		AAF806B12CE25E60009C2D43 /* NCShareDateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDateCell.swift; sourceTree = "<group>"; };
-		AAF806B32CE25EFE009C2D43 /* NCShareToggleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareToggleCell.swift; sourceTree = "<group>"; };
-		AAF806B52CE34C72009C2D43 /* NCShareDownloadLimitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDownloadLimitViewController.swift; sourceTree = "<group>"; };
-		AAF806B72CE37C15009C2D43 /* NCShareDownloadLimitTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDownloadLimitTableViewController.swift; sourceTree = "<group>"; };
-		AAF806B92CE38BB2009C2D43 /* NextcloudKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = NextcloudKit; path = ../NextcloudKit; sourceTree = SOURCE_ROOT; };
 		AACCAB522CFE041F00DA1786 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Intent.strings; sourceTree = "<group>"; };
 		AACCAB532CFE041F00DA1786 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		AACCAB542CFE041F00DA1786 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1182,6 +1177,11 @@
 		AACCAB622CFE04F700DA1786 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Intent.strings; sourceTree = "<group>"; };
 		AACCAB632CFE04F700DA1786 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Localizable.strings; sourceTree = "<group>"; };
 		AACCAB642CFE04F700DA1786 /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		AAF806B12CE25E60009C2D43 /* NCShareDateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDateCell.swift; sourceTree = "<group>"; };
+		AAF806B32CE25EFE009C2D43 /* NCShareToggleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareToggleCell.swift; sourceTree = "<group>"; };
+		AAF806B52CE34C72009C2D43 /* NCShareDownloadLimitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDownloadLimitViewController.swift; sourceTree = "<group>"; };
+		AAF806B72CE37C15009C2D43 /* NCShareDownloadLimitTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDownloadLimitTableViewController.swift; sourceTree = "<group>"; };
+		AAF806B92CE38BB2009C2D43 /* NextcloudKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = NextcloudKit; path = ../NextcloudKit; sourceTree = SOURCE_ROOT; };
 		AF1A9B6327D0CA1E00F17A9E /* UIAlertController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extension.swift"; sourceTree = "<group>"; };
 		AF22B20B277C6F4D00DAB0CC /* NCShareCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareCell.swift; sourceTree = "<group>"; };
 		AF22B215277D196700DAB0CC /* NCShareExtension+DataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NCShareExtension+DataSource.swift"; sourceTree = "<group>"; };
@@ -5913,7 +5913,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nextcloud/NextcloudKit";
 			requirement = {
-				branch = files_downloadlimit;
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -16,6 +16,18 @@
 		371B5A2E23D0B04500FAFAE9 /* NCMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371B5A2D23D0B04500FAFAE9 /* NCMenu.swift */; };
 		3781B9B023DB2B7E006B4B1D /* AppDelegate+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3781B9AF23DB2B7E006B4B1D /* AppDelegate+Menu.swift */; };
 		8491B1CD273BBA82001C8C5B /* UIViewController+Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8491B1CC273BBA82001C8C5B /* UIViewController+Menu.swift */; };
+		AA3494FE2CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */; };
+		AA3494FF2CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */; };
+		AA3495002CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */; };
+		AA3495012CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */; };
+		AA3495022CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */; };
+		AA3495032CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */; };
+		AA3495042CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */; };
+		AAAC0A122CEE34700001949E /* NCShareDownloadLimitNetworking.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAC0A112CEE346A0001949E /* NCShareDownloadLimitNetworking.swift */; };
+		AAF806B22CE25E67009C2D43 /* NCShareDateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF806B12CE25E60009C2D43 /* NCShareDateCell.swift */; };
+		AAF806B42CE25EFF009C2D43 /* NCShareToggleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF806B32CE25EFE009C2D43 /* NCShareToggleCell.swift */; };
+		AAF806B62CE34C7A009C2D43 /* NCShareDownloadLimitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF806B52CE34C72009C2D43 /* NCShareDownloadLimitViewController.swift */; };
+		AAF806B82CE37C1A009C2D43 /* NCShareDownloadLimitTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF806B72CE37C15009C2D43 /* NCShareDownloadLimitTableViewController.swift */; };
 		AF1A9B6427D0CA1E00F17A9E /* UIAlertController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1A9B6327D0CA1E00F17A9E /* UIAlertController+Extension.swift */; };
 		AF1A9B6527D0CC0500F17A9E /* UIAlertController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1A9B6327D0CA1E00F17A9E /* UIAlertController+Extension.swift */; };
 		AF22B206277B4E4C00DAB0CC /* NCCreateFormUploadConflict.swift in Sources */ = {isa = PBXBuildFile; fileRef = F704B5E42430AA8000632F5F /* NCCreateFormUploadConflict.swift */; };
@@ -1154,6 +1166,13 @@
 		371B5A2D23D0B04500FAFAE9 /* NCMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMenu.swift; sourceTree = "<group>"; };
 		3781B9AF23DB2B7E006B4B1D /* AppDelegate+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Menu.swift"; sourceTree = "<group>"; };
 		8491B1CC273BBA82001C8C5B /* UIViewController+Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Menu.swift"; sourceTree = "<group>"; };
+		AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+DownloadLimit.swift"; sourceTree = "<group>"; };
+		AAAC0A112CEE346A0001949E /* NCShareDownloadLimitNetworking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDownloadLimitNetworking.swift; sourceTree = "<group>"; };
+		AAF806B12CE25E60009C2D43 /* NCShareDateCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDateCell.swift; sourceTree = "<group>"; };
+		AAF806B32CE25EFE009C2D43 /* NCShareToggleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareToggleCell.swift; sourceTree = "<group>"; };
+		AAF806B52CE34C72009C2D43 /* NCShareDownloadLimitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDownloadLimitViewController.swift; sourceTree = "<group>"; };
+		AAF806B72CE37C15009C2D43 /* NCShareDownloadLimitTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareDownloadLimitTableViewController.swift; sourceTree = "<group>"; };
+		AAF806B92CE38BB2009C2D43 /* NextcloudKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = NextcloudKit; path = ../NextcloudKit; sourceTree = SOURCE_ROOT; };
 		AACCAB522CFE041F00DA1786 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Intent.strings; sourceTree = "<group>"; };
 		AACCAB532CFE041F00DA1786 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		AACCAB542CFE041F00DA1786 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1934,6 +1953,15 @@
 			path = Menu;
 			sourceTree = "<group>";
 		};
+		AA3494FC2CE4FF02005CC075 /* DownloadLimit */ = {
+			isa = PBXGroup;
+			children = (
+				AAF806B52CE34C72009C2D43 /* NCShareDownloadLimitViewController.swift */,
+				AAF806B72CE37C15009C2D43 /* NCShareDownloadLimitTableViewController.swift */,
+			);
+			path = DownloadLimit;
+			sourceTree = "<group>";
+		};
 		AF8ED1FA2757821000B8DBC4 /* NextcloudUnitTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1945,11 +1973,14 @@
 		AF93471327E235EB002537EE /* Advanced */ = {
 			isa = PBXGroup;
 			children = (
+				AA3494FC2CE4FF02005CC075 /* DownloadLimit */,
 				AF93471627E2361E002537EE /* NCShareAdvancePermission.swift */,
 				AF93471827E2361E002537EE /* NCShareAdvancePermissionFooter.swift */,
 				AF93471427E2361E002537EE /* NCShareAdvancePermissionFooter.xib */,
 				AFCE353627E4ED7B00FEA6C2 /* NCShareCells.swift */,
+				AAF806B12CE25E60009C2D43 /* NCShareDateCell.swift */,
 				AF93474D27E3F211002537EE /* NCShareNewUserAddComment.swift */,
+				AAF806B32CE25EFE009C2D43 /* NCShareToggleCell.swift */,
 			);
 			path = Advanced;
 			sourceTree = "<group>";
@@ -2170,6 +2201,7 @@
 				F787704E22E7019900F287A9 /* NCShareLinkCell.xib */,
 				AF2D7C7B2742556F00ADF566 /* NCShareLinkCell.swift */,
 				F769454722E9F20D000A798A /* NCShareNetworking.swift */,
+				AAAC0A112CEE346A0001949E /* NCShareDownloadLimitNetworking.swift */,
 				F769453F22E9F077000A798A /* NCSharePaging.swift */,
 				F774264822EB4D0000B23912 /* NCSearchUserDropDownCell.xib */,
 				F769453B22E9CFFF000A798A /* NCShareUserCell.xib */,
@@ -2700,6 +2732,7 @@
 		F7BAAD951ED5A63D00B7EAD4 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				AA3494FD2CE65EA9005CC075 /* NCManageDatabase+DownloadLimit.swift */,
 				F7BAADB51ED5A87C00B7EAD4 /* NCManageDatabase.swift */,
 				AF4BF613275629E20081CEEF /* NCManageDatabase+Account.swift */,
 				AF4BF61D27562B3F0081CEEF /* NCManageDatabase+Activity.swift */,
@@ -3036,6 +3069,7 @@
 		F7F67B9F1A24D27800EE80DA = {
 			isa = PBXGroup;
 			children = (
+				AAF806B92CE38BB2009C2D43 /* NextcloudKit */,
 				F7B8B82F25681C3400967775 /* GoogleService-Info.plist */,
 				F7C1CDD91E6DFC6F005D92BE /* Brand */,
 				F7F67BAA1A24D27800EE80DA /* iOSClient */,
@@ -3869,6 +3903,7 @@
 				F711A4E22AF92CAE00095DD8 /* NCUtility+Date.swift in Sources */,
 				F7401C1B2C75E6F300649E87 /* NCCapabilities.swift in Sources */,
 				AF4BF61C27562A4B0081CEEF /* NCManageDatabase+Metadata.swift in Sources */,
+				AA3495022CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */,
 				F78E2D6B29AF02DB0024D4F3 /* Database.swift in Sources */,
 				F7817CFF29802D1A00FFBC65 /* NCPushNotificationEncryption.m in Sources */,
 				F798F0EC2588060A000DAFFD /* UIColor+Extension.swift in Sources */,
@@ -3941,6 +3976,7 @@
 				F711A4E12AF92CAE00095DD8 /* NCUtility+Date.swift in Sources */,
 				F76882382C0DD22F001CF441 /* NCKeychain.swift in Sources */,
 				F7C9B9222B582F550064EA91 /* NCManageDatabase+SecurityGuard.swift in Sources */,
+				AA3495032CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */,
 				F7490E8529882C8C009DCE94 /* NCManageDatabase+Video.swift in Sources */,
 				F7490E7729882C10009DCE94 /* UIColor+Extension.swift in Sources */,
 				F70716E62987F81500E72C1D /* DocumentActionViewController.swift in Sources */,
@@ -3989,6 +4025,7 @@
 				F73EF7DA2B0226080087E6E9 /* NCManageDatabase+Tip.swift in Sources */,
 				F7817CFB29801A3500FFBC65 /* Data+Extension.swift in Sources */,
 				F72429362AFE39860040AEF3 /* NCLivePhoto.swift in Sources */,
+				AA3494FF2CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */,
 				AF4BF61F27562B3F0081CEEF /* NCManageDatabase+Activity.swift in Sources */,
 				F7CBC1262BAC8B0000EC1D55 /* NCSectionFirstHeaderEmptyData.swift in Sources */,
 				F7A0D1362591FBC5008F8A13 /* String+Extension.swift in Sources */,
@@ -4111,6 +4148,7 @@
 				F783030328B4C4DD00B84583 /* ThreadSafeDictionary.swift in Sources */,
 				F77ED59128C9CE9D00E24ED0 /* ToolbarData.swift in Sources */,
 				F78302F728B4C3C900B84583 /* NCManageDatabase.swift in Sources */,
+				AA3495042CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */,
 				F359D8682A7D03420023F405 /* NCUtility+Exif.swift in Sources */,
 				F7346E1628B0EF5C006CE2D2 /* Widget.swift in Sources */,
 				F78302F828B4C3E100B84583 /* NCManageDatabase+Activity.swift in Sources */,
@@ -4243,6 +4281,7 @@
 				F7327E392B73B8D400A462C7 /* Array+Extension.swift in Sources */,
 				F78E2D6929AF02DB0024D4F3 /* Database.swift in Sources */,
 				F749B64E297B0CBB00087535 /* NCManageDatabase+Share.swift in Sources */,
+				AA3494FE2CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */,
 				F73EF7B32B0224350087E6E9 /* NCManageDatabase+DirectEditing.swift in Sources */,
 				F7401C192C75E6F300649E87 /* NCCapabilities.swift in Sources */,
 				F771E3F320E239A600AFB62D /* FileProviderData.swift in Sources */,
@@ -4355,6 +4394,7 @@
 				F758B460212C56A400515F55 /* NCScan.swift in Sources */,
 				F76882262C0DD1E7001CF441 /* NCSettingsView.swift in Sources */,
 				F78ACD52219046DC0088454D /* NCSectionFirstHeader.swift in Sources */,
+				AAF806B42CE25EFF009C2D43 /* NCShareToggleCell.swift in Sources */,
 				F72944F52A8424F800246839 /* NCEndToEndMetadataV1.swift in Sources */,
 				F710D2022405826100A6033D /* NCViewer+Menu.swift in Sources */,
 				F765E9CD295C585800A09ED8 /* NCUploadScanDocument.swift in Sources */,
@@ -4394,6 +4434,7 @@
 				F7D4BF472CA2E8D800A5E746 /* TOSettingsKeypadImage.m in Sources */,
 				F7D4BF482CA2E8D800A5E746 /* TOPasscodeSettingsWarningLabel.m in Sources */,
 				F7D4BF492CA2E8D800A5E746 /* TOPasscodeVariableInputView.m in Sources */,
+				AA3495012CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */,
 				F7D4BF4A2CA2E8D800A5E746 /* TOPasscodeCircleView.m in Sources */,
 				F7D4BF4B2CA2E8D800A5E746 /* TOPasscodeViewContentLayout.m in Sources */,
 				F7D4BF4C2CA2E8D800A5E746 /* TOPasscodeSettingsKeypadButton.m in Sources */,
@@ -4435,6 +4476,7 @@
 				F7EB9B132BBC12F300EDF036 /* UIApplication+Extension.swift in Sources */,
 				F7E98C1627E0D0FC001F9F19 /* NCManageDatabase+Video.swift in Sources */,
 				F7F4F11227ECDC52008676F9 /* UIFont+Extension.swift in Sources */,
+				AAF806B62CE34C7A009C2D43 /* NCShareDownloadLimitViewController.swift in Sources */,
 				F76882222C0DD1E7001CF441 /* NCCapabilitiesView.swift in Sources */,
 				AF93471A27E2361E002537EE /* NCShareHeader.swift in Sources */,
 				F7F878AE1FB9E3B900599E4F /* NCEndToEndMetadata.swift in Sources */,
@@ -4522,6 +4564,7 @@
 				F77C97392953131000FDDD09 /* NCCameraRoll.swift in Sources */,
 				F343A4B32A1E01FF00DDA874 /* PHAsset+Extension.swift in Sources */,
 				F70968A424212C4E00ED60E5 /* NCLivePhoto.swift in Sources */,
+				AAF806B22CE25E67009C2D43 /* NCShareDateCell.swift in Sources */,
 				F7C30DFA291BCF790017149B /* NCNetworkingE2EECreateFolder.swift in Sources */,
 				F7BC288026663F85004D46C5 /* NCViewCertificateDetails.swift in Sources */,
 				F78B87E92B62550800C65ADC /* NCMediaDownloadThumbnail.swift in Sources */,
@@ -4543,8 +4586,10 @@
 				F7D68FCC28CB9051009139F3 /* NCManageDatabase+DashboardWidget.swift in Sources */,
 				F76882292C0DD1E7001CF441 /* NCManageE2EEModel.swift in Sources */,
 				F799DF8B2C4B84EB003410B5 /* NCCollectionViewCommon+EndToEndInitialize.swift in Sources */,
+				AAAC0A122CEE34700001949E /* NCShareDownloadLimitNetworking.swift in Sources */,
 				F78E2D6529AF02DB0024D4F3 /* Database.swift in Sources */,
 				F70CEF5623E9C7E50007035B /* UIColor+Extension.swift in Sources */,
+				AAF806B82CE37C1A009C2D43 /* NCShareDownloadLimitTableViewController.swift in Sources */,
 				F76882242C0DD1E7001CF441 /* NCSettingsAdvancedView.swift in Sources */,
 				F75CA1472962F13700B01130 /* NCHUDView.swift in Sources */,
 				F77BB748289985270090FC19 /* UITabBarController+Extension.swift in Sources */,
@@ -4586,6 +4631,7 @@
 				F7C9739528F17131002C43E2 /* IntentHandler.swift in Sources */,
 				F7A8D73D28F181D3008BBE1C /* NCUtilityFileSystem.swift in Sources */,
 				F73EF7E12B02266D0087E6E9 /* NCManageDatabase+Trash.swift in Sources */,
+				AA3495002CE65EB6005CC075 /* NCManageDatabase+DownloadLimit.swift in Sources */,
 				F7C9B91F2B582F550064EA91 /* NCManageDatabase+SecurityGuard.swift in Sources */,
 				F75DD767290ABB25002EB562 /* Intent.intentdefinition in Sources */,
 				F72437812C10B92500C7C68D /* NCPermissions.swift in Sources */,

--- a/iOSClient/Data/NCManageDatabase+Capabilities.swift
+++ b/iOSClient/Data/NCManageDatabase+Capabilities.swift
@@ -88,6 +88,7 @@ extension NCManageDatabase {
                     }
 
                     struct Capabilities: Codable {
+                        let downloadLimit: DownloadLimit?
                         let filessharing: FilesSharing?
                         let theming: Theming?
                         let endtoendencryption: EndToEndEncryption?
@@ -102,6 +103,7 @@ extension NCManageDatabase {
                         let assistant: Assistant?
 
                         enum CodingKeys: String, CodingKey {
+                            case downloadLimit = "downloadlimit"
                             case filessharing = "files_sharing"
                             case theming
                             case endtoendencryption = "end-to-end-encryption"
@@ -110,6 +112,11 @@ extension NCManageDatabase {
                             case external, groupfolders
                             case securityguard = "security_guard"
                             case assistant
+                        }
+
+                        struct DownloadLimit: Codable {
+                            let enabled: Bool?
+                            let defaultLimit: Int?
                         }
 
                         struct FilesSharing: Codable {
@@ -327,6 +334,8 @@ extension NCManageDatabase {
             capabilities.capabilityFileSharingInternalExpireDateDays = data.capabilities.filessharing?.ncpublic?.expiredateinternal?.days ?? 0
             capabilities.capabilityFileSharingRemoteExpireDateEnforced = data.capabilities.filessharing?.ncpublic?.expiredateremote?.enforced ?? false
             capabilities.capabilityFileSharingRemoteExpireDateDays = data.capabilities.filessharing?.ncpublic?.expiredateremote?.days ?? 0
+            capabilities.capabilityFileSharingDownloadLimit = data.capabilities.downloadLimit?.enabled ?? false
+            capabilities.capabilityFileSharingDownloadLimitDefaultLimit = data.capabilities.downloadLimit?.defaultLimit ?? 1
 
             capabilities.capabilityThemingColor = data.capabilities.theming?.color ?? ""
             capabilities.capabilityThemingColorElement = data.capabilities.theming?.colorelement ?? ""

--- a/iOSClient/Data/NCManageDatabase+DownloadLimit.swift
+++ b/iOSClient/Data/NCManageDatabase+DownloadLimit.swift
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2024 Iva Horn
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import NextcloudKit
+import RealmSwift
+
+///
+/// Data model for storing information about download limits of shares.
+///
+class tableDownloadLimit: Object {
+    ///
+    /// The number of downloads which already happened.
+    ///
+    @Persisted
+    @objc dynamic var count: Int = 0
+
+    ///
+    /// Total number of allowed downloas.
+    ///
+    @Persisted
+    @objc dynamic var limit: Int = 0
+
+    ///
+    /// The token identifying the related share.
+    ///
+    @Persisted(primaryKey: true)
+    @objc dynamic var token: String = ""
+}
+
+extension NCManageDatabase {
+    ///
+    /// Create a new download limit object in the database.
+    ///
+    @discardableResult
+    func createDownloadLimit(count: Int, limit: Int, token: String) throws -> tableDownloadLimit? {
+        let downloadLimit = tableDownloadLimit()
+        downloadLimit.count = count
+        downloadLimit.limit = limit
+        downloadLimit.token = token
+
+        do {
+            let realm = try Realm()
+
+            try realm.write {
+                realm.add(downloadLimit, update: .all)
+            }
+        } catch let error as NSError {
+            NextcloudKit.shared.nkCommonInstance.writeLog("[ERROR] Could not write to database: \(error)")
+        }
+
+        return downloadLimit
+    }
+
+    ///
+    /// Delete an existing download limit object identified by the token of its related share.
+    ///
+    /// - Parameter token: The `token` of the associated ``Nextcloud/tableShare/token``.
+    ///
+    func deleteDownloadLimit(byShareToken token: String) throws {
+        do {
+            let realm = try Realm()
+
+            try realm.write {
+                let result = realm.objects(tableDownloadLimit.self).filter("token == %@", token)
+                realm.delete(result)
+            }
+        } catch let error as NSError {
+            NextcloudKit.shared.nkCommonInstance.writeLog("[ERROR] Could not write to database: \(error)")
+        }
+    }
+
+    ///
+    /// Retrieve a download limit by the token of the associated ``Nextcloud/tableShare/token``.
+    ///
+    /// - Parameter token: The `token` of the associated ``tableShare``.
+    ///
+    func getDownloadLimit(byShareToken token: String) throws -> tableDownloadLimit? {
+        do {
+            let realm = try Realm()
+            let predicate = NSPredicate(format: "token == %@", token)
+
+            guard let result = realm.objects(tableDownloadLimit.self).filter(predicate).first else {
+                return nil
+            }
+
+            return result
+        } catch let error as NSError {
+            NextcloudKit.shared.nkCommonInstance.writeLog("[ERROR] Could not access database: \(error)")
+        }
+
+        return nil
+    }
+}

--- a/iOSClient/Data/NCManageDatabase+DownloadLimit.swift
+++ b/iOSClient/Data/NCManageDatabase+DownloadLimit.swift
@@ -17,7 +17,7 @@ class tableDownloadLimit: Object {
     @objc dynamic var count: Int = 0
 
     ///
-    /// Total number of allowed downloas.
+    /// Total number of allowed downloads.
     ///
     @Persisted
     @objc dynamic var limit: Int = 0

--- a/iOSClient/Data/NCManageDatabase.swift
+++ b/iOSClient/Data/NCManageDatabase.swift
@@ -84,7 +84,8 @@ class NCManageDatabase: NSObject {
                                 tableDashboardWidget.self,
                                 tableDashboardWidgetButton.self,
                                 NCDBLayoutForView.self,
-                                TableSecurityGuardDiagnostics.self]
+                                TableSecurityGuardDiagnostics.self,
+                                tableDownloadLimit.self]
 
         // Disable file protection for directory DB
         // https://docs.mongodb.com/realm/sdk/ios/examples/configure-and-open-a-realm/#std-label-ios-open-a-local-realm

--- a/iOSClient/Menu/NCShare+Menu.swift
+++ b/iOSClient/Menu/NCShare+Menu.swift
@@ -54,6 +54,7 @@ extension NCShare {
                     advancePermission.share = tableShare(value: share)
                     advancePermission.oldTableShare = tableShare(value: share)
                     advancePermission.metadata = self.metadata
+                    advancePermission.downloadLimit = try? self.database.getDownloadLimit(byShareToken: share.token)
                     navigationController.pushViewController(advancePermission, animated: true)
                 }
             )

--- a/iOSClient/NCCapabilities.swift
+++ b/iOSClient/NCCapabilities.swift
@@ -46,6 +46,8 @@ public class NCCapabilities: NSObject {
         var capabilityFileSharingRemoteExpireDateEnforced: Bool     = false
         var capabilityFileSharingRemoteExpireDateDays: Int          = 0
         var capabilityFileSharingDefaultPermission: Int             = 0
+        var capabilityFileSharingDownloadLimit: Bool                = false
+        var capabilityFileSharingDownloadLimitDefaultLimit: Int     = 1
         var capabilityThemingColor: String                          = ""
         var capabilityThemingColorElement: String                   = ""
         var capabilityThemingColorText: String                      = ""

--- a/iOSClient/Settings/Advanced/Capabilities/NCCapabilitiesModel.swift
+++ b/iOSClient/Settings/Advanced/Capabilities/NCCapabilitiesModel.swift
@@ -10,6 +10,11 @@ import Foundation
 import UIKit
 import SwiftUI
 
+///
+/// Data model for ``NCCapabilitiesView``.
+///
+/// Compiles capabilities, their availability and symbol images for display.
+///
 class NCCapabilitiesModel: ObservableObject, ViewOnAppearHandling {
     struct Capability: Identifiable, Hashable {
         let id = UUID()
@@ -43,6 +48,9 @@ class NCCapabilitiesModel: ObservableObject, ViewOnAppearHandling {
 
         var image = utility.loadImage(named: "person.fill.badge.plus")
         capabililies.append(Capability(text: "File sharing", image: image, resize: false, available: capability.capabilityFileSharingApiEnabled))
+
+        image = utility.loadImage(named: "gauge.with.dots.needle.bottom.100percent")
+        capabililies.append(Capability(text: "Download Limit", image: image, resize: false, available: capability.capabilityFileSharingDownloadLimit))
 
         image = utility.loadImage(named: "network")
         capabililies.append(Capability(text: "External site", image: image, resize: false, available: capability.capabilityExternalSites))

--- a/iOSClient/Share/Advanced/DownloadLimit/NCShareDownloadLimitTableViewController.swift
+++ b/iOSClient/Share/Advanced/DownloadLimit/NCShareDownloadLimitTableViewController.swift
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2024 Iva Horn
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import NextcloudKit
+import UIKit
+
+///
+/// View controller for the table view managing the input form for download limits.
+///
+/// This child view controller is required because table views require a dedicated table view controller.
+///
+class NCShareDownloadLimitTableViewController: UITableViewController {
+    let database = NCManageDatabase.shared
+
+    ///
+    /// The initial state injected from the parent view controller on appearance.
+    ///
+    public var initialDownloadLimit: tableDownloadLimit?
+    public var metadata: tableMetadata!
+    public var share: NCTableShareable!
+
+    ///
+    /// Default value for limits as possibly provided by the server capabilities.
+    ///
+    var defaultLimit: Int {
+        NCCapabilities.shared.getCapabilities(account: metadata.account).capabilityFileSharingDownloadLimitDefaultLimit
+    }
+
+    ///
+    /// Share token required to work with download limits.
+    ///
+    private var token: String!
+
+    ///
+    /// The final state to apply once the view is about to disappear.
+    ///
+    private var finalDownloadLimit: tableDownloadLimit?
+
+    private var networking: NCShareDownloadLimitNetworking!
+
+    @IBOutlet var limitSwitch: UISwitch!
+    @IBOutlet var limitTextField: UITextField!
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if let initialDownloadLimit {
+            limitSwitch.isOn = true
+            limitTextField.text = "\(initialDownloadLimit.limit)"
+
+            finalDownloadLimit = tableDownloadLimit()
+            finalDownloadLimit?.count = initialDownloadLimit.count
+            finalDownloadLimit?.limit = initialDownloadLimit.limit
+            finalDownloadLimit?.token = initialDownloadLimit.token
+        } else {
+            limitSwitch.isOn = false
+        }
+
+        if let token = self.database.getTableShare(account: metadata.account, idShare: share.idShare)?.token {
+            self.token = token
+        } else {
+            NextcloudKit.shared.nkCommonInstance.writeLog("[ERROR] Failed to resolve share token!")
+            self.token = ""
+        }
+
+        networking = NCShareDownloadLimitNetworking(account: metadata.account, delegate: self, token: token)
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard indexPath.row == 1 else {
+            super.tableView(tableView, didSelectRowAt: indexPath)
+            return
+        }
+
+        // The accessory text field should become first responder regardless where the user tapped in the table row.
+        limitTextField.becomeFirstResponder()
+    }
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        // Programmatically hide the limit input row depending on limit enablement.
+        if limitSwitch.isOn == false && indexPath.row == 1 {
+            return 0
+        }
+
+        return super.tableView(tableView, heightForRowAt: indexPath)
+    }
+
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if let finalDownloadLimit {
+            String(format: NSLocalizedString("_remaining_share_downloads_", comment: "Table footer text for form of configuring download limits."), finalDownloadLimit.limit - finalDownloadLimit.count)
+        } else {
+            nil
+        }
+    }
+
+    @IBAction func switchDownloadLimit(_ sender: UISwitch) {
+        if sender.isOn {
+            finalDownloadLimit = tableDownloadLimit()
+            finalDownloadLimit?.count = 0
+            finalDownloadLimit?.limit = defaultLimit
+            finalDownloadLimit?.token = token
+
+            limitTextField.text = String(defaultLimit)
+        } else {
+            finalDownloadLimit = nil
+        }
+
+        tableView.reloadData()
+        dispatchShareDownloadLimitUpdate()
+    }
+
+    @IBAction func editingAllowedDownloadsDidBegin(_ sender: UITextField) {
+        sender.selectAll(nil)
+    }
+    
+    @IBAction func editingAllowedDownloadsDidEnd(_ sender: UITextField) {
+        finalDownloadLimit?.limit = Int(sender.text ?? "1") ?? defaultLimit
+        finalDownloadLimit?.count = 0
+
+        tableView.reloadData()
+        dispatchShareDownloadLimitUpdate()
+    }
+
+    func dispatchShareDownloadLimitUpdate() {
+        guard let text = limitTextField.text else {
+            return
+        }
+
+        guard let limit = Int(text) else {
+            return
+        }
+
+        if limitSwitch.isOn {
+            networking.setShareDownloadLimit(limit: limit)
+        } else {
+            networking.removeShareDownloadLimit()
+        }
+    }
+}
+
+// MARK: - NCShareDownloadLimitNetworkingDelegate
+
+extension NCShareDownloadLimitTableViewController: NCShareDownloadLimitNetworkingDelegate {
+    func downloadLimitRemoved(by token: String, in account: String) {
+        do {
+            try self.database.deleteDownloadLimit(byShareToken: token)
+        } catch {
+            NextcloudKit.shared.nkCommonInstance.writeLog("[ERROR] Failed to delete download limit in database!")
+        }
+    }
+
+    func downloadLimitSet(to limit: Int, by token: String, in account: String) {
+        do {
+            try self.database.createDownloadLimit(count: 0, limit: limit, token: token)
+        } catch {
+            NextcloudKit.shared.nkCommonInstance.writeLog("[ERROR] Failed to create download limit in database!")
+        }
+    }
+}

--- a/iOSClient/Share/Advanced/DownloadLimit/NCShareDownloadLimitViewController.swift
+++ b/iOSClient/Share/Advanced/DownloadLimit/NCShareDownloadLimitViewController.swift
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2024 Iva Horn
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import UIKit
+import NextcloudKit
+
+///
+/// View controller for the download limit detail view in share details.
+///
+class NCShareDownloadLimitViewController: UIViewController, NCShareDetail {
+    public var downloadLimit: tableDownloadLimit?
+    public var metadata: tableMetadata!
+    public var onDismiss: (() -> Void)?
+    public var share: NCTableShareable!
+
+    @IBOutlet var headerContainerView: UIView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setNavigationTitle()
+
+        // Set up header view.
+
+        guard let headerView = (Bundle.main.loadNibNamed("NCShareHeader", owner: self, options: nil)?.first as? NCShareHeader) else { return }
+        headerContainerView.addSubview(headerView)
+        headerView.frame = headerContainerView.frame
+        headerView.translatesAutoresizingMaskIntoConstraints = false
+        headerView.topAnchor.constraint(equalTo: headerContainerView.topAnchor).isActive = true
+        headerView.bottomAnchor.constraint(equalTo: headerContainerView.bottomAnchor).isActive = true
+        headerView.leftAnchor.constraint(equalTo: headerContainerView.leftAnchor).isActive = true
+        headerView.rightAnchor.constraint(equalTo: headerContainerView.rightAnchor).isActive = true
+
+        headerView.setupUI(with: metadata)
+
+        // End editing of inputs when the user taps anywhere else.
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tapGesture)
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let tableViewController = segue.destination as? NCShareDownloadLimitTableViewController else {
+            return
+        }
+
+        tableViewController.initialDownloadLimit = downloadLimit
+        tableViewController.metadata = metadata
+        tableViewController.share = share
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}

--- a/iOSClient/Share/Advanced/NCShareAdvancePermission.swift
+++ b/iOSClient/Share/Advanced/NCShareAdvancePermission.swift
@@ -71,6 +71,7 @@ class NCShareAdvancePermission: UITableViewController, NCShareAdvanceFotterDeleg
     var share: NCTableShareable!
     var isNewShare: Bool { share is NCTableShareOptions }
     var metadata: tableMetadata!
+    var downloadLimit: tableDownloadLimit?
     var shareConfig: NCShareConfig!
     var networking: NCShareNetworking?
 
@@ -165,6 +166,14 @@ class NCShareAdvancePermission: UITableViewController, NCShareAdvanceFotterDeleg
         }
 
         switch cellConfig {
+        case .limitDownload:
+            let storyboard = UIStoryboard(name: "NCShare", bundle: nil)
+            guard let viewController = storyboard.instantiateViewController(withIdentifier: "NCShareDownloadLimit") as? NCShareDownloadLimitViewController else { return }
+            viewController.downloadLimit = self.downloadLimit
+            viewController.metadata = self.metadata
+            viewController.share = self.share
+            viewController.onDismiss = tableView.reloadData
+            self.navigationController?.pushViewController(viewController, animated: true)
         case .hideDownload:
             share.hideDownload.toggle()
             tableView.reloadData()

--- a/iOSClient/Share/Advanced/NCShareCells.swift
+++ b/iOSClient/Share/Advanced/NCShareCells.swift
@@ -192,10 +192,14 @@ enum NCLinkPermission: NCPermission {
     static let forFile: [NCLinkPermission] = [.allowEdit]
 }
 
+///
+/// Individual aspects of share.
+///
 enum NCShareDetails: CaseIterable, NCShareCellConfig {
     func didSelect(for share: NCTableShareable) {
         switch self {
         case .hideDownload: share.hideDownload.toggle()
+        case .limitDownload: return
         case .expirationDate: return
         case .password: return
         case .note: return
@@ -207,6 +211,10 @@ enum NCShareDetails: CaseIterable, NCShareCellConfig {
         switch self {
         case .hideDownload:
             return NCShareToggleCell(isOn: share.hideDownload)
+        case .limitDownload:
+            let cell = UITableViewCell(style: .value1, reuseIdentifier: "downloadLimit")
+            cell.accessoryType = .disclosureIndicator
+            return cell
         case .expirationDate:
             return NCShareDateCell(share: share)
         case .password: return NCShareToggleCell(isOn: !share.password.isEmpty, customIcons: ("lock", "lock_open"))
@@ -225,6 +233,7 @@ enum NCShareDetails: CaseIterable, NCShareCellConfig {
     var title: String {
         switch self {
         case .hideDownload: return NSLocalizedString("_share_hide_download_", comment: "")
+        case .limitDownload: return NSLocalizedString("_share_limit_download_", comment: "")
         case .expirationDate: return NSLocalizedString("_share_expiration_date_", comment: "")
         case .password: return NSLocalizedString("_share_password_protect_", comment: "")
         case .note: return NSLocalizedString("_share_note_recipient_", comment: "")
@@ -232,7 +241,7 @@ enum NCShareDetails: CaseIterable, NCShareCellConfig {
         }
     }
 
-    case label, hideDownload, expirationDate, password, note
+    case label, hideDownload, limitDownload, expirationDate, password, note
     static let forLink: [NCShareDetails] = NCShareDetails.allCases
     static let forUser: [NCShareDetails] = [.expirationDate, .note]
 }
@@ -248,7 +257,16 @@ struct NCShareConfig {
         self.resharePermission = parentMetadata.sharePermissionsCollaborationServices
         let type: NCPermission.Type = share.shareType == NCShareCommon().SHARE_TYPE_LINK ? NCLinkPermission.self : NCUserPermission.self
         self.permissions = parentMetadata.directory ? (parentMetadata.e2eEncrypted ? type.forDirectoryE2EE(account: parentMetadata.account) : type.forDirectory) : type.forFile
-        self.advanced = share.shareType == NCShareCommon().SHARE_TYPE_LINK ? NCShareDetails.forLink : NCShareDetails.forUser
+
+        if share.shareType == NCShareCommon().SHARE_TYPE_LINK {
+            if NCCapabilities.shared.getCapabilities(account: parentMetadata.account).capabilityFileSharingDownloadLimit {
+                self.advanced = NCShareDetails.forLink
+            } else {
+                self.advanced = NCShareDetails.forLink.filter { $0 != .limitDownload }
+            }
+        } else {
+            self.advanced = NCShareDetails.forUser
+        }
     }
 
     func cellFor(indexPath: IndexPath) -> UITableViewCell? {
@@ -273,116 +291,5 @@ struct NCShareConfig {
         } else if indexPath.section == 1, indexPath.row < advanced.count {
             return advanced[indexPath.row]
         } else { return nil }
-    }
-}
-
-class NCShareToggleCell: UITableViewCell {
-    typealias CustomToggleIcon = (onIconName: String?, offIconName: String?)
-    init(isOn: Bool, customIcons: CustomToggleIcon? = nil) {
-        super.init(style: .default, reuseIdentifier: "toggleCell")
-        self.accessibilityValue = isOn ? NSLocalizedString("_on_", comment: "") : NSLocalizedString("_off_", comment: "")
-
-        guard let customIcons = customIcons,
-              let iconName = isOn ? customIcons.onIconName : customIcons.offIconName else {
-            self.accessoryType = isOn ? .checkmark : .none
-            return
-        }
-        let image = NCUtility().loadImage(named: iconName, colors: [NCBrandColor.shared.customer], size: self.frame.height - 26)
-        self.accessoryView = UIImageView(image: image)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
-class NCShareDateCell: UITableViewCell {
-    let picker = UIDatePicker()
-    let textField = UITextField()
-    var shareType: Int
-    var onReload: (() -> Void)?
-    let shareCommon = NCShareCommon()
-
-    init(share: NCTableShareable) {
-        self.shareType = share.shareType
-        super.init(style: .value1, reuseIdentifier: "shareExpDate")
-
-        picker.datePickerMode = .date
-        picker.minimumDate = Date()
-        picker.preferredDatePickerStyle = .wheels
-        picker.action(for: .valueChanged) { datePicker in
-            guard let datePicker = datePicker as? UIDatePicker else { return }
-            self.detailTextLabel?.text = DateFormatter.shareExpDate.string(from: datePicker.date)
-        }
-        accessoryView = textField
-
-        let toolbar = UIToolbar.toolbar {
-            self.resignFirstResponder()
-            share.expirationDate = nil
-            self.onReload?()
-        } onDone: {
-            self.resignFirstResponder()
-            share.expirationDate = self.picker.date as NSDate
-            self.onReload?()
-        }
-
-        textField.isAccessibilityElement = false
-        textField.accessibilityElementsHidden = true
-        textField.inputAccessoryView = toolbar.wrappedSafeAreaContainer
-        textField.inputView = picker
-
-        if let expDate = share.expirationDate {
-            detailTextLabel?.text = DateFormatter.shareExpDate.string(from: expDate as Date)
-        }
-    }
-
-    required public init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func checkMaximumDate(account: String) {
-        let defaultExpDays = defaultExpirationDays(account: account)
-        if defaultExpDays > 0 && isExpireDateEnforced(account: account) {
-            let enforcedInSecs = TimeInterval(defaultExpDays * 24 * 60 * 60)
-            self.picker.maximumDate = Date().advanced(by: enforcedInSecs)
-        }
-    }
-
-    private func isExpireDateEnforced(account: String) -> Bool {
-        switch self.shareType {
-        case shareCommon.SHARE_TYPE_LINK,
-            shareCommon.SHARE_TYPE_EMAIL,
-            shareCommon.SHARE_TYPE_GUEST:
-            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingPubExpireDateEnforced
-        case shareCommon.SHARE_TYPE_USER,
-            shareCommon.SHARE_TYPE_GROUP,
-            shareCommon.SHARE_TYPE_CIRCLE,
-            shareCommon.SHARE_TYPE_ROOM:
-            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingInternalExpireDateEnforced
-        case shareCommon.SHARE_TYPE_REMOTE,
-            shareCommon.SHARE_TYPE_REMOTE_GROUP:
-            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingRemoteExpireDateEnforced
-        default:
-            return false
-        }
-    }
-
-    private func defaultExpirationDays(account: String) -> Int {
-        switch self.shareType {
-        case shareCommon.SHARE_TYPE_LINK,
-            shareCommon.SHARE_TYPE_EMAIL,
-            shareCommon.SHARE_TYPE_GUEST:
-            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingPubExpireDateDays
-        case shareCommon.SHARE_TYPE_USER,
-            shareCommon.SHARE_TYPE_GROUP,
-            shareCommon.SHARE_TYPE_CIRCLE,
-            shareCommon.SHARE_TYPE_ROOM:
-            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingInternalExpireDateDays
-        case shareCommon.SHARE_TYPE_REMOTE,
-            shareCommon.SHARE_TYPE_REMOTE_GROUP:
-            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingRemoteExpireDateDays
-        default:
-            return 0
-        }
     }
 }

--- a/iOSClient/Share/Advanced/NCShareDateCell.swift
+++ b/iOSClient/Share/Advanced/NCShareDateCell.swift
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2022 Henrik Storch
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+///
+/// Table view cell to manage the expiration date on a share in its details.
+///
+class NCShareDateCell: UITableViewCell {
+    let picker = UIDatePicker()
+    let textField = UITextField()
+    var shareType: Int
+    var onReload: (() -> Void)?
+    let shareCommon = NCShareCommon()
+
+    init(share: NCTableShareable) {
+        self.shareType = share.shareType
+        super.init(style: .value1, reuseIdentifier: "shareExpDate")
+
+        picker.datePickerMode = .date
+        picker.minimumDate = Date()
+        picker.preferredDatePickerStyle = .wheels
+        picker.action(for: .valueChanged) { datePicker in
+            guard let datePicker = datePicker as? UIDatePicker else { return }
+            self.detailTextLabel?.text = DateFormatter.shareExpDate.string(from: datePicker.date)
+        }
+        accessoryView = textField
+
+        let toolbar = UIToolbar.toolbar {
+            self.resignFirstResponder()
+            share.expirationDate = nil
+            self.onReload?()
+        } onDone: {
+            self.resignFirstResponder()
+            share.expirationDate = self.picker.date as NSDate
+            self.onReload?()
+        }
+
+        textField.isAccessibilityElement = false
+        textField.accessibilityElementsHidden = true
+        textField.inputAccessoryView = toolbar.wrappedSafeAreaContainer
+        textField.inputView = picker
+
+        if let expDate = share.expirationDate {
+            detailTextLabel?.text = DateFormatter.shareExpDate.string(from: expDate as Date)
+        }
+    }
+
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func checkMaximumDate(account: String) {
+        let defaultExpDays = defaultExpirationDays(account: account)
+        if defaultExpDays > 0 && isExpireDateEnforced(account: account) {
+            let enforcedInSecs = TimeInterval(defaultExpDays * 24 * 60 * 60)
+            self.picker.maximumDate = Date().advanced(by: enforcedInSecs)
+        }
+    }
+
+    private func isExpireDateEnforced(account: String) -> Bool {
+        switch self.shareType {
+        case shareCommon.SHARE_TYPE_LINK,
+            shareCommon.SHARE_TYPE_EMAIL,
+            shareCommon.SHARE_TYPE_GUEST:
+            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingPubExpireDateEnforced
+        case shareCommon.SHARE_TYPE_USER,
+            shareCommon.SHARE_TYPE_GROUP,
+            shareCommon.SHARE_TYPE_CIRCLE,
+            shareCommon.SHARE_TYPE_ROOM:
+            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingInternalExpireDateEnforced
+        case shareCommon.SHARE_TYPE_REMOTE,
+            shareCommon.SHARE_TYPE_REMOTE_GROUP:
+            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingRemoteExpireDateEnforced
+        default:
+            return false
+        }
+    }
+
+    private func defaultExpirationDays(account: String) -> Int {
+        switch self.shareType {
+        case shareCommon.SHARE_TYPE_LINK,
+            shareCommon.SHARE_TYPE_EMAIL,
+            shareCommon.SHARE_TYPE_GUEST:
+            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingPubExpireDateDays
+        case shareCommon.SHARE_TYPE_USER,
+            shareCommon.SHARE_TYPE_GROUP,
+            shareCommon.SHARE_TYPE_CIRCLE,
+            shareCommon.SHARE_TYPE_ROOM:
+            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingInternalExpireDateDays
+        case shareCommon.SHARE_TYPE_REMOTE,
+            shareCommon.SHARE_TYPE_REMOTE_GROUP:
+            return NCCapabilities.shared.getCapabilities(account: account).capabilityFileSharingRemoteExpireDateDays
+        default:
+            return 0
+        }
+    }
+}

--- a/iOSClient/Share/Advanced/NCShareToggleCell.swift
+++ b/iOSClient/Share/Advanced/NCShareToggleCell.swift
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2022 Henrik Storch
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+///
+/// A table view cell for logical switches in the detaills of a share configuration.
+///
+class NCShareToggleCell: UITableViewCell {
+    typealias CustomToggleIcon = (onIconName: String?, offIconName: String?)
+    init(isOn: Bool, customIcons: CustomToggleIcon? = nil) {
+        super.init(style: .default, reuseIdentifier: "toggleCell")
+        self.accessibilityValue = isOn ? NSLocalizedString("_on_", comment: "") : NSLocalizedString("_off_", comment: "")
+
+        guard let customIcons = customIcons,
+              let iconName = isOn ? customIcons.onIconName : customIcons.offIconName else {
+            self.accessoryType = isOn ? .checkmark : .none
+            return
+        }
+        let image = NCUtility().loadImage(named: iconName, colors: [NCBrandColor.shared.customer], size: self.frame.height - 26)
+        self.accessoryView = UIImageView(image: image)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/iOSClient/Share/NCShare.storyboard
+++ b/iOSClient/Share/NCShare.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Ts3-RO-A9l">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Ts3-RO-A9l">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -247,6 +247,119 @@
             </objects>
             <point key="canvasLocation" x="4261" y="-168"/>
         </scene>
+        <!--Share Download Limit View Controller-->
+        <scene sceneID="htO-RU-Zuq">
+            <objects>
+                <viewController storyboardIdentifier="NCShareDownloadLimit" id="Mo3-9m-pYX" customClass="NCShareDownloadLimitViewController" customModule="Nextcloud" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ODc-Pp-29W">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="kCx-WL-m3f">
+                                <rect key="frame" x="0.0" y="20" width="414" height="716"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aOt-y7-Fc9">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="200" id="5MK-r1-81S"/>
+                                        </constraints>
+                                    </view>
+                                    <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QF6-o7-CuW">
+                                        <rect key="frame" x="0.0" y="200" width="414" height="516"/>
+                                        <connections>
+                                            <segue destination="z7r-s7-nxD" kind="embed" id="xjC-2g-i9X"/>
+                                        </connections>
+                                    </containerView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="i58-we-TZn"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="kCx-WL-m3f" firstAttribute="leading" secondItem="i58-we-TZn" secondAttribute="leading" id="5Xp-cY-6Wf"/>
+                            <constraint firstAttribute="trailing" secondItem="kCx-WL-m3f" secondAttribute="trailing" id="f6a-Qa-OSX"/>
+                            <constraint firstAttribute="bottom" secondItem="kCx-WL-m3f" secondAttribute="bottom" id="hWv-wm-Q31"/>
+                            <constraint firstItem="kCx-WL-m3f" firstAttribute="top" secondItem="i58-we-TZn" secondAttribute="top" id="lI5-1R-nU7"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="headerContainerView" destination="aOt-y7-Fc9" id="VB5-qx-GGN"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="l38-Wd-mtP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5018.840579710145" y="-170.38043478260872"/>
+        </scene>
+        <!--Share Download Limit Table View Controller-->
+        <scene sceneID="xXY-6h-qd9">
+            <objects>
+                <tableViewController id="z7r-s7-nxD" customClass="NCShareDownloadLimitTableViewController" customModule="Nextcloud" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="GIS-yz-DEq">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="516"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <sections>
+                            <tableViewSection footerTitle="X remaining downloads allowed" id="eag-Ek-kyv">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Nhk-Fc-G3o">
+                                        <rect key="frame" x="0.0" y="50" width="414" height="44.333332061767578"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Nhk-Fc-G3o" id="qUd-cW-Bvy">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44.333332061767578"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                        <listContentConfiguration key="contentConfiguration" text="Limit Downloads" secondaryText=""/>
+                                        <connections>
+                                            <outlet property="accessoryView" destination="nFs-et-CHB" id="8Sm-24-xgE"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="tvZ-6P-X8V">
+                                        <rect key="frame" x="0.0" y="94.333332061767578" width="414" height="44.333332061767578"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tvZ-6P-X8V" id="gDL-8G-sHX">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44.333332061767578"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                        <listContentConfiguration key="contentConfiguration" text="Allowed Downloads" secondaryText=""/>
+                                        <connections>
+                                            <outlet property="accessoryView" destination="XQ1-Wz-Q84" id="YQu-MJ-xGi"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="z7r-s7-nxD" id="bcZ-EG-Ns9"/>
+                            <outlet property="delegate" destination="z7r-s7-nxD" id="CYZ-nh-TPG"/>
+                        </connections>
+                    </tableView>
+                    <connections>
+                        <outlet property="limitSwitch" destination="nFs-et-CHB" id="VPn-S5-HsB"/>
+                        <outlet property="limitTextField" destination="XQ1-Wz-Q84" id="Wr9-ib-xta"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xFX-mf-2eM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="nFs-et-CHB">
+                    <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <connections>
+                        <action selector="switchDownloadLimit:" destination="z7r-s7-nxD" eventType="valueChanged" id="BgD-7W-XjM"/>
+                    </connections>
+                </switch>
+                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="right" contentVerticalAlignment="center" text="1" textAlignment="right" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" id="XQ1-Wz-Q84">
+                    <rect key="frame" x="0.0" y="0.0" width="97" height="34"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                    <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad" returnKeyType="done"/>
+                    <connections>
+                        <action selector="editingAllowedDownloadsDidBegin:" destination="z7r-s7-nxD" eventType="editingDidBegin" id="aN8-OV-iMc"/>
+                        <action selector="editingAllowedDownloadsDidEnd:" destination="z7r-s7-nxD" eventType="editingDidEnd" id="hqq-ag-KN9"/>
+                    </connections>
+                </textField>
+            </objects>
+            <point key="canvasLocation" x="6554" y="-170"/>
+        </scene>
         <!--Share Advance Permission-->
         <scene sceneID="59b-BB-FLA">
             <objects>
@@ -282,16 +395,16 @@
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondarySystemBackgroundColor">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="tertiaryLabelColor">
-            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29803921570000003" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29803921568627451" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOSClient/Share/NCShareDownloadLimitNetworking.swift
+++ b/iOSClient/Share/NCShareDownloadLimitNetworking.swift
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2024 Iva Horn
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import UIKit
+import NextcloudKit
+
+///
+/// Delegate requirements for ``NCShareDownloadLimitNetworking`` to handle results.
+///
+protocol NCShareDownloadLimitNetworkingDelegate: AnyObject {
+    ///
+    /// The download limit was successfully removed from the share on the server.
+    ///
+    func downloadLimitRemoved(by token: String, in account: String)
+
+    ///
+    /// The download limit was successfully removed from the share on the server.
+    ///
+    func downloadLimitSet(to limit: Int, by token: String, in account: String)
+}
+
+///
+/// Share-bound network abstraction for download limits.
+///
+class NCShareDownloadLimitNetworking: NSObject {
+    let account: String
+    weak var delegate: (any NCShareDownloadLimitNetworkingDelegate)?
+    weak var view: UIView?
+    let token: String
+
+    init(account: String, delegate: (any NCShareDownloadLimitNetworkingDelegate)?, token: String) {
+        self.account = account
+        self.delegate = delegate
+        self.token = token
+    }
+
+    ///
+    /// Remove the download limit on the share, if existent.
+    ///
+    func removeShareDownloadLimit() {
+        NCActivityIndicator.shared.start(backgroundView: view)
+        NextcloudKit.shared.removeShareDownloadLimit(account: account, token: token) { error in
+            NCActivityIndicator.shared.stop()
+
+            if error == .success {
+                self.delegate?.downloadLimitRemoved(by: self.token, in: self.account)
+            } else {
+                NCContentPresenter().showError(error: error)
+            }
+        }
+    }
+
+    ///
+    /// Set the download limit for the share.
+    ///
+    /// - Parameter limit: The new download limit to set.
+    ///
+    func setShareDownloadLimit(limit: Int) {
+        NCActivityIndicator.shared.start(backgroundView: view)
+        NextcloudKit.shared.setShareDownloadLimit(account: account, token: token, limit: limit) { error in
+            NCActivityIndicator.shared.stop()
+
+            if error == .success {
+                self.delegate?.downloadLimitSet(to: limit, by: self.token, in: self.account)
+            } else {
+                NCContentPresenter().showError(error: error)
+            }
+        }
+    }
+}

--- a/iOSClient/Supporting Files/en.lproj/Localizable.strings
+++ b/iOSClient/Supporting Files/en.lproj/Localizable.strings
@@ -677,6 +677,9 @@
 "_share_file_drop_"             = "File drop (upload only)";
 "_share_secure_file_drop_"      = "Secure file drop (upload only)";
 "_share_hide_download_"         = "Hide download";
+"_share_limit_download_"        = "Limit downloads";
+"_remaining_share_downloads_"   = "%d remaining downloads allowed";
+"_remaining_"                   = "%d remaining";
 "_share_password_protect_"      = "Password protect";
 "_share_expiration_date_"       = "Set expiration date";
 "_share_note_recipient_"        = "Note to recipient";


### PR DESCRIPTION
- Added tableDownloadLimit entity to app database.
- Extended capability query to also consider download limit app.
- Extended capabilities list view for display of download limit availability.
- Extended share detail user interface to mimic the web user interface for managing download limits.
- Every time WebDAV properties of a file are retrieved, its associated download limits are removed and recreated.

Housekeeping:
- Outsourced NCShareDateCell into dedicated source code file.
- Outsourced NCShareToggleCell into dedicated source code file.

Notes:
- In my first attempt I had a detail view in the download limit row of the advanced share options showing the remaining number of downloads. However, that required to inject and retain the download limit entity object into the complicated share table configuration object. That, in turn, results in inconsistent data state due to invalid and outdated references. To resolve those issues, the assembly of the advanced share options user interface needs some refactoring which appears to expansive at this point and I prefer to leave it as it is for now.