### PR TITLE
fix: flip lat/lon from exif to negative when needed

### DIFF
--- a/iOSClient/Utility/NCUtility+Exif.swift
+++ b/iOSClient/Utility/NCUtility+Exif.swift
@@ -130,7 +130,13 @@ extension NCUtility {
             data.hPositioningError = gpsData[kCGImagePropertyGPSHPositioningError] as? String
             data.imgDirection = gpsData[kCGImagePropertyGPSImgDirection] as? String
             data.latitude = gpsData[kCGImagePropertyGPSLatitude] as? Double
+            if gpsData[kCGImagePropertyGPSLatitudeRef] as? String == "S" {
+                data.latitude! *= -1
+            }
             data.longitude = gpsData[kCGImagePropertyGPSLongitude] as? Double
+            if gpsData[kCGImagePropertyGPSLongitudeRef] as? String == "W" {
+                data.longitude! *= -1
+            }
             data.speed = gpsData[kCGImagePropertyGPSSpeed] as? Double
         }
 


### PR DESCRIPTION
### Fix GPS Coordinate Sign Handling

#### Summary:
This update ensures that latitude and longitude values are correctly signed based on their reference (`N/S` for latitude, `E/W` for longitude) when extracting EXIF GPS metadata.

#### Changes:
- If `kCGImagePropertyGPSLatitudeRef` is `"S"`, negate `latitude` to reflect the southern hemisphere.
- If `kCGImagePropertyGPSLongitudeRef` is `"W"`, negate `longitude` to reflect the western hemisphere.

#### Why?
Previously, latitude and longitude were assigned without considering their reference direction, potentially leading to incorrect coordinate values. This fix ensures extracted GPS data is numerically accurate.

#### Impact:
- Prevents incorrect GPS positioning for images taken in the southern or western hemispheres.
- Ensures compatibility with mapping and geolocation services.

Let me know if any refinements are needed! 🚀

This resolves https://github.com/nextcloud/ios/issues/3044