### PR TITLE
Change codec from Apple Lossless to AAC

### DIFF
--- a/iOSClient/AudioRecorder/NCAudioRecorderViewController.swift
+++ b/iOSClient/AudioRecorder/NCAudioRecorderViewController.swift
@@ -191,7 +191,7 @@ open class NCAudioRecorder: NSObject {
     open func prepare() throws {
 
         let settings: [String: AnyObject] = [
-            AVFormatIDKey: NSNumber(value: Int32(kAudioFormatAppleLossless) as Int32),
+            AVFormatIDKey: NSNumber(value: Int32(kAudioFormatMPEG4AAC) as Int32),
             AVEncoderAudioQualityKey: AVAudioQuality.max.rawValue as AnyObject,
             AVEncoderBitRateKey: bitRate as AnyObject,
             AVNumberOfChannelsKey: channels as AnyObject,


### PR DESCRIPTION
### Why this change?
This change updates the audio codec used for voice memo recordings from Apple Lossless (ALAC) to AAC, which is more widely supported, for instance if you want to play the file in Nextcloud web using Firefox or Chrome.

### Testing
I do not currently have access to a local development environment, so I haven't tested this change myself. I hope maintainers can verify this before merging.

### Related issue
Fixes #3810 