### PR TITLE
Added verbose logging to the login polling.

### DIFF
--- a/Brand/Intro/NCIntroViewController.swift
+++ b/Brand/Intro/NCIntroViewController.swift
@@ -189,7 +189,7 @@ class NCIntroViewController: UIViewController, UICollectionViewDataSource, UICol
     @IBAction func signupWithProvider(_ sender: Any) {
         if let viewController = UIStoryboard(name: "NCLogin", bundle: nil).instantiateViewController(withIdentifier: "NCLoginProvider") as? NCLoginProvider {
             viewController.controller = self.controller
-            viewController.urlBase = NCBrandOptions.shared.linkloginPreferredProviders
+            viewController.initialURLString = NCBrandOptions.shared.linkloginPreferredProviders
             self.navigationController?.pushViewController(viewController, animated: true)
         }
     }

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -6233,8 +6233,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nextcloud/NextcloudKit";
 			requirement = {
-				kind = exactVersion;
-				version = 6.0.10;
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.0.10;
 			};
 		};
 		F788ECC5263AAAF900ADC67F /* XCRemoteSwiftPackageReference "MarkdownKit" */ = {

--- a/iOSClient/Login/NCLogin.swift
+++ b/iOSClient/Login/NCLogin.swift
@@ -328,8 +328,9 @@ class NCLogin: UIViewController, UITextFieldDelegate, NCLoginQRCodeDelegate {
                 NextcloudKit.shared.getLoginFlowV2(serverUrl: url, options: loginOptions) { [self] token, endpoint, login, _, error in
                     // Login Flow V2
                     if error == .success, let token, let endpoint, let login {
+                        NextcloudKit.shared.nkCommonInstance.writeLog(info: "Successfully received login flow information.")
                         let safariVC = NCLoginProvider()
-                        safariVC.urlBase = login
+                        safariVC.initialURLString = login
                         safariVC.uiColor = textColor
                         safariVC.delegate = self
                         safariVC.startPolling(loginFlowV2Token: token, loginFlowV2Endpoint: endpoint, loginFlowV2Login: login)
@@ -419,11 +420,15 @@ class NCLogin: UIViewController, UITextFieldDelegate, NCLoginQRCodeDelegate {
     }
 }
 
+// MARK: - NCShareAccountsDelegate
+
 extension NCLogin: NCShareAccountsDelegate {
     func selected(url: String, user: String) {
         isUrlValid(url: url, user: user)
     }
 }
+
+// MARK: - UIDocumentPickerDelegate
 
 extension NCLogin: ClientCertificateDelegate, UIDocumentPickerDelegate {
     func didAskForClientCertificate() {
@@ -465,6 +470,8 @@ extension NCLogin: ClientCertificateDelegate, UIDocumentPickerDelegate {
         }
     }
 }
+
+// MARK: - NCLoginProviderDelegate
 
 extension NCLogin: NCLoginProviderDelegate {
     func onBack() {

--- a/iOSClient/NCAccount.swift
+++ b/iOSClient/NCAccount.swift
@@ -35,6 +35,8 @@ class NCAccount: NSObject {
                        password: String,
                        controller: NCMainTabBarController?,
                        completion: @escaping () -> Void = {}) {
+        NextcloudKit.shared.nkCommonInstance.writeLog(info: "Creating account...")
+
         var urlBase = urlBase
         if urlBase.last == "/" { urlBase = String(urlBase.dropLast()) }
         let account: String = "\(user) \(urlBase)"
@@ -57,19 +59,24 @@ class NCAccount: NSObject {
         NextcloudKit.shared.getUserProfile(account: account) { account, userProfile, _, error in
             if error == .success, let userProfile {
                 /// Login log debug
-                NextcloudKit.shared.nkCommonInstance.writeLog("[DEBUG] Create new account \(account) with user \(user) and userId \(userProfile.userId)")
+                NextcloudKit.shared.nkCommonInstance.writeLog(info: "Got user profile, creating new account \(account) with user \(user) and userId \(userProfile.userId)")
                 ///
                 NextcloudKit.shared.updateSession(account: account, userId: userProfile.userId)
                 NCSession.shared.appendSession(account: account, urlBase: urlBase, user: user, userId: userProfile.userId)
                 self.database.addAccount(account, urlBase: urlBase, user: user, userId: userProfile.userId, password: password)
+
                 self.changeAccount(account, userProfile: userProfile, controller: controller) {
+                    NextcloudKit.shared.nkCommonInstance.writeLog(info: "NCAccount changed user profile to \(userProfile.userId).")
                     NCKeychain().setClientCertificate(account: account, p12Data: NCNetworking.shared.p12Data, p12Password: NCNetworking.shared.p12Password)
+
                     if let controller {
                         controller.account = account
+                        NextcloudKit.shared.nkCommonInstance.writeLog(info: "Dismissing login provider view controller...")
                         viewController.dismiss(animated: true)
 
                         completion()
                     } else if let controller = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? NCMainTabBarController {
+                        NextcloudKit.shared.nkCommonInstance.writeLog(info: "Presenting initial view controller from main storyboard...")
                         controller.account = account
                         controller.modalPresentationStyle = .fullScreen
                         controller.view.alpha = 0


### PR DESCRIPTION
- Removed user-defined device name from user agent string because since iOS 16 only a generic one is returned for privacy reasons anway. This also makes the user agent string consistent with other requests from the iOS app so server logs can be filtered correctly.
- Updated web view to use a private browser session which does not persist any data on disk but only keeps them in memory for the lifetime of the web view.
- Updated variable names to remove redundancy and improve overall code legibility.
- Added a lot of logging statement to NCLoginProvider.
- Added some documentation comments on NCLoginProvider.
- Updated NextcloudKit reference to 6.0.10.