### PR TITLE
Fixed login grant handler continuation leak

### DIFF
--- a/iOSClient/Login/NCLoginProvider.swift
+++ b/iOSClient/Login/NCLoginProvider.swift
@@ -120,8 +120,8 @@ class NCLoginProvider: UIViewController {
 
     private func handleGrant(urlBase: String, loginName: String, appPassword: String) async {
         await withCheckedContinuation { continuation in
-            if self.controller == nil {
-                self.controller = UIApplication.shared.firstWindow?.rootViewController as? NCMainTabBarController
+            if controller == nil {
+                controller = UIApplication.shared.firstWindow?.rootViewController as? NCMainTabBarController
             }
 
             NCAccount().createAccount(viewController: self, urlBase: urlBase, user: loginName, password: appPassword, controller: controller) {

--- a/iOSClient/NCAccount.swift
+++ b/iOSClient/NCAccount.swift
@@ -87,6 +87,8 @@ class NCAccount: NSObject {
                 alertController.addAction(UIAlertAction(title: NSLocalizedString("_ok_", comment: ""), style: .default, handler: { _ in }))
                 viewController.present(alertController, animated: true)
             }
+
+            completion()
         }
     }
 


### PR DESCRIPTION
`NCAccount.createAccount()` has a completion handler argument which was not called in the implementation. Probably an oversight which did not surface yet.