### PR TITLE
Fix QR code button not showing for light background

### DIFF
--- a/iOSClient/Login/NCLogin.swift
+++ b/iOSClient/Login/NCLogin.swift
@@ -83,6 +83,9 @@ class NCLogin: UIViewController, UITextFieldDelegate, NCLoginQRCodeDelegate {
         loginAddressDetail.textColor = textColor
         loginAddressDetail.text = String.localizedStringWithFormat(NSLocalizedString("_login_address_detail_", comment: ""), NCBrandOptions.shared.brand)
 
+        // QR code button
+        qrCode.tintColor = NCBrandColor.shared.customer.isTooLight() ? .black : .white
+
         // brand
         if NCBrandOptions.shared.disable_request_login_url {
             baseUrlTextField.isEnabled = false


### PR DESCRIPTION
Fixed button to use inverse color when background is light

<img width="326" alt="image" src="https://github.com/user-attachments/assets/3f42bb0a-3370-48f9-8cc1-f113e32c8f0b" />
