### PR TITLE
Rebrand to HPA Cloud

### DIFF
--- a/Brand/File_Provider_Extension.entitlements
+++ b/Brand/File_Provider_Extension.entitlements
@@ -4,11 +4,11 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.it.twsweb.Crypto-Cloud</string>
+		<string>group.com.hpa.cloud</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)it.twsweb.Crypto-Cloud</string>
+		<string>$(AppIdentifierPrefix)com.hpa.cloud</string>
 	</array>
 </dict>
 </plist>

--- a/Brand/File_Provider_Extension.plist
+++ b/Brand/File_Provider_Extension.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Nextcloud</string>
+	<string>HPA Cloud</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Brand/File_Provider_Extension_UI.entitlements
+++ b/Brand/File_Provider_Extension_UI.entitlements
@@ -4,11 +4,11 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.it.twsweb.Crypto-Cloud</string>
+		<string>group.com.hpa.cloud</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)it.twsweb.Crypto-Cloud</string>
+		<string>$(AppIdentifierPrefix)com.hpa.cloud</string>
 	</array>
 </dict>
 </plist>

--- a/Brand/File_Provider_Extension_UI.plist
+++ b/Brand/File_Provider_Extension_UI.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDisplayName</key>
-	<string>Nextcloud</string>
+	<string>HPA Cloud</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionFileProviderActions</key>

--- a/Brand/NCBrand.swift
+++ b/Brand/NCBrand.swift
@@ -23,26 +23,26 @@ let userAgent: String = {
 final class NCBrandOptions: @unchecked Sendable {
     static let shared = NCBrandOptions()
 
-    var brand: String = "Nextcloud"
+    var brand: String = "HPA Cloud"
     var brandUserAgent: String = ""
-    var textCopyrightNextcloudiOS: String = "Nextcloud Matheria for iOS %@ © 2026"
-    var textCopyrightNextcloudServer: String = "Nextcloud Server %@"
-    var loginBaseUrl: String = "https://cloud.nextcloud.com"
+    var textCopyrightNextcloudiOS: String = "HPA Cloud for iOS %@ © 2026"
+    var textCopyrightNextcloudServer: String = "HPA Cloud Server %@"
+    var loginBaseUrl: String = "https://cloud.apps.vn"
     var pushNotificationServerProxy: String = ""
-    var linkLoginHost: String = "https://nextcloud.com/install"
-    var linkloginPreferredProviders: String = "https://nextcloud.com/signup-ios"
-    var webLoginAutenticationProtocol: String = "nc://"                                        // example "abc://"
-    var privacy: String = "https://nextcloud.com/privacy"
-    var sourceCode: String = "https://github.com/nextcloud/ios"
+    var linkLoginHost: String = "https://cloud.apps.vn"
+    var linkloginPreferredProviders: String = "https://cloud.apps.vn"
+    var webLoginAutenticationProtocol: String = "hpacloud://"                                        // example "abc://"
+    var privacy: String = "https://cloud.apps.vn/privacy"
+    var sourceCode: String = "https://github.com/hpa/cloud"
     var mobileconfig: String = "/remote.php/dav/provisioning/apple-provisioning.mobileconfig"
-    var appStoreUrl: String = "https://apps.apple.com/in/app/nextcloud/id1125420102"
+    var appStoreUrl: String = "https://apps.apple.com/app/hpa-cloud/idYOURID"
 
     // Auto Upload default folder
     var folderDefaultAutoUpload: String = "Photos"
 
     // Capabilities Group
-    var capabilitiesGroup: String = "group.it.twsweb.Crypto-Cloud"
-    var capabilitiesGroupApps: String = "group.com.nextcloud.apps"
+    var capabilitiesGroup: String = "group.com.hpa.cloud"
+    var capabilitiesGroupApps: String = "group.com.hpa.apps"
 
     // BRAND ONLY
     var use_AppConfig: Bool = false                                                         // Don't touch me !!
@@ -51,8 +51,8 @@ final class NCBrandOptions: @unchecked Sendable {
     var use_themingColor: Bool = true
 
     var disable_intro: Bool = false
-    var disable_request_login_url: Bool = false
-    var disable_multiaccount: Bool = false
+    var disable_request_login_url: Bool = true
+    var disable_multiaccount: Bool = true
     var disable_more_external_site: Bool = false
     var disable_openin_file: Bool = false                                                       // Don't touch me !!
     var disable_crash_service: Bool = false
@@ -64,8 +64,8 @@ final class NCBrandOptions: @unchecked Sendable {
     var enforce_passcode_lock = false
     var enforce_privacyScreenEnabled = false
 
-    // Example: (name: "Name 1", url: "https://cloud.nextcloud.com"),(name: "Name 2", url: "https://cloud.nextcloud.com")
-    var enforce_servers: [(name: String, url: String)] = []
+    // Only allow HPA Cloud server
+    var enforce_servers: [(name: String, url: String)] = [(name: "HPA Cloud", url: "https://cloud.apps.vn")]
 
     // Internal option behaviour
     var cleanUpDay: Int = 0                                                                     // Set default "Delete all cached files older than" possible days value are: 0, 1, 7, 30, 90, 180, 365

--- a/Brand/Notification_Service_Extension.entitlements
+++ b/Brand/Notification_Service_Extension.entitlements
@@ -6,13 +6,13 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.it.twsweb.Crypto-Cloud</string>
+		<string>group.com.hpa.cloud</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)it.twsweb.Crypto-Cloud</string>
+		<string>$(AppIdentifierPrefix)com.hpa.cloud</string>
 	</array>
 </dict>
 </plist>

--- a/Brand/Share.entitlements
+++ b/Brand/Share.entitlements
@@ -6,13 +6,13 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.it.twsweb.Crypto-Cloud</string>
+		<string>group.com.hpa.cloud</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)it.twsweb.Crypto-Cloud</string>
+		<string>$(AppIdentifierPrefix)com.hpa.cloud</string>
 	</array>
 </dict>
 </plist>

--- a/Brand/Share.plist
+++ b/Brand/Share.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Nextcloud</string>
+	<string>HPA Cloud</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Brand/Widget.entitlements
+++ b/Brand/Widget.entitlements
@@ -6,13 +6,13 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.it.twsweb.Crypto-Cloud</string>
+		<string>group.com.hpa.cloud</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)it.twsweb.Crypto-Cloud</string>
+		<string>$(AppIdentifierPrefix)com.hpa.cloud</string>
 	</array>
 </dict>
 </plist>

--- a/Brand/WidgetDashboardIntentHandler.entitlements
+++ b/Brand/WidgetDashboardIntentHandler.entitlements
@@ -6,13 +6,13 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.it.twsweb.Crypto-Cloud</string>
+		<string>group.com.hpa.cloud</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)it.twsweb.Crypto-Cloud</string>
+		<string>$(AppIdentifierPrefix)com.hpa.cloud</string>
 	</array>
 </dict>
 </plist>

--- a/Brand/iOSClient.entitlements
+++ b/Brand/iOSClient.entitlements
@@ -8,8 +8,8 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.nextcloud.apps</string>
-		<string>group.it.twsweb.Crypto-Cloud</string>
+		<string>group.com.hpa.apps</string>
+		<string>group.com.hpa.cloud</string>
 	</array>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
@@ -23,7 +23,7 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)it.twsweb.Crypto-Cloud</string>
+		<string>$(AppIdentifierPrefix)com.hpa.cloud</string>
 	</array>
 </dict>
 </plist>

--- a/Brand/iOSClient.plist
+++ b/Brand/iOSClient.plist
@@ -12,7 +12,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Nextcloud</string>
+	<string>HPA Cloud</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -33,10 +33,10 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>it.twsweb.Nextcloud</string>
+			<string>com.hpa.cloud</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>nextcloud</string>
+				<string>hpacloud</string>
 			</array>
 		</dict>
 	</array>
@@ -48,8 +48,8 @@
 	<string>8e9f9874-938e-460b-a9be-f82cb3393971</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-		<string>nextcloudtalk</string>
-		<string>nextcloudnotes</string>
+		<string>hpacloudtalk</string>
+		<string>hpacloudnotes</string>
 	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.3</string>


### PR DESCRIPTION
- Change app name from Nextcloud to HPA Cloud
- Update bundle identifier to com.hpa.cloud
- Update App Groups to group.com.hpa.cloud
- Set default server URL to https://cloud.apps.vn
- Enforce only HPA Cloud server (disable custom URL input)
- Disable multi-account support
- Update URL scheme to hpacloud://