### PR TITLE
Sort shares by date

### DIFF
--- a/iOSClient/Share/NCShare.swift
+++ b/iOSClient/Share/NCShare.swift
@@ -380,7 +380,8 @@ extension NCShare: UITableViewDataSource {
             return cell
         }
 
-        guard let tableShare = shares.share?[indexPath.row] else { return UITableViewCell() }
+        let orderedShares = shares.share?.sorted(by: { $0.date?.compare($1.date as Date? ?? Date()) == .orderedAscending })
+        guard let tableShare = orderedShares?[indexPath.row] else { return UITableViewCell() }
 
         // LINK, EMAIL
         if tableShare.shareType == NKShare.ShareType.publicLink.rawValue || tableShare.shareType == NKShare.ShareType.email.rawValue {


### PR DESCRIPTION
Shares were unsorted before, so for example a new link share would go in the middle of the list. Now they are sorted by date.