### PR TITLE
Fix empty files not being able to be shared

### DIFF
--- a/iOSClient/Utility/NCUtilityFileSystem.swift
+++ b/iOSClient/Utility/NCUtilityFileSystem.swift
@@ -178,7 +178,7 @@ final class NCUtilityFileSystem: NSObject, @unchecked Sendable {
             return (fileNameViewSize == metadata.size) && metadata.size > 0
 #else
             if metadata.isDirectoryE2EE == true {
-                if (fileNameSize == metadata.size || fileNameViewSize == metadata.size) {
+                if fileNameSize == metadata.size || fileNameViewSize == metadata.size {
                     return true
                 } else {
                     return false


### PR DESCRIPTION
An empty .md or .txt is 0 bytes, and the check if the file exists in the document storage expects the size of the file to be > 0. This removes the check, which allows a 0 byte file to be shared. 

@marinofaggiana do you think this is a dangerous solution? I haven't noticed any issues so far. I think all the other checks we do to make sure the file exists are enough.