### PR TITLE
fix blank webview on RTL interfaces

### DIFF
--- a/iOSClient/Login/NCLoginProvider.swift
+++ b/iOSClient/Login/NCLoginProvider.swift
@@ -50,6 +50,7 @@ class NCLoginProvider: UIViewController {
         webView.rightAnchor.constraint(equalTo: view.rightAnchor, constant: 0).isActive = true
         webView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0).isActive = true
         webView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0).isActive = true
+        webView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0).isActive = true
 
         self.webView = webView
 


### PR DESCRIPTION
solves https://github.com/nextcloud/ios/issues/3211

Before in RTL interface 

<img width="330" height="717" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-14 at 14 09 44" src="https://github.com/user-attachments/assets/16479b25-53e4-4afd-b586-63277d0b5c19" />
<img width="330" height="717" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-14 at 14 10 20" src="https://github.com/user-attachments/assets/595ee867-b3f5-4968-82ee-0789c9d6c302" />



-------------


After :
<img width="330" height="717" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-14 at 14 13 50" src="https://github.com/user-attachments/assets/b7f35545-6197-4c20-9696-00ece96dab4f" />




the issue was : 


<img width="894" height="213" alt="Screenshot 2025-09-14 at 2 11 33 PM" src="https://github.com/user-attachments/assets/59cca684-175c-4c6f-9489-78d115a480db" />




