### PR TITLE
#3169 fix ssl client certificate

### DIFF
--- a/iOSClient/Login/NCLogin.swift
+++ b/iOSClient/Login/NCLogin.swift
@@ -188,6 +188,8 @@ class NCLogin: UIViewController, UITextFieldDelegate, NCLoginQRCodeDelegate {
                  return outgoing
              }
         }
+        
+        NCNetworking.shared.certificateDelegate = self
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/iOSClient/Login/NCLogin.swift
+++ b/iOSClient/Login/NCLogin.swift
@@ -468,7 +468,9 @@ extension NCLogin: ClientCertificateDelegate, UIDocumentPickerDelegate {
             documentProviderMenu.delegate = self
             self.present(documentProviderMenu, animated: true, completion: nil)
         }))
-        present(alertNoCertFound, animated: true)
+        DispatchQueue.main.async {
+            self.present(alertNoCertFound, animated: true)
+        }
     }
 
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
@@ -483,7 +485,9 @@ extension NCLogin: ClientCertificateDelegate, UIDocumentPickerDelegate {
         alertEnterPassword.addTextField { textField in
             textField.isSecureTextEntry = true
         }
-        present(alertEnterPassword, animated: true)
+        DispatchQueue.main.async {
+            self.present(alertEnterPassword, animated: true)
+        }
     }
 
     func onIncorrectPassword() {
@@ -491,6 +495,8 @@ extension NCLogin: ClientCertificateDelegate, UIDocumentPickerDelegate {
         NCNetworking.shared.p12Password = nil
         let alertWrongPassword = UIAlertController(title: NSLocalizedString("_client_cert_wrong_password_", comment: ""), message: "", preferredStyle: .alert)
         alertWrongPassword.addAction(UIAlertAction(title: NSLocalizedString("_ok_", comment: ""), style: .default))
-        present(alertWrongPassword, animated: true)
+        DispatchQueue.main.async {
+            self.present(alertWrongPassword, animated: true)
+        }
     }
 }

--- a/iOSClient/Networking/NCNetworking.swift
+++ b/iOSClient/Networking/NCNetworking.swift
@@ -147,7 +147,7 @@ class NCNetworking: NSObject, NextcloudKitDelegate {
                 completionHandler(URLSession.AuthChallengeDisposition.useCredential, creds)
             } else {
                 self.certificateDelegate?.didAskForClientCertificate()
-                completionHandler(URLSession.AuthChallengeDisposition.performDefaultHandling, nil)
+                completionHandler(URLSession.AuthChallengeDisposition.cancelAuthenticationChallenge, nil)
             }
         } else {
             self.checkTrustedChallenge(session, didReceive: challenge, completionHandler: completionHandler)


### PR DESCRIPTION
Issue #3169

I tested SSL Client Certificate authentication and found that it didn't really work for me.

`NCLogin` does not set itself as `certificateDelegate` of `NCNetworking` hence its delegate methods are never called if NSURLAuthenticationMethodClientCertificate is received in `NCNetworking.authenticationChallenge didReceive challenge`

UIAlertControllers in `NCLogin` are not presented on the main thread

These two changes correctly prompt for a certificate file to pick and also ask for a certificate password.

However, once the login flow is restarted after `p12Data` is set, `authenticationChallenge didReceive challenge` wasn't called once more, I suspect due to a reuse of the underlying SSL session.

I found that instead of the default action, it is better to cancel the authentication challenge if `didAskForClientCertificate()` is called on the delegate. This leads to the challenge being received and now properly answered with the client certificate.