### PR TITLE
fix: Use correct key for push notification registration

### DIFF
--- a/iOSClient/PushNotification/NCPushNotification.swift
+++ b/iOSClient/PushNotification/NCPushNotification.swift
@@ -44,8 +44,7 @@ class NCPushNotification {
         guard let keyPair = NCPushNotificationEncryption.shared().generatePushNotificationsKeyPair(account),
               let pushKitToken,
               let pushTokenHash = NCEndToEndEncryption.shared().createSHA512(pushKitToken),
-              let pushPublicKey = keychain.getPushNotificationPublicKey(account: account),
-              let pushDevicePublicKey = String(data: pushPublicKey, encoding: .utf8) else {
+              let pushDevicePublicKey = String(data: keyPair.publicKey, encoding: .utf8) else {
             return
         }
 


### PR DESCRIPTION
Regression from https://github.com/nextcloud/ios/commit/2f2e41e75af8336407f08b38f9f2120df8cbc200

Fixes an issue with using the correct key for push registration

* A new keypair is generated (not saved!)
* We fetch the public key from the keychain
* ...
* We store the new keypair in the keychain
* Registration is now done with the previous public key, but we stored a new private one
