### PR TITLE
Remove middle dot separator in tags

### DIFF
--- a/iOSClient/Main/Collection Common/Cell/NCListCell.swift
+++ b/iOSClient/Main/Collection Common/Cell/NCListCell.swift
@@ -263,12 +263,14 @@ class NCListCell: UICollectionViewCell, UIGestureRecognizerDelegate, NCCellProto
             tag1.isHidden = true
             labelInfo.isHidden = false
             labelSubinfo.isHidden = false
+            labelInfoSeparator.isHidden = false
         } else {
             tag0.isHidden = false
             tag1.isHidden = true
             labelInfo.isHidden = true
             labelSubinfo.isHidden = true
-
+            labelInfoSeparator.isHidden = true
+            
             if let tag = tags.first {
                 tag0.text = tag
                 if tags.count > 1 {

--- a/iOSClient/Main/Collection Common/Cell/NCListCell.xib
+++ b/iOSClient/Main/Collection Common/Cell/NCListCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24412" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="landscape" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24405"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>


### PR DESCRIPTION
Before:

<img width="175" height="67" alt="image" src="https://github.com/user-attachments/assets/8938a26a-8fca-49da-b3b1-8cfde70ae984" />

After:

<img width="172" height="58" alt="image" src="https://github.com/user-attachments/assets/8058c226-4159-47fb-a14d-681b93fc01f5" />
