### PR TITLE
Share fixes

### DIFF
--- a/iOSClient/Share/Advanced/NCShareDateCell.swift
+++ b/iOSClient/Share/Advanced/NCShareDateCell.swift
@@ -18,7 +18,7 @@ class NCShareDateCell: UITableViewCell {
         super.init(style: .value1, reuseIdentifier: "shareExpDate")
 
         picker.datePickerMode = .date
-        picker.minimumDate = Date()
+        picker.minimumDate = Calendar.current.date(byAdding: .day, value: 1, to: Date())
         picker.preferredDatePickerStyle = .wheels
         picker.action(for: .valueChanged) { datePicker in
             guard let datePicker = datePicker as? UIDatePicker else { return }

--- a/iOSClient/Share/NCShareNetworking.swift
+++ b/iOSClient/Share/NCShareNetworking.swift
@@ -265,7 +265,7 @@ class NCShareNetworking: NSObject {
     func removeShareDownloadLimit(token: String) {
         let capabilities = NCNetworking.shared.capabilities[self.metadata.account] ?? NKCapabilities.Capabilities()
 
-        if !capabilities.fileSharingDownloadLimit {
+        if !capabilities.fileSharingDownloadLimit || token.isEmpty {
             return
         }
 
@@ -290,7 +290,7 @@ class NCShareNetworking: NSObject {
     func setShareDownloadLimit(_ limit: Int, token: String) {
         let capabilities = NCNetworking.shared.capabilities[self.metadata.account] ?? NKCapabilities.Capabilities()
 
-        if !capabilities.fileSharingDownloadLimit {
+        if !capabilities.fileSharingDownloadLimit || token.isEmpty {
             return
         }
 


### PR DESCRIPTION
Prerequisite: https://github.com/nextcloud/NextcloudKit/pull/183

- Now allows changing download limit only if the shareable type is a file **and** shareable is a link share
- Set expiration date to "today + 1 day" minimum date, otherwise you will be able to choose an invalid date. 
