### PR TITLE
Use unicode regex for email validation

### DIFF
--- a/iOSClient/Share/NCShare.swift
+++ b/iOSClient/Share/NCShare.swift
@@ -110,8 +110,6 @@ class NCShare: UIViewController, NCSharePagingContent {
             networking = NCShareNetworking(metadata: metadata, view: self.view, delegate: self, session: session)
             let isVisible = (self.navigationController?.topViewController as? NCSharePaging)?.page == .sharing
             networking?.readShare(showLoadingIndicator: isVisible)
-
-            
             searchField.searchTextField.font = .systemFont(ofSize: 14)
             searchField.delegate = self
         }


### PR DESCRIPTION
Email validation for shares did not allow special localized characters in emails (ex. ß), but switching the regex from ASCII to Unicode fixes the issue.

- Also now ignores whitespaces when searching sharees.

<img width="523" height="300" alt="image" src="https://github.com/user-attachments/assets/ac3212e0-4dde-4d81-9c3f-af3e44b03139" />
