### PR TITLE
sync improved

### DIFF
--- a/iOSClient/Data/NCManageDatabase+Directory.swift
+++ b/iOSClient/Data/NCManageDatabase+Directory.swift
@@ -57,6 +57,7 @@ extension NCManageDatabase {
                 tableDirectory.favorite = metadata.favorite
                 tableDirectory.permissions = metadata.permissions
                 tableDirectory.richWorkspace = metadata.richWorkspace
+                tableDirectory.lastSyncDate = NSDate()
             } else {
                 let directory = tableDirectory()
                 directory.account = metadata.account
@@ -67,6 +68,7 @@ extension NCManageDatabase {
                 directory.permissions = metadata.permissions
                 directory.richWorkspace = metadata.richWorkspace
                 directory.serverUrl = directoryServerUrl
+                directory.lastSyncDate = NSDate()
                 realm.add(directory, update: .all)
             }
 

--- a/iOSClient/Files/NCFiles+SyncMetadata.swift
+++ b/iOSClient/Files/NCFiles+SyncMetadata.swift
@@ -118,11 +118,25 @@ extension NCFiles {
             }
 
             let directory = await database.getTableDirectoryAsync(ocId: metadata.ocId)
-            guard directory?.etag != metadata.etag else {
+
+            // Skips processing the current directory if it has not changed recently.
+            // The loop continues only when both the ETag matches the metadata (indicating no content change)
+            // and the last synchronization date is within the last 3 hours.
+            // This prevents redundant work on directories that were already synced recently.
+            //
+            // - Conditions:
+            //   - `directory?.etag == metadata.etag`: the directory content has not changed.
+            //   - `let lastSyncDate = directory?.lastSyncDate as? Date`: ensures the last sync date exists and is convertible to `Date`.
+            //   - `lastSyncDate >= Date().addingTimeInterval(-3 * 3600)`: skips only if the last sync occurred less than 3 hours ago.
+            //
+            // In all other cases (different ETag, missing date, or sync older than 3 hours), the loop proceeds normally.
+            if directory?.etag == metadata.etag,
+               let lastSyncDate = directory?.lastSyncDate as? Date,
+               lastSyncDate >= Date().addingTimeInterval(-3 * 3600) {
                 continue
             }
-            let serverUrl = metadata.serverUrlFileName
 
+            let serverUrl = metadata.serverUrlFileName
             let resultsReadFolder = await NCNetworking.shared.readFolderAsync(serverUrl: serverUrl, account: metadata.account) { task in
                 Task {
                     await self.networking.networkingTasks.track(identifier: identifier, task: task)


### PR DESCRIPTION
**Skips processing the current directory if it has not changed recently.**

The loop continues only when both the ETag matches the metadata (indicating no content change)
and the last synchronization date is within the last 3 hours.
This prevents redundant work on directories that were already synced recently.

- Conditions:
- `directory?.etag == metadata.etag`: the directory content has not changed.
- `let lastSyncDate = directory?.lastSyncDate as? Date`: ensures the last sync date exists and is convertible to `Date`.
- `lastSyncDate >= Date().addingTimeInterval(-3 * 3600)`: skips only if the last sync occurred less than 3 hours ago.

In all other cases (different ETag, missing date, or sync older than 3 hours), the loop proceeds normally.