### PR TITLE
Remove code from content presenter when not in DEBUG

### DIFF
--- a/iOSClient/Utility/NCContentPresenter.swift
+++ b/iOSClient/Utility/NCContentPresenter.swift
@@ -135,7 +135,11 @@ class NCContentPresenter: NSObject {
                     }
                 }
                 if error.errorDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return }
+                #if DEBUG
                 var description = NSLocalizedString(error.errorDescription, comment: "") + ", code: \(error.errorCode)"
+                #else
+                var description = NSLocalizedString(error.errorDescription, comment: "")
+                #endif
                 description = description.replacingOccurrences(of: "\t", with: "\n")
                 self.flatTop(title: NSLocalizedString(title, comment: ""), description: description + responseMessage, delay: delay, type: type, priority: priority, dropEnqueuedEntries: dropEnqueuedEntries)
             }


### PR DESCRIPTION
Showing the error code in error messages is way too technical and should not be shown to users. This PR hides the error code if not #DEBUG