### PR TITLE
Disable Activity field in More if app is disabled

### DIFF
--- a/iOSClient/Data/NCManageDatabase+Capabilities.swift
+++ b/iOSClient/Data/NCManageDatabase+Capabilities.swift
@@ -362,6 +362,8 @@ extension NCManageDatabase {
 
             capabilities.capabilityAssistantEnabled = data.capabilities.assistant?.enabled ?? false
 
+            capabilities.capabilityActivityEnabled = data.capabilities.activity != nil
+            
             capabilities.capabilityActivity.removeAll()
             if let activities = data.capabilities.activity?.apiv2 {
                 for activity in activities {

--- a/iOSClient/More/NCMore.swift
+++ b/iOSClient/More/NCMore.swift
@@ -116,13 +116,15 @@ class NCMore: UIViewController, UITableViewDelegate, UITableViewDataSource {
         item.order = 20
         functionMenu.append(item)
 
-        // ITEM : Activity
-        item = NKExternalSite()
-        item.name = "_activity_"
-        item.icon = "bolt"
-        item.url = "segueActivity"
-        item.order = 30
-        functionMenu.append(item)
+        if capabilities.capabilityActivityEnabled {
+            // ITEM : Activity
+            item = NKExternalSite()
+            item.name = "_activity_"
+            item.icon = "bolt"
+            item.url = "segueActivity"
+            item.order = 30
+            functionMenu.append(item)
+        }
 
         if capabilities.capabilityAssistantEnabled, NCBrandOptions.shared.disable_show_more_nextcloud_apps_in_settings {
             // ITEM : Assistant

--- a/iOSClient/NCCapabilities.swift
+++ b/iOSClient/NCCapabilities.swift
@@ -65,6 +65,7 @@ final public class NCCapabilities: Sendable {
         var capabilityFilesBigfilechunking: Bool                    = false
         var capabilityUserStatusEnabled: Bool                       = false
         var capabilityExternalSites: Bool                           = false
+        var capabilityActivityEnabled: Bool                         = false
         var capabilityGroupfoldersEnabled: Bool                     = false // NC27
         var capabilityAssistantEnabled: Bool                        = false // NC28
         var isLivePhotoServerAvailable: Bool                        = false // NC28


### PR DESCRIPTION
When Activity app is not enabled there is no Activity option in More:

<img width="243" alt="image" src="https://github.com/user-attachments/assets/f9859d44-3407-47bd-82b3-6e6daa8710c9" />
