### PR TITLE
Changed NextcloudKit branch reference from "assistant-v2" to "develop"

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -6179,7 +6179,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nextcloud/NextcloudKit";
 			requirement = {
-				branch = "assistant-v2";
+				branch = develop;
 				kind = branch;
 			};
 		};


### PR DESCRIPTION
The reference broke in example the polling fix. Also, the feature branch in NextcloudKit was already integrated into `develop` there.

Either Nextcloud develop refers to develop or some specific tag but randomly changing branch references will cause confusion to chaos with multiple simultaneous contributors.