### PR TITLE
Fix folder naming not using capabilities renamer

### DIFF
--- a/iOSClient/Extensions/UIAlertController+Extension.swift
+++ b/iOSClient/Extensions/UIAlertController+Extension.swift
@@ -101,7 +101,6 @@ extension UIAlertController {
             textField.autocapitalizationType = .words
         }
 
-        // only allow saving if folder name exists
         NotificationCenter.default.addObserver(
             forName: UITextField.textDidChangeNotification,
             object: alertController.textFields?.first,

--- a/iOSClient/Networking/E2EE/NCNetworkingE2EECreateFolder.swift
+++ b/iOSClient/Networking/E2EE/NCNetworkingE2EECreateFolder.swift
@@ -15,7 +15,8 @@ class NCNetworkingE2EECreateFolder: NSObject {
     let global = NCGlobal.shared
 
     func createFolder(fileName: String, serverUrl: String, sceneIdentifier: String?, session: NCSession.Session) async -> NKError {
-        var fileNameFolder = utility.removeForbiddenCharacters(fileName)
+        var fileNameFolder = FileAutoRenamer.rename(fileName, isFolderPath: true, account: session.account)
+
         if fileName != fileNameFolder {
             let errorDescription = String(format: NSLocalizedString("_forbidden_characters_", comment: ""), global.forbiddenCharacters.joined(separator: " "))
             let error = NKError(errorCode: global.errorConflict, errorDescription: errorDescription)

--- a/iOSClient/Networking/NCNetworking+WebDAV.swift
+++ b/iOSClient/Networking/NCNetworking+WebDAV.swift
@@ -209,7 +209,7 @@ extension NCNetworking {
                       selector: String? = nil,
                       options: NKRequestOptions = NKRequestOptions()) async -> (serverExists: Bool, error: NKError) {
 
-        var fileNameFolder = utility.removeForbiddenCharacters(fileName.trimmingCharacters(in: .whitespacesAndNewlines))
+        var fileNameFolder = FileAutoRenamer.rename(fileName, isFolderPath: true, account: session.account)
         if !overwrite {
             fileNameFolder = utilityFileSystem.createFileName(fileNameFolder, serverUrl: serverUrl, account: session.account)
         }

--- a/iOSClient/Settings/Advanced/File Name/NCFileNameModel.swift
+++ b/iOSClient/Settings/Advanced/File Name/NCFileNameModel.swift
@@ -78,7 +78,7 @@ class NCFileNameModel: ObservableObject, ViewOnAppearHandling {
 
     /// Submits the changed file name.
     func submitChangedName() {
-        let fileNameWithoutForbiddenChars = NCUtility().removeForbiddenCharacters(changedName)
+        let fileNameWithoutForbiddenChars = FileAutoRenamer.rename(changedName, account: session.account)
         if changedName != fileNameWithoutForbiddenChars {
             changedName = fileNameWithoutForbiddenChars
             let errorDescription = String(format: NSLocalizedString("_forbidden_characters_", comment: ""), NCGlobal.shared.forbiddenCharacters.joined(separator: " "))

--- a/iOSClient/Utility/NCUtility.swift
+++ b/iOSClient/Utility/NCUtility.swift
@@ -275,14 +275,6 @@ final class NCUtility: NSObject, Sendable {
         return (usedmegabytes, totalmegabytes)
     }
 
-    func removeForbiddenCharacters(_ fileName: String) -> String {
-        var fileName = fileName
-        for character in global.forbiddenCharacters {
-            fileName = fileName.replacingOccurrences(of: character, with: "")
-        }
-        return fileName
-    }
-
     func getHeightHeaderEmptyData(view: UIView, portraitOffset: CGFloat, landscapeOffset: CGFloat) -> CGFloat {
         var height: CGFloat = 0
         if UIDevice.current.orientation.isPortrait {


### PR DESCRIPTION
Naming a folder **A*** where the "*" is not part of the forbidden characters coming from capabilities, would cause the folder to be named **A** instead.

Fixed by making the folder creating take into account forbidden characters from capabilities instead of generic forbidden characters.