### PR TITLE
Add a CSV fallback for Nextcloud-Text

### DIFF
--- a/iOSClient/Data/NCManageDatabase+Metadata.swift
+++ b/iOSClient/Data/NCManageDatabase+Metadata.swift
@@ -305,6 +305,10 @@ extension tableMetadata {
         return (contentType == "application/pdf" || contentType == "com.adobe.pdf")
     }
 
+    var isCsv: Bool {
+        return (contentType == "text/csv")
+    }
+
     /// Returns false if the user is lokced out of the file. I.e. The file is locked but by somone else
     func canUnlock(as user: String) -> Bool {
         return !lock || (lockOwner == user && lockOwnerType == 0)

--- a/iOSClient/Viewer/NCViewer.swift
+++ b/iOSClient/Viewer/NCViewer.swift
@@ -91,6 +91,14 @@ class NCViewer: NSObject {
                 }
                 return
             }
+            // CSV
+            if metadata.isCsv {
+                let editors = utility.editorsDirectEditing(account: metadata.account, contentType: metadata.contentType)
+                if editors.contains("Nextcloud Text") {
+                    qlPreview(viewController: viewController, metadata: metadata)
+                }
+            }
+
             // RichDocument: Collabora
             if metadata.isAvailableRichDocumentEditorView {
                 if metadata.url.isEmpty {
@@ -167,6 +175,10 @@ class NCViewer: NSObject {
             }
         }
 
+        qlPreview(viewController: viewController, metadata: metadata)
+    }
+
+    func qlPreview(viewController: UIViewController, metadata: tableMetadata) {
         // QLPreview
         let item = URL(fileURLWithPath: utilityFileSystem.getDirectoryProviderStorageOcId(metadata.ocId, fileNameView: metadata.fileNameView))
         if QLPreviewController.canPreview(item as QLPreviewItem) {


### PR DESCRIPTION
Add a fallback for CSV files if the editor is Nextcloud-Text, as the Nextcloud-Text editor displays CSV files as text rather than as a table.