### PR TITLE
Context menu fixes

### DIFF
--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon+SelectTabBarDelegate.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon+SelectTabBarDelegate.swift
@@ -103,7 +103,7 @@ extension NCCollectionViewCommon: NCCollectionViewCommonSelectTabBarDelegate {
         Task {
             let metadatas = getSelectedMetadatas()
             for metadata in metadatas where metadata.lock == isAnyLocked {
-                self.networking.lockUnlockFile(metadata, shoulLock: !isAnyLocked)
+                self.networking.lockUnlockFile(metadata, shouldLock: !isAnyLocked)
             }
             await setEditMode(false)
         }

--- a/iOSClient/Menu/ContextMenuActions.swift
+++ b/iOSClient/Menu/ContextMenuActions.swift
@@ -139,28 +139,29 @@ enum ContextMenuActions {
          }
      }
 
-     static func lockUnlock(shouldLock: Bool,
-                            metadatas: [tableMetadata],
-                            completion: (() -> Void)? = nil) -> UIAction {
-         let titleKey: String
-         var subtitleKey: String = ""
+    static func lockUnlock(isLocked: Bool,
+                           metadata: tableMetadata,
+                           completion: (() -> Void)? = nil) -> UIAction {
+        let titleKey: String
+        var subtitleKey: String = ""
+        let image: UIImage?
+        if !metadata.canUnlock(as: metadata.userId), isLocked {
+            titleKey = String(format: NSLocalizedString("_locked_by_", comment: ""), metadata.lockOwnerDisplayName)
+            image = UIImage(systemName: "lock")
+        } else {
+            titleKey = isLocked ? "_unlock_file_" : "_lock_file_"
+            image = UIImage(systemName: isLocked ? "lock.open" : "lock")
+            subtitleKey = !metadata.lockOwnerDisplayName.isEmpty ? String(format: NSLocalizedString("_locked_by_", comment: ""), metadata.lockOwnerDisplayName) : ""
+        }
 
-         if metadatas.count == 1, let metadata = metadatas.first {
-             titleKey = shouldLock ? "_lock_file_" : "_unlock_file_"
-             subtitleKey = !shouldLock ? String(format: NSLocalizedString("_locked_by_", comment: ""), metadata.lockOwnerDisplayName) : ""
-         } else {
-             titleKey = shouldLock ? "_lock_selected_files_" : "_unlock_selected_files_"
-         }
-
-         return UIAction(
-             title: NSLocalizedString(titleKey, comment: ""),
-             subtitle: subtitleKey,
-             image: UIImage(systemName: shouldLock ? "lock" : "lock.open")
-         ) { _ in
-             for metadata in metadatas where metadata.lock != shouldLock {
-                 NCNetworking.shared.lockUnlockFile(metadata, shoulLock: shouldLock)
-             }
-             completion?()
-         }
-     }
+        return UIAction(
+            title: NSLocalizedString(titleKey, comment: ""),
+            subtitle: subtitleKey,
+            image: image,
+            attributes: metadata.canUnlock(as: metadata.userId) ? [] : [.disabled]
+        ) { _ in
+            NCNetworking.shared.lockUnlockFile(metadata, shouldLock: !isLocked)
+            completion?()
+        }
+    }
 }

--- a/iOSClient/Menu/NCContextMenu.swift
+++ b/iOSClient/Menu/NCContextMenu.swift
@@ -136,10 +136,9 @@ class NCContextMenu: NSObject {
         // Lock/Unlock
         if NCNetworking.shared.isOnline,
            !metadata.directory,
-           metadata.canUnlock(as: metadata.userId),
            !capabilities.filesLockVersion.isEmpty {
             mainActionsMenu.append(
-                ContextMenuActions.lockUnlock(shouldLock: !metadata.lock, metadatas: [metadata])
+                ContextMenuActions.lockUnlock(isLocked: metadata.lock, metadata: metadata)
             )
         }
 

--- a/iOSClient/Menu/NCMenuAction.swift
+++ b/iOSClient/Menu/NCMenuAction.swift
@@ -266,7 +266,7 @@ extension NCMenuAction {
             sender: sender,
             action: { _ in
                 for metadata in metadatas where metadata.lock != shouldLock {
-                    NCNetworking.shared.lockUnlockFile(metadata, shoulLock: shouldLock)
+                    NCNetworking.shared.lockUnlockFile(metadata, shouldLock: shouldLock)
                 }
                 completion?()
             }

--- a/iOSClient/Networking/NCNetworking+WebDAV.swift
+++ b/iOSClient/Networking/NCNetworking+WebDAV.swift
@@ -765,8 +765,8 @@ extension NCNetworking {
 
     // MARK: - Lock Files
 
-    func lockUnlockFile(_ metadata: tableMetadata, shoulLock: Bool) {
-        NextcloudKit.shared.lockUnlockFile(serverUrlFileName: metadata.serverUrlFileName, shouldLock: shoulLock, account: metadata.account) { task in
+    func lockUnlockFile(_ metadata: tableMetadata, shouldLock: Bool) {
+        NextcloudKit.shared.lockUnlockFile(serverUrlFileName: metadata.serverUrlFileName, shouldLock: shouldLock, account: metadata.account) { task in
             Task {
                 let identifier = await NCNetworking.shared.networkingTasks.createIdentifier(account: metadata.account,
                                                                                             path: metadata.serverUrlFileName,


### PR DESCRIPTION
-Added fixes for when to show top menu items (favorite and share) by bringing back required conditionals
-Added "Locked by" subtitle that mimics old implementation:

<img width="456" height="377" alt="image" src="https://github.com/user-attachments/assets/fdfd081b-6460-49c9-86fa-70d868bdfea0" />

<img width="472" height="502" alt="image" src="https://github.com/user-attachments/assets/4dee7a10-1b20-4bfb-84fd-7f396baef43e" />
