### PR TITLE
Update NCNetworking+WebDAV.swift

### DIFF
--- a/iOSClient/Networking/NCNetworking+WebDAV.swift
+++ b/iOSClient/Networking/NCNetworking+WebDAV.swift
@@ -56,7 +56,7 @@ extension NCNetworking {
                                              depth: "1",
                                              showHiddenFiles: NCKeychain().showHiddenFiles,
                                              account: account,
-                                             options: NKRequestOptions(queue: queue)) { task in
+                                             options: NKRequestOptions(queue: queue, timeout: 300)) { task in
             taskHandler(task)
         } completion: { account, files, responseData, error in
             guard error == .success, let files else {


### PR DESCRIPTION
Extending timeout for webdav folder reads to 5min to allow for Scanning folders with large number of files.

Editing and further testing by maintainers appreciated.