### PR TITLE
Media queue and Picture-in-Picture support

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -11,8 +11,12 @@
 		2C1D5D7923E2DE9100334ABB /* NCBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76B3CCD1EAE01BD00921AC9 /* NCBrand.swift */; };
 		2C33C48223E2C475005F963B /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C33C48123E2C475005F963B /* NotificationService.swift */; };
 		2C33C48623E2C475005F963B /* Notification Service Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 2C33C47F23E2C475005F963B /* Notification Service Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		2F96A1BAFB10ACFEAC68EF1C /* NCContextMenuPlayerTracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C7A5B36D1ED178FB6B76CB /* NCContextMenuPlayerTracks.swift */; };
 		370D26AF248A3D7A00121797 /* NCCellMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D26AE248A3D7A00121797 /* NCCellMain.swift */; };
+		420216572F557C9100BBD630 /* NCMediaCoordinatorVLCStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420216562F557C7F00BBD630 /* NCMediaCoordinatorVLCStrategy.swift */; };
+		420216592F557CB100BBD630 /* NCMediaCoordinatorAVKitStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 420216582F557CA300BBD630 /* NCMediaCoordinatorAVKitStrategy.swift */; };
+		4202165D2F5586D800BBD630 /* NCMediaCoordinatorStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4202165C2F5586D300BBD630 /* NCMediaCoordinatorStrategy.swift */; };
+		4250C8472E2E53BA00349A8A /* NCMediaCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4250C8462E2E53B400349A8A /* NCMediaCoordinator.swift */; };
+		426E38DD2F571E8D0073EE47 /* NCMediaCoordinatorConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 426E38DC2F571E890073EE47 /* NCMediaCoordinatorConstants.swift */; };
 		A5A87F9E4B0E4441A6A4BC20 /* NCContextMenuProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7697C94BA14450A0867940 /* NCContextMenuProfile.swift */; };
 		AA3C85E82D36B08C00F74F12 /* UITestBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3C85E72D36B08C00F74F12 /* UITestBackend.swift */; };
 		AA3C85EB2D36BBFB00F74F12 /* OCSResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3C85EA2D36BBF400F74F12 /* OCSResponse.swift */; };
@@ -84,6 +88,7 @@
 		AFCE353927E5DE0500FEA6C2 /* Shareable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE353827E5DE0400FEA6C2 /* Shareable.swift */; };
 		CB3666201AF7550816B5CD6A /* NCContextMenuComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8932E90EC4278026D86CCCC9 /* NCContextMenuComment.swift */; };
 		D5B6AA7827200C7200D49C24 /* NCActivityTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B6AA7727200C7200D49C24 /* NCActivityTableViewCell.swift */; };
+		D5EB5DD42F490D2F009D88B1 /* NCContextMenuPlayerTracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EB5DD32F490D2E009D88B1 /* NCContextMenuPlayerTracks.swift */; };
 		F310B1EF2BA862F1001C42F5 /* NCViewerMedia+VisionKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = F310B1EE2BA862F1001C42F5 /* NCViewerMedia+VisionKit.swift */; };
 		F317C82E2E844C5300761AEA /* ClientIntegrationUIViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F317C82D2E844C5300761AEA /* ClientIntegrationUIViewer.swift */; };
 		F321DA8A2B71205A00DDA0E6 /* NCTrashSelectTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F321DA892B71205A00DDA0E6 /* NCTrashSelectTabBar.swift */; };
@@ -1115,6 +1120,11 @@
 		2C33C48123E2C475005F963B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		2C33C48A23E2CC26005F963B /* Notification_Service_Extension-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Notification_Service_Extension-Bridging-Header.h"; sourceTree = "<group>"; };
 		370D26AE248A3D7A00121797 /* NCCellMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCCellMain.swift; sourceTree = "<group>"; };
+		420216562F557C7F00BBD630 /* NCMediaCoordinatorVLCStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaCoordinatorVLCStrategy.swift; sourceTree = "<group>"; };
+		420216582F557CA300BBD630 /* NCMediaCoordinatorAVKitStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaCoordinatorAVKitStrategy.swift; sourceTree = "<group>"; };
+		4202165C2F5586D300BBD630 /* NCMediaCoordinatorStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaCoordinatorStrategy.swift; sourceTree = "<group>"; };
+		4250C8462E2E53B400349A8A /* NCMediaCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaCoordinator.swift; sourceTree = "<group>"; };
+		426E38DC2F571E890073EE47 /* NCMediaCoordinatorConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaCoordinatorConstants.swift; sourceTree = "<group>"; };
 		8932E90EC4278026D86CCCC9 /* NCContextMenuComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCContextMenuComment.swift; sourceTree = "<group>"; };
 		AA3C85E72D36B08C00F74F12 /* UITestBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestBackend.swift; sourceTree = "<group>"; };
 		AA3C85EA2D36BBF400F74F12 /* OCSResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCSResponse.swift; sourceTree = "<group>"; };
@@ -1231,11 +1241,11 @@
 		AFCE353427E4ED5900FEA6C2 /* DateFormatter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extension.swift"; sourceTree = "<group>"; };
 		AFCE353627E4ED7B00FEA6C2 /* NCShareCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCShareCells.swift; sourceTree = "<group>"; };
 		AFCE353827E5DE0400FEA6C2 /* Shareable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shareable.swift; sourceTree = "<group>"; };
-		B4C7A5B36D1ED178FB6B76CB /* NCContextMenuPlayerTracks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCContextMenuPlayerTracks.swift; sourceTree = "<group>"; };
 		BB7697C94BA14450A0867940 /* NCContextMenuProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCContextMenuProfile.swift; sourceTree = "<group>"; };
 		C0046CDA2A17B98400D87C9D /* NextcloudUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextcloudUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C04E2F202A17BB4D001BAD85 /* NextcloudIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextcloudIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B6AA7727200C7200D49C24 /* NCActivityTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCActivityTableViewCell.swift; sourceTree = "<group>"; };
+		D5EB5DD32F490D2E009D88B1 /* NCContextMenuPlayerTracks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCContextMenuPlayerTracks.swift; sourceTree = "<group>"; };
 		F310B1EE2BA862F1001C42F5 /* NCViewerMedia+VisionKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCViewerMedia+VisionKit.swift"; sourceTree = "<group>"; };
 		F317C82D2E844C5300761AEA /* ClientIntegrationUIViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIntegrationUIViewer.swift; sourceTree = "<group>"; };
 		F321DA892B71205A00DDA0E6 /* NCTrashSelectTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCTrashSelectTabBar.swift; sourceTree = "<group>"; };
@@ -2002,19 +2012,31 @@
 		371B5A2F23D0B04B00FAFAE9 /* Menu */ = {
 			isa = PBXGroup;
 			children = (
+				D5EB5DD32F490D2E009D88B1 /* NCContextMenuPlayerTracks.swift */,
 				F376A3732E5CC5FF0067EE25 /* ContextMenuActions.swift */,
 				F78C6FDD296D677300C952C3 /* NCContextMenuMain.swift */,
 				BB7697C94BA14450A0867940 /* NCContextMenuProfile.swift */,
 				8932E90EC4278026D86CCCC9 /* NCContextMenuComment.swift */,
 				F72EC7252F45C90600A2135C /* NCContextMenuNavigation.swift */,
 				F72EC7272F45FF0600A2135C /* NCContextMenuPlus.swift */,
-				B4C7A5B36D1ED178FB6B76CB /* NCContextMenuPlayerTracks.swift */,
 				F7FAFD3928BFA947000777FE /* NCContextMenuNotification.swift */,
 				AF93471127E2341B002537EE /* NCContextMenuShare.swift */,
 				F75D19E225EFE09000D74598 /* NCContextMenuTrash.swift */,
 				F710D2012405826100A6033D /* NCViewerContextMenu.swift */,
 			);
 			path = Menu;
+			sourceTree = "<group>";
+		};
+		420216552F55791E00BBD630 /* NCMediaCoordinator */ = {
+			isa = PBXGroup;
+			children = (
+				426E38DC2F571E890073EE47 /* NCMediaCoordinatorConstants.swift */,
+				4250C8462E2E53B400349A8A /* NCMediaCoordinator.swift */,
+				4202165C2F5586D300BBD630 /* NCMediaCoordinatorStrategy.swift */,
+				420216562F557C7F00BBD630 /* NCMediaCoordinatorVLCStrategy.swift */,
+				420216582F557CA300BBD630 /* NCMediaCoordinatorAVKitStrategy.swift */,
+			);
+			path = NCMediaCoordinator;
 			sourceTree = "<group>";
 		};
 		AA3C85E92D36BBDE00F74F12 /* UITestBackend */ = {
@@ -2765,11 +2787,12 @@
 		F79018B1240962C7007C9B6D /* NCViewerMedia */ = {
 			isa = PBXGroup;
 			children = (
-				F70753EA2542A99800972D44 /* NCViewerMediaPage.swift */,
+				420216552F55791E00BBD630 /* NCMediaCoordinator */,
 				F718C24D254D507B00C5C256 /* NCViewerMediaDetailView.swift */,
+				F70753F62542A9C000972D44 /* NCViewerMediaPage.storyboard */,
+				F70753EA2542A99800972D44 /* NCViewerMediaPage.swift */,
 				F70753F02542A9A200972D44 /* NCViewerMedia.swift */,
 				F310B1EE2BA862F1001C42F5 /* NCViewerMedia+VisionKit.swift */,
-				F70753F62542A9C000972D44 /* NCViewerMediaPage.storyboard */,
 				F79EDA9E26B004980007D134 /* NCPlayer */,
 			);
 			path = NCViewerMedia;
@@ -4435,7 +4458,6 @@
 				F78C6FDE296D677300C952C3 /* NCContextMenuMain.swift in Sources */,
 				A5A87F9E4B0E4441A6A4BC20 /* NCContextMenuProfile.swift in Sources */,
 				CB3666201AF7550816B5CD6A /* NCContextMenuComment.swift in Sources */,
-				2F96A1BAFB10ACFEAC68EF1C /* NCContextMenuPlayerTracks.swift in Sources */,
 				F7E402332BA89551007E5609 /* NCTrash+Networking.swift in Sources */,
 				F73EF7A72B0223900087E6E9 /* NCManageDatabase+Comments.swift in Sources */,
 				F33918C42C7CD8F2002D9AA1 /* FileNameValidator+Extensions.swift in Sources */,
@@ -4462,6 +4484,7 @@
 				F78ACD4021903CC20088454D /* NCGridCell.swift in Sources */,
 				F7D890752BD25C570050B8A6 /* NCCollectionViewCommon+DragDrop.swift in Sources */,
 				F7BD0A042C4689E9003A4A6D /* NCMedia+MediaLayout.swift in Sources */,
+				426E38DD2F571E8D0073EE47 /* NCMediaCoordinatorConstants.swift in Sources */,
 				F718E25A2DF2D5D1004038AF /* NCBackgroundLocationUploadManager.swift in Sources */,
 				F761856B29E98543006EB3B0 /* NCIntroViewController.swift in Sources */,
 				F7743A142C33F13A0034F670 /* NCCollectionViewCommon+CollectionViewDataSource.swift in Sources */,
@@ -4490,6 +4513,7 @@
 				F757CC8229E7F88B00F31428 /* NCManageDatabase+Groupfolders.swift in Sources */,
 				F7B769A82B7A0B2000C1AAEB /* NCManageDatabase+Metadata+Session.swift in Sources */,
 				F79EDAA326B004980007D134 /* NCPlayerToolBar.swift in Sources */,
+				D5EB5DD42F490D2F009D88B1 /* NCContextMenuPlayerTracks.swift in Sources */,
 				F7B934FE2BDCFE1E002B2FC9 /* NCDragDrop.swift in Sources */,
 				F77444F8222816D5000D5EB0 /* NCPickerViewController.swift in Sources */,
 				F77BB74A2899857B0090FC19 /* UINavigationController+Extension.swift in Sources */,
@@ -4523,6 +4547,7 @@
 				F7BF9D822934CA21009EE9A6 /* NCManageDatabase+LayoutForView.swift in Sources */,
 				AA8D31662D411FA100FE2775 /* NCShareDateCell.swift in Sources */,
 				F3F442EE2DDE292D00FD701F /* NCMetadataPermissions.swift in Sources */,
+				420216592F557CB100BBD630 /* NCMediaCoordinatorAVKitStrategy.swift in Sources */,
 				F3374A812D64AB9F002A38F9 /* StatusInfo.swift in Sources */,
 				AF7E504E27A2D8FF00B5E4AF /* UIBarButton+Extension.swift in Sources */,
 				AA8D31682D41224800FE2775 /* NCShareToggleCell.swift in Sources */,
@@ -4542,6 +4567,7 @@
 				F785EE9D246196DF00B3F945 /* NCNetworkingE2EE.swift in Sources */,
 				F724377B2C10B83E00C7C68D /* NCSharePermissions.swift in Sources */,
 				F317C82E2E844C5300761AEA /* ClientIntegrationUIViewer.swift in Sources */,
+				420216572F557C9100BBD630 /* NCMediaCoordinatorVLCStrategy.swift in Sources */,
 				F794E13D2BBBFF2E003693D7 /* NCMainTabBarController.swift in Sources */,
 				F7CBC1252BAC8B0000EC1D55 /* NCSectionFirstHeaderEmptyData.swift in Sources */,
 				F7D4BF3D2CA2E8D800A5E746 /* TOPasscodeKeypadView.m in Sources */,
@@ -4573,6 +4599,7 @@
 				F7DF7B422F1A36C100514020 /* HelperBanner.swift in Sources */,
 				F78ACD4A21903F850088454D /* NCTrashListCell.swift in Sources */,
 				F7386E482DA90E0F009A00F6 /* NCAppVersionManager.swift in Sources */,
+				4250C8472E2E53BA00349A8A /* NCMediaCoordinator.swift in Sources */,
 				F76882352C0DD1E7001CF441 /* NCWebBrowserView.swift in Sources */,
 				F3A047972BD2668800658E7B /* NCAssistantEmptyView.swift in Sources */,
 				F757CC8D29E82D0500F31428 /* NCGroupfolders.swift in Sources */,
@@ -4604,6 +4631,7 @@
 				F7EB9B132BBC12F300EDF036 /* UIApplication+Extension.swift in Sources */,
 				F75D90212D2BE26F003E740B /* NCRecommendationsCell.swift in Sources */,
 				F7E98C1627E0D0FC001F9F19 /* NCManageDatabase+Video.swift in Sources */,
+				4202165D2F5586D800BBD630 /* NCMediaCoordinatorStrategy.swift in Sources */,
 				F76882222C0DD1E7001CF441 /* NCCapabilitiesView.swift in Sources */,
 				F3CA337D2D0B2B6C00672333 /* AlbumModel.swift in Sources */,
 				AF93471A27E2361E002537EE /* NCShareHeader.swift in Sources */,

--- a/iOSClient/Data/NCManageDatabase+Video.swift
+++ b/iOSClient/Data/NCManageDatabase+Video.swift
@@ -29,7 +29,7 @@ extension NCManageDatabase {
 
     // MARK: - Realm write
 
-    func addVideo(metadata: tableMetadata, position: Float? = nil, width: Int? = nil, height: Int? = nil, length: Int? = nil, currentAudioTrackIndex: Int? = nil, currentVideoSubTitleIndex: Int? = nil) {
+    func addVideoOrAudio(metadata: tableMetadata, position: Float? = nil, width: Int? = nil, height: Int? = nil, length: Int? = nil, currentAudioTrackIndex: Int? = nil, currentVideoSubTitleIndex: Int? = nil) {
         if metadata.isLivePhoto { return }
 
         core.performRealmWrite { realm in
@@ -81,7 +81,7 @@ extension NCManageDatabase {
         }
     }
 
-    func deleteVideoAsync(_ ocId: String) async {
+    func deleteVideoOrAudioAsync(_ ocId: String) async {
         await core.performRealmWriteAsync { realm in
             if let result = realm.objects(tableVideo.self)
                 .filter("ocId == %@", ocId)
@@ -93,7 +93,7 @@ extension NCManageDatabase {
 
     // MARK: - Realm read
 
-    func getVideo(metadata: tableMetadata?) -> tableVideo? {
+    func getVideoOrAudio(metadata: tableMetadata?) -> tableVideo? {
         guard let metadata else { return nil }
 
         return core.performRealmRead { realm in

--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon+CollectionViewDelegate.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon+CollectionViewDelegate.swift
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
 // SPDX-FileCopyrightText: 2024 Marino Faggiana
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import Foundation
@@ -71,51 +72,62 @@ extension NCCollectionViewCommon: UICollectionViewDelegate {
         if metadata.directory {
             pushMetadata(metadata)
         } else {
-            let image = utility.getImage(ocId: metadata.ocId, etag: metadata.etag, ext: self.global.previewExt1024, userId: metadata.userId, urlBase: metadata.urlBase)
-            let fileExists = utilityFileSystem.fileProviderStorageExists(metadata)
+            Task { @MainActor in
+                let image = utility.getImage(ocId: metadata.ocId, etag: metadata.etag, ext: self.global.previewExt1024, userId: metadata.userId, urlBase: metadata.urlBase)
+                let fileExists = utilityFileSystem.fileProviderStorageExists(metadata)
 
-            // --- E2EE -------
-            if metadata.isDirectoryE2EE {
-                if fileExists {
-                    if let vc = await NCViewer().getViewerController(metadata: metadata, delegate: self) {
+                // --- E2EE -------
+                if metadata.isDirectoryE2EE {
+                    if fileExists {
+                        if let vc = await NCViewer().getViewerController(metadata: metadata, delegate: self) {
+                            self.navigationController?.pushViewController(vc, animated: true)
+                        }
+                    } else {
+                        await downloadFile()
+                    }
+                    return
+                }
+                // ---------------
+
+                if metadata.isImage || metadata.isAudioOrVideo {
+                    let metadatas = self.dataSource.getMetadatas()
+
+                    let siblingMedia: [tableMetadata]
+                    let siblingMetadatasOcIds: [String]
+                    if self.layoutKey == NCGlobal.shared.layoutViewFiles {
+                        siblingMedia = metadatas.filter { $0.classFile == metadata.classFile }
+                        siblingMetadatasOcIds = siblingMedia.map(\.ocId)
+                    } else {
+                        siblingMedia = [metadata]
+                        siblingMetadatasOcIds = metadatas.filter { $0.classFile == NKTypeClassFile.image.rawValue ||
+                            $0.classFile == NKTypeClassFile.video.rawValue ||
+                            $0.classFile == NKTypeClassFile.audio.rawValue }.map(\.ocId)
+                    }
+
+                    if let vc = await NCViewer().getViewerController(metadata: metadata, ocIds: withOcIds ? siblingMetadatasOcIds : nil, siblingMedia: siblingMedia, image: image, delegate: self) {
+                        self.navigationController?.pushViewController(vc, animated: true)
+                    }
+                } else if !metadata.isDirectoryE2EE, metadata.isAvailableEditorView || utilityFileSystem.fileProviderStorageExists(metadata) || metadata.name == self.global.talkName {
+                    if let vc = await NCViewer().getViewerController(metadata: metadata, image: image, delegate: self) {
+                        self.navigationController?.pushViewController(vc, animated: true)
+                    }
+                } else if NextcloudKit.shared.isNetworkReachable() {
+                    guard let  metadata = await database.setMetadataSessionInWaitDownloadAsync(ocId: metadata.ocId,
+                                                                                               session: self.networking.sessionDownload,
+                                                                                               selector: global.selectorLoadFileView,
+                                                                                               sceneIdentifier: self.controller?.sceneIdentifier) else {
+                        return
+                    }
+
+                    if metadata.name == "files" {
+                        await downloadFile()
+                    } else if !metadata.url.isEmpty,
+                              let vc = await NCViewer().getViewerController(metadata: metadata, delegate: self) {
                         self.navigationController?.pushViewController(vc, animated: true)
                     }
                 } else {
-                    await downloadFile()
+                    await showErrorBanner(controller: controller, text: "_go_online_", errorCode: NCGlobal.shared.errorOffline)
                 }
-                return
-            }
-            // ---------------
-
-            if metadata.isImage || metadata.isAudioOrVideo {
-                let metadatas = self.dataSource.getMetadatas()
-                let ocIds = metadatas.filter { $0.classFile == NKTypeClassFile.image.rawValue ||
-                    $0.classFile == NKTypeClassFile.video.rawValue ||
-                    $0.classFile == NKTypeClassFile.audio.rawValue }.map(\.ocId)
-
-                if let vc = await NCViewer().getViewerController(metadata: metadata, ocIds: withOcIds ? ocIds : nil, image: image, delegate: self) {
-                    self.navigationController?.pushViewController(vc, animated: true)
-                }
-            } else if !metadata.isDirectoryE2EE, metadata.isAvailableEditorView || utilityFileSystem.fileProviderStorageExists(metadata) || metadata.name == self.global.talkName {
-                if let vc = await NCViewer().getViewerController(metadata: metadata, image: image, delegate: self) {
-                    self.navigationController?.pushViewController(vc, animated: true)
-                }
-            } else if NextcloudKit.shared.isNetworkReachable() {
-                guard let  metadata = await database.setMetadataSessionInWaitDownloadAsync(ocId: metadata.ocId,
-                                                                                           session: self.networking.sessionDownload,
-                                                                                           selector: global.selectorLoadFileView,
-                                                                                           sceneIdentifier: self.controller?.sceneIdentifier) else {
-                    return
-                }
-
-                if metadata.name == "files" {
-                    await downloadFile()
-                } else if !metadata.url.isEmpty,
-                          let vc = await NCViewer().getViewerController(metadata: metadata, delegate: self) {
-                    self.navigationController?.pushViewController(vc, animated: true)
-                }
-            } else {
-                await showErrorBanner(controller: controller, text: "_go_online_", errorCode: NCGlobal.shared.errorOffline)
             }
         }
     }

--- a/iOSClient/Media/NCMedia+CollectionViewDelegate.swift
+++ b/iOSClient/Media/NCMedia+CollectionViewDelegate.swift
@@ -25,7 +25,7 @@ extension NCMedia: UICollectionViewDelegate {
                 let image = utility.getImage(ocId: metadata.ocId, etag: metadata.etag, ext: global.previewExt1024, userId: metadata.userId, urlBase: metadata.urlBase)
                 let ocIds = dataSource.metadatas.map { $0.ocId }
 
-                if let vc = await NCViewer().getViewerController(metadata: metadata, ocIds: ocIds, image: image, delegate: self) {
+                if let vc = await NCViewer().getViewerController(metadata: metadata, ocIds: ocIds, siblingMedia: [metadata], image: image, delegate: self) {
                     self.navigationController?.pushViewController(vc, animated: true)
                 }
             }

--- a/iOSClient/Menu/NCContextMenuPlayerTracks.swift
+++ b/iOSClient/Menu/NCContextMenuPlayerTracks.swift
@@ -42,17 +42,17 @@ class NCContextMenuPlayerTracks: NSObject {
         switch self.trackType {
         case .subtitle:
             let deferredElement = UIDeferredMenuElement.uncached { [self] completion in
-                guard let player = ncplayer?.player else { return completion([]) }
+                guard let player = ncplayer else { return completion([]) }
                 let spuTracks = player.videoSubTitlesNames
                 let spuTrackIndexes = player.videoSubTitlesIndexes
 
                 var actions = [UIAction]()
                 var subTitleIndex: Int?
 
-                if let data = self.database.getVideo(metadata: metadata), let idx = data.currentVideoSubTitleIndex {
+                if let data = self.database.getVideoOrAudio(metadata: metadata), let idx = data.currentVideoSubTitleIndex {
                     subTitleIndex = idx
-                } else if let idx = ncplayer?.player.currentVideoSubTitleIndex {
-                    subTitleIndex = Int(idx)
+                } else {
+                    subTitleIndex = Int(player.currentVideoSubTitleIndex)
                 }
 
                 if !spuTracks.isEmpty {
@@ -70,17 +70,17 @@ class NCContextMenuPlayerTracks: NSObject {
             children.append(deferredElement)
         case .audio:
             let deferredElement = UIDeferredMenuElement.uncached { [self] completion in
-                guard let player = ncplayer?.player else { return completion([]) }
+                guard let player = ncplayer else { return completion([]) }
                 let audioTracks = player.audioTrackNames
                 let audioTrackIndexes = player.audioTrackIndexes
 
                 var actions = [UIAction]()
                 var audioIndex: Int?
 
-                if let data = self.database.getVideo(metadata: metadata), let idx = data.currentAudioTrackIndex {
+                if let data = self.database.getVideoOrAudio(metadata: metadata), let idx = data.currentAudioTrackIndex {
                     audioIndex = idx
-                } else if let idx = ncplayer?.player.currentAudioTrackIndex {
-                    audioIndex = Int(idx)
+                } else {
+                    audioIndex = Int(player.currentAudioTrackIndex)
                 }
 
                 if !audioTracks.isEmpty {
@@ -112,11 +112,11 @@ class NCContextMenuPlayerTracks: NSObject {
 
             switch self.trackType {
             case .subtitle:
-                self.ncplayer?.player.currentVideoSubTitleIndex = index
-                self.database.addVideo(metadata: metadata, currentVideoSubTitleIndex: Int(index))
+                self.ncplayer?.currentVideoSubTitleIndex = index
+                self.database.addVideoOrAudio(metadata: metadata, currentVideoSubTitleIndex: Int(index))
             case .audio:
-                self.ncplayer?.player.currentAudioTrackIndex = index
-                self.database.addVideo(metadata: metadata, currentAudioTrackIndex: Int(index))
+                self.ncplayer?.currentAudioTrackIndex = index
+                self.database.addVideoOrAudio(metadata: metadata, currentAudioTrackIndex: Int(index))
             }
         }
     }

--- a/iOSClient/Networking/E2EE/NCNetworkingE2EEDelete.swift
+++ b/iOSClient/Networking/E2EE/NCNetworkingE2EEDelete.swift
@@ -47,7 +47,7 @@ class NCNetworkingE2EEDelete: NSObject {
         if result.error == .success || result.error.errorCode == NCGlobal.shared.errorResourceNotFound {
             do {
                 try FileManager.default.removeItem(atPath: NCUtilityFileSystem().getDirectoryProviderStorageOcId(metadata.ocId, userId: metadata.userId, urlBase: metadata.urlBase))
-                await database.deleteVideoAsync(metadata.ocId)
+                await database.deleteVideoOrAudioAsync(metadata.ocId)
                 await database.deleteMetadataAsync(id: metadata.ocId)
                 await database.deleteLocalFileAsync(id: metadata.ocId)
                 // LIVE PHOTO SERVER
@@ -56,7 +56,7 @@ class NCNetworkingE2EEDelete: NSObject {
                     do {
                         try FileManager.default.removeItem(atPath: NCUtilityFileSystem().getDirectoryProviderStorageOcId(metadataLive.ocId, userId: metadataLive.userId, urlBase: metadataLive.urlBase))
                     } catch { }
-                    await self.database.deleteVideoAsync(metadataLive.ocId)
+                    await self.database.deleteVideoOrAudioAsync(metadataLive.ocId)
                     await self.database.deleteMetadataAsync(id: metadataLive.ocId)
                     await self.database.deleteLocalFileAsync(id: metadataLive.ocId)
                 }

--- a/iOSClient/Networking/NCNetworking+WebDAV.swift
+++ b/iOSClient/Networking/NCNetworking+WebDAV.swift
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
 // SPDX-FileCopyrightText: 2024 Marino Faggiana
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import UIKit
@@ -326,7 +327,7 @@ extension NCNetworking {
                 await NCManageDatabase.shared.deleteLocalFileAsync(id: metadataLive.ocId)
                 utilityFileSystem.removeFile(atPath: utilityFileSystem.getDirectoryProviderStorageOcId(metadataLive.ocId, userId: metadata.userId, urlBase: metadata.urlBase))
             }
-            await NCManageDatabase.shared.deleteVideoAsync(metadata.ocId)
+            await NCManageDatabase.shared.deleteVideoOrAudioAsync(metadata.ocId)
             await NCManageDatabase.shared.deleteLocalFileAsync(id: metadata.ocId)
             utilityFileSystem.removeFile(atPath: utilityFileSystem.getDirectoryProviderStorageOcId(metadata.ocId, userId: metadata.userId, urlBase: metadata.urlBase))
 
@@ -484,7 +485,7 @@ extension NCNetworking {
                 try FileManager.default.removeItem(atPath: self.utilityFileSystem.getDirectoryProviderStorageOcId(metadata.ocId, userId: metadata.userId, urlBase: metadata.urlBase))
             } catch { }
 
-            await NCManageDatabase.shared.deleteVideoAsync(metadata.ocId)
+            await NCManageDatabase.shared.deleteVideoOrAudioAsync(metadata.ocId)
             if !metadata.livePhotoFile.isEmpty {
                 await NCManageDatabase.shared.deleteMetadataAsync(id: metadata.livePhotoFile)
             }
@@ -803,15 +804,15 @@ extension NCNetworking {
     // MARK: - Direct Download
 
     func getVideoUrl(metadata: tableMetadata,
-                     completition: @escaping (_ url: URL?, _ autoplay: Bool, _ error: NKError) -> Void) {
+                     completition: @escaping (_ url: URL?, _ error: NKError) -> Void) {
         if !metadata.url.isEmpty {
             if metadata.url.hasPrefix("/") {
-                completition(URL(fileURLWithPath: metadata.url), true, .success)
+                completition(URL(fileURLWithPath: metadata.url), .success)
             } else {
-                completition(URL(string: metadata.url), true, .success)
+                completition(URL(string: metadata.url), .success)
             }
         } else if utilityFileSystem.fileProviderStorageExists(metadata) {
-            completition(URL(fileURLWithPath: utilityFileSystem.getDirectoryProviderStorageOcId(metadata.ocId, fileName: metadata.fileNameView, userId: metadata.userId, urlBase: metadata.urlBase)), false, .success)
+            completition(URL(fileURLWithPath: utilityFileSystem.getDirectoryProviderStorageOcId(metadata.ocId, fileName: metadata.fileNameView, userId: metadata.userId, urlBase: metadata.urlBase)), .success)
         } else {
             NextcloudKit.shared.getDirectDownload(fileId: metadata.fileId, account: metadata.account) { task in
                 Task {
@@ -823,12 +824,12 @@ extension NCNetworking {
             } completion: { _, url, _, error in
                 if error == .success && url != nil {
                     if let url = URL(string: url!) {
-                        completition(url, false, error)
+                        completition(url, error)
                     } else {
-                        completition(nil, false, error)
+                        completition(nil, error)
                     }
                 } else {
-                    completition(nil, false, error)
+                    completition(nil, error)
                 }
             }
         }

--- a/iOSClient/Viewer/NCViewer.swift
+++ b/iOSClient/Viewer/NCViewer.swift
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
 // SPDX-FileCopyrightText: 2020 Marino Faggiana
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import UIKit
@@ -13,7 +14,7 @@ class NCViewer: NSObject {
     private var viewerQuickLook: NCViewerQuickLook?
 
     @MainActor
-    func getViewerController(metadata: tableMetadata, ocIds: [String]? = nil, image: UIImage? = nil, delegate: UIViewController? = nil) async -> UIViewController? {
+    func getViewerController(metadata: tableMetadata, ocIds: [String]? = nil, siblingMedia: [tableMetadata] = [], image: UIImage? = nil, delegate: UIViewController? = nil) async -> UIViewController? {
         let session = NCSession.shared.getSession(account: metadata.account)
         // Set Last Opening Date
         await self.database.setLocalFileLastOpeningDateAsync(metadata: metadata)
@@ -40,19 +41,27 @@ class NCViewer: NSObject {
         }
 
         // IMAGE AUDIO VIDEO
-        else if metadata.isImage || metadata.isAudioOrVideo {
-            let viewerMediaPageContainer = UIStoryboard(name: "NCViewerMediaPage", bundle: nil).instantiateInitialViewController() as? NCViewerMediaPage
+        else if metadata.isImage || metadata.isAudioOrVideo,
+            let viewerMediaPageContainer = UIStoryboard(name: "NCViewerMediaPage", bundle: nil).instantiateInitialViewController() as? NCViewerMediaPage {
+                if metadata.isAudioOrVideo {
+                    let mediaCoordinator = NCMediaCoordinator.shared
+                    mediaCoordinator.finishMediaSession()
+                    if metadata.isAudio {
+                        mediaCoordinator.items = siblingMedia
+                    } else {
+                        mediaCoordinator.items = [metadata]
+                    }
+                }
 
-            viewerMediaPageContainer?.delegateViewController = delegate
-            if let ocIds {
-                viewerMediaPageContainer?.currentIndex = ocIds.firstIndex(where: { $0 == metadata.ocId }) ?? 0
-                viewerMediaPageContainer?.ocIds = ocIds
-            } else {
-                viewerMediaPageContainer?.currentIndex = 0
-                viewerMediaPageContainer?.ocIds = [metadata.ocId]
-            }
+                if let ocIds {
+                    viewerMediaPageContainer.currentIndex = ocIds.firstIndex(where: { $0 == metadata.ocId }) ?? 0
+                    viewerMediaPageContainer.ocIds = ocIds
+                } else {
+                    viewerMediaPageContainer.currentIndex = 0
+                    viewerMediaPageContainer.ocIds = [metadata.ocId]
+                }
 
-            return viewerMediaPageContainer
+                return viewerMediaPageContainer
         }
 
         // DOCUMENTS

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinator.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinator.swift
@@ -1,0 +1,708 @@
+// SPDX-FileCopyrightText: STRATO GmbH
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Combine
+import MediaPlayer
+import NextcloudKit
+import Alamofire
+
+enum NCPlayerState: Equatable {
+    static func == (lhs: NCPlayerState, rhs: NCPlayerState) -> Bool {
+        switch (lhs, rhs) {
+        case (.stopped, .stopped): return true
+        case (.opening, .opening): return true
+        case (.buffering, .buffering): return true
+        case (.ended, .ended): return true
+        case (.error(let lhsError), .error(let rhsError)): return rhsError == lhsError
+        case (.playing, .playing): return true
+        case (.paused, .paused): return true
+        case (.gettingURL, .gettingURL): return true
+        case (.downloading(let lhsProgress), .downloading(let rhsProgress)): return lhsProgress == rhsProgress
+        case (.downloaded, .downloaded): return true
+        default: return false
+        }
+    }
+
+    case stopped
+    case opening
+    case buffering
+    case ended
+    case error(error: NKError?)
+    case playing
+    case paused
+    case gettingURL
+    case downloading(progress: Double)
+    case downloaded
+    case streamAdded
+}
+
+class NCMediaCoordinator: NSObject {
+
+    enum MediaTrackType {
+        case audio
+        case subtitle
+    }
+
+    static let secondsIn5Minutes: Int = 300
+    static let secondsToSeek: Int = 10
+
+    private let database = NCManageDatabase.shared
+    private let utility = NCUtility()
+    private let global = NCGlobal.shared
+    private let utilityFileSystem = NCUtilityFileSystem()
+    private let networking = NCNetworking.shared
+
+    static let shared = NCMediaCoordinator()
+
+    // MARK: - Strategy
+    private var strategy: NCMediaCoordinatorStrategy?
+
+    // MARK: - Delegate
+    weak var delegate: NCMediaCoordinatorVLCStrategyDelegate? {
+        didSet {
+            (strategy as? NCMediaCoordinatorVLCStrategy)?.delegate = delegate
+        }
+    }
+
+    // MARK: - Picture in Picture Properties
+    private(set) var isPictureInPictureActive: Bool = false {
+        didSet(oldValue) {
+            guard oldValue != isPictureInPictureActive else { return }
+            isPictureInPictureActiveSubject.send(isPictureInPictureActive)
+        }
+    }
+    private(set) var isPictureInPictureSupported: Bool = false {
+        didSet(oldValue) {
+            guard oldValue != isPictureInPictureSupported else { return }
+            isPictureInPictureSupportedSubject
+                .send(isPictureInPictureSupported)
+        }
+    }
+
+    // MARK: - Command Center Properties
+    private var playCommand: Any?
+    private var pauseCommand: Any?
+    private var previousTrackCommand: Any?
+    private var nextTrackCommand: Any?
+    private var skipBackwardCommand: Any?
+    private var skipForwardCommand: Any?
+
+    private var url: URL? {
+        didSet {
+            if let url = url {
+                strategy?.url = url
+            } else {
+                strategy?.url = nil
+            }
+        }
+    }
+
+    // MARK: - Publishers
+    private let metadataSwitchSubject = PassthroughSubject<(old: tableMetadata?, new: tableMetadata?), Never>()
+    private let positionSubject = PassthroughSubject<Float, Never>()
+    private let isPlayingSubject = PassthroughSubject<Bool, Never>()
+    private let stateSubject = PassthroughSubject<NCPlayerState, Never>()
+    private let isPictureInPictureSupportedSubject = PassthroughSubject<Bool, Never>()
+    private let isPictureInPictureActiveSubject = PassthroughSubject<Bool, Never>()
+
+    // MARK: - Public Publishers
+    var metadataSwitchPublisher: AnyPublisher<(old: tableMetadata?, new: tableMetadata?), Never> {
+        metadataSwitchSubject.eraseToAnyPublisher()
+    }
+
+    var positionPublisher: AnyPublisher<Float, Never> {
+        positionSubject.eraseToAnyPublisher()
+    }
+
+    var statePublisher: AnyPublisher<NCPlayerState, Never> {
+        stateSubject.eraseToAnyPublisher()
+    }
+
+    var isPictureInPictureSupportedPublisher: AnyPublisher<Bool, Never> {
+        isPictureInPictureSupportedSubject
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+
+    var isPictureInPictureActivePublisher: AnyPublisher<Bool, Never> {
+        isPictureInPictureActiveSubject.eraseToAnyPublisher()
+    }
+
+    var isPlayingPublisher: AnyPublisher<Bool, Never> {
+        isPlayingSubject.eraseToAnyPublisher()
+    }
+
+    var currentItemIndex: Int? {
+        guard let item else {
+            return nil
+        }
+        return items.firstIndex(where: { $0.ocId == item.ocId })
+    }
+    var items: [tableMetadata] = []
+    var item: tableMetadata? {
+        didSet {
+            if oldValue?.ocId != item?.ocId {
+                metadataSwitchSubject.send((oldValue, item))
+                updateCoverImage()
+            }
+        }
+    }
+    private var coverImage: UIImage? {
+        didSet {
+            updateNowPlayingImage(coverImage)
+        }
+    }
+
+    var playRepeat: Bool = false
+
+    var fileName: String {
+        item?.fileName ?? ""
+    }
+
+    private weak var viewToPutVideoOutputView: UIView?
+    func putVideoOutputView(in view: UIView) {
+        viewToPutVideoOutputView = view
+        strategy?.putVideoOutputView(in: view)
+    }
+
+    var position: Float {
+        get {
+            return strategy?.position ?? 0
+        }
+        set {
+            strategy?.position = newValue
+            positionSubject.send(newValue)
+        }
+    }
+
+    var length: Float {
+        return strategy?.length ?? 0
+    }
+
+    var isPlaying: Bool {
+        return strategy?.isPlaying ?? false
+    }
+
+    private(set) var state: NCPlayerState = .stopped {
+        didSet {
+            stateSubject.send(state)
+        }
+    }
+
+    var currentAudioTrackIndex: Int32 {
+        get { return strategy?.currentAudioTrackIndex ?? 0 }
+        set { strategy?.currentAudioTrackIndex = newValue }
+    }
+
+    var currentVideoSubTitleIndex: Int32 {
+        get { return strategy?.currentVideoSubTitleIndex ?? 0 }
+        set { strategy?.currentVideoSubTitleIndex = newValue }
+    }
+
+    var playedTime: String {
+        return strategy?.playedTime ?? ""
+    }
+
+    var remainingTime: String {
+        return strategy?.remainingTime ?? ""
+    }
+
+    var videoSubTitlesNames: [String] {
+        return strategy?.videoSubTitlesNames ?? []
+    }
+
+    var videoSubTitlesIndexes: [Int32] {
+        return strategy?.videoSubTitlesIndexes ?? []
+    }
+
+    var audioTrackNames: [String] {
+        return strategy?.audioTrackNames ?? []
+    }
+
+    var audioTrackIndexes: [Int32] {
+        return strategy?.audioTrackIndexes ?? []
+    }
+
+    var videoSize: CGSize {
+        return strategy?.videoSize ?? .zero
+    }
+
+    private override init() {
+        super.init()
+    }
+
+    func stop() {
+        savePosition()
+        strategy?.stop()
+    }
+
+    func play(restart: Bool = false) {
+        strategy?.play(restart: restart)
+    }
+
+    func play(item: tableMetadata) {
+        if (self.item?.ocId == item.ocId) && !isPlayerInErrorState() {
+            play()
+        } else {
+            self.item = item
+            setNowPlayingInfo()
+            prepareAndStartPlayback(for: item)
+        }
+    }
+
+    internal func isPlayerInErrorState() -> Bool {
+        switch state {
+        case .error: return true
+        default: return false
+        }
+    }
+
+    func pause() {
+        savePosition()
+        strategy?.pause()
+    }
+
+    func jumpForward(_ seconds: Int32) {
+        strategy?.play()
+        strategy?.jumpForward(seconds)
+    }
+
+    func jumpBackward(_ seconds: Int32) {
+        strategy?.play()
+        strategy?.jumpBackward(seconds)
+    }
+
+    private func savePosition() {
+        guard let metadata = self.item, let strategy = self.strategy else { return }
+        guard currentMediaIsInPlayer() else { return }
+        guard strategy.currentMediaLengthInSeconds() > Self.secondsIn5Minutes else { return }
+        self.database.addVideoOrAudio(metadata: metadata, position: position)
+    }
+
+    private func resetSavedPosition() {
+        guard let metadata = self.item, currentMediaIsInPlayer() else { return }
+        self.database.addVideoOrAudio(metadata: metadata, position: 0)
+    }
+
+    func addPlaybackTrack(_ trackURL: URL, type mediaTrackType: MediaTrackType, enforce enforceSelection: Bool) {
+        guard strategy != nil else { return }
+
+        if let vlcStrategy = strategy as? NCMediaCoordinatorVLCStrategy {
+            vlcStrategy.addPlaybackTrack(trackURL,
+                                         type: mediaTrackType,
+                                         enforce: enforceSelection)
+            return
+        }
+
+        guard let currentURL = url else {
+            return
+        }
+
+        stop()
+
+        let vlcStrategy = NCMediaCoordinatorVLCStrategy(context: self)
+        vlcStrategy.delegate = delegate
+
+        strategy = vlcStrategy
+
+        vlcStrategy.url = currentURL
+        if let viewToPutVideoOutputView {
+            vlcStrategy.putVideoOutputView(in: viewToPutVideoOutputView)
+        }
+
+        isPictureInPictureSupported = vlcStrategy.isPictureInPictureSupported
+
+        vlcStrategy.play(restart: false)
+
+        vlcStrategy.addPlaybackTrack(trackURL,
+                                     type: mediaTrackType,
+                                     enforce: enforceSelection)
+    }
+
+    private var downloadRequest: DownloadRequest?
+    private func prepareAndStartPlayback(for metadata: tableMetadata) {
+        self.state = .gettingURL
+        networking.getVideoUrl(metadata: metadata) { url, error in
+            if error == .success, let url = url {
+                self.onReceived(playbackURL: url, metadata: metadata)
+            } else {
+                Task { @MainActor in
+                    guard let metadata = await self.database.setMetadataSessionInWaitDownloadAsync(ocId: metadata.ocId,
+                                                                                                   session: self.networking.sessionDownload,
+                                                                                                   selector: "") else {
+                        return
+                    }
+                    let results = await self.networking.downloadFile(metadata: metadata) { request in
+                        self.downloadRequest = request
+                    } progressHandler: { progress in
+                        self.state = .downloading(progress: progress.fractionCompleted)
+                    }
+                    if results.nkError == .success {
+                        self.state = .downloaded
+                        if self.utilityFileSystem.fileProviderStorageExists(metadata) {
+                            let url = URL(fileURLWithPath: self.utilityFileSystem.getDirectoryProviderStorageOcId(metadata.ocId, fileName: metadata.fileNameView, userId: metadata.userId, urlBase: metadata.urlBase))
+                            self.onReceived(playbackURL: url, metadata: metadata)
+                        }
+                    } else {
+                        self.state = .error(error: results.nkError)
+                    }
+                }
+            }
+        }
+    }
+
+    func cancelDownload() {
+        downloadRequest?.cancel()
+        downloadRequest = nil
+    }
+
+    private func onReceived(playbackURL url: URL, metadata: tableMetadata) {
+        guard self.item?.ocId == metadata.ocId else { return }
+
+        if metadata.isVideo {
+            Task { @MainActor in
+                self.strategy = await createStrategy(for: url)
+                self.url = url
+                self.play()
+            }
+        } else {
+            self.strategy = NCMediaCoordinatorVLCStrategy(context: self)
+            self.url = url
+            self.play()
+        }
+    }
+
+    func forward() {
+        guard let metadata = self.item,
+              let index = items.firstIndex(where: { $0.ocId == metadata.ocId }),
+              index < items.count - 1 else {
+            return
+        }
+        let nextItemIndex = items.index(after: index)
+        let nextMetadata = items[nextItemIndex]
+        pause()
+        play(item: nextMetadata)
+    }
+
+    private var needToRestartOnRewindAfterPlayedSeconds: Int = 5
+    func rewind() {
+        guard let item, let strategy else { return }
+        if strategy.playedTimeInSeconds > needToRestartOnRewindAfterPlayedSeconds {
+            self.database.addVideoOrAudio(metadata: item, position: 0)
+            position = 0
+            return
+        }
+
+        guard let metadata = self.item,
+              let index = items.firstIndex(where: { $0.ocId == metadata.ocId }),
+              index > 0 else {
+            return
+        }
+        let prevItemIndex = items.index(before: index)
+        let prevMetadata = items[prevItemIndex]
+        pause()
+        play(item: prevMetadata)
+    }
+
+    func finishMediaSession(clearQueue: Bool = true) {
+        savePosition()
+        strategy?.finishMediaSession()
+        isPlayingSubject.send(false)
+        strategy = nil
+        item = nil
+        playRepeat = false
+        if clearQueue {
+            items.removeAll()
+        }
+        clearNowPlaying()
+        isPictureInPictureSupported = false
+        isPictureInPictureActive = false
+    }
+
+    // MARK: - Command Center
+
+    private func setNowPlayingInfo() {
+        var nowPlayingInfo = [String: Any]()
+
+        UIApplication.shared.beginReceivingRemoteControlEvents()
+
+        // Add handler for Play Command
+        MPRemoteCommandCenter.shared().playCommand.isEnabled = true
+        if playCommand == nil {
+            playCommand = MPRemoteCommandCenter.shared().playCommand.addTarget { _ in
+                if !self.isPlaying {
+                    self.play()
+                    return .success
+                }
+                return .commandFailed
+            }
+        }
+
+        // Add handler for Pause Command
+        MPRemoteCommandCenter.shared().pauseCommand.isEnabled = true
+        if pauseCommand == nil {
+            pauseCommand = MPRemoteCommandCenter.shared().pauseCommand.addTarget { _ in
+                if self.isPlaying {
+                    self.pause()
+                    return .success
+                }
+                return .commandFailed
+            }
+        }
+
+        if item?.isVideo == true {
+            // Seek Backward
+            MPRemoteCommandCenter.shared().skipBackwardCommand.isEnabled = true
+            if skipBackwardCommand == nil {
+                skipBackwardCommand = MPRemoteCommandCenter.shared().skipBackwardCommand.addTarget { _ in
+                    self.jumpBackward(Int32(Self.secondsToSeek))
+                    return .success
+                }
+            }
+            // Seek Forward
+            MPRemoteCommandCenter.shared().skipForwardCommand.isEnabled = true
+            if skipForwardCommand == nil {
+                skipForwardCommand = MPRemoteCommandCenter.shared().skipForwardCommand.addTarget { _ in
+                    self.jumpForward(Int32(Self.secondsToSeek))
+                    return .success
+                }
+            }
+        } else {
+            // Previous Track
+            MPRemoteCommandCenter.shared().previousTrackCommand.isEnabled = true
+            if previousTrackCommand == nil {
+                previousTrackCommand = MPRemoteCommandCenter.shared().previousTrackCommand.addTarget { _ in
+                    self.rewind()
+                    return .success
+                }
+            }
+
+            // Next Track
+            MPRemoteCommandCenter.shared().nextTrackCommand.isEnabled = true
+            if nextTrackCommand == nil {
+                nextTrackCommand = MPRemoteCommandCenter.shared().nextTrackCommand.addTarget { _ in
+                    self.forward()
+                    return .success
+                }
+            }
+        }
+
+        nowPlayingInfo[MPMediaItemPropertyTitle] = item?.fileName
+        if let coverImage {
+            nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: coverImage.size) { _ in
+                return coverImage
+            }
+        }
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    }
+
+    private func updateNowPlayingTime() {
+        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+
+        let length = self.length / 1000
+        let positionInSecond = position * length
+
+        nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = length
+        nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = positionInSecond
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    }
+
+    private func updateNowPlayingPlaybackRate(isPlaying: Bool) {
+        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1 : 0
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    }
+
+    private func updateNowPlayingImage(_ image: UIImage?) {
+        var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+        if let image = image {
+            nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in
+                return image
+            }
+        } else {
+            nowPlayingInfo.removeValue(forKey: MPMediaItemPropertyArtwork)
+        }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    }
+
+    private func clearNowPlaying() {
+        UIApplication.shared.endReceivingRemoteControlEvents()
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = [:]
+
+        MPRemoteCommandCenter.shared().playCommand.isEnabled = false
+        MPRemoteCommandCenter.shared().pauseCommand.isEnabled = false
+        MPRemoteCommandCenter.shared().nextTrackCommand.isEnabled = false
+        MPRemoteCommandCenter.shared().previousTrackCommand.isEnabled = false
+        MPRemoteCommandCenter.shared().skipBackwardCommand.isEnabled = false
+        MPRemoteCommandCenter.shared().skipForwardCommand.isEnabled = false
+
+        if let playCommand = playCommand {
+            MPRemoteCommandCenter.shared().playCommand.removeTarget(playCommand)
+            self.playCommand = nil
+        }
+        if let pauseCommand = pauseCommand {
+            MPRemoteCommandCenter.shared().pauseCommand.removeTarget(pauseCommand)
+            self.pauseCommand = nil
+        }
+        if let previousTrackCommand = previousTrackCommand {
+            MPRemoteCommandCenter.shared().previousTrackCommand.removeTarget(previousTrackCommand)
+            self.previousTrackCommand = nil
+        }
+        if let nextTrackCommand = nextTrackCommand {
+            MPRemoteCommandCenter.shared().nextTrackCommand.removeTarget(nextTrackCommand)
+            self.nextTrackCommand = nil
+        }
+        if let skipBackwardCommand = skipBackwardCommand {
+            MPRemoteCommandCenter.shared().skipBackwardCommand.removeTarget(skipBackwardCommand)
+            self.skipBackwardCommand = nil
+        }
+        if let skipForwardCommand = skipForwardCommand {
+            MPRemoteCommandCenter.shared().skipForwardCommand.removeTarget(skipForwardCommand)
+            self.skipForwardCommand = nil
+        }
+    }
+
+    private func updateCoverImage() {
+        guard let item else { return }
+
+        self.coverImage = nil
+
+        if item.isVideo && !item.hasPreview {
+            utility.createImageFileFrom(metadata: item)
+            self.coverImage = utility.getImage(ocId: item.ocId,
+                                               etag: item.etag,
+                                               ext: global.previewExt1024,
+                                               userId: item.userId,
+                                               urlBase: item.urlBase)
+        } else if let image = UIImage(contentsOfFile: utilityFileSystem.getDirectoryProviderStorageImageOcId(item.ocId,
+                                                                                                             etag: item.etag,
+                                                                                                             ext: global.previewExt1024,
+                                                                                                             userId: item.userId,
+                                                                                                             urlBase: item.urlBase)) {
+            self.coverImage = image
+        } else if item.isAudio {
+            self.coverImage = utility.loadImage(named: "waveform", colors: [NCBrandColor.shared.iconImageColor2])
+        }
+    }
+
+    private func onItemPlaybackEnded() {
+        guard let ocId = item?.ocId,
+              let endedItemIndex = items.firstIndex(where: { $0.ocId == ocId }) else { return }
+
+        if endedItemIndex < items.count - 1 {
+            url = nil
+            let nextItemIndex = items.index(after: endedItemIndex)
+            let metadata = items[nextItemIndex]
+            play(item: metadata)
+        } else {
+            resetSavedPosition()
+            strategy?.onItemPlaybackEnded()
+        }
+    }
+
+    private func currentMediaIsInPlayer() -> Bool {
+        guard let strategy else { return false }
+        return strategy.currentMediaIsInPlayer()
+    }
+
+    // MARK: - Picture in Picture
+
+    func switchPictureInPicture() {
+        guard isPictureInPictureSupported else { return }
+
+        if isPictureInPictureActive {
+            strategy?.stopPictureInPicture()
+        } else {
+            strategy?.startPictureInPicture()
+        }
+    }
+
+    @MainActor
+    private func createStrategy(for url: URL) async -> NCMediaCoordinatorStrategy {
+        let avKitStrategy = NCMediaCoordinatorAVKitStrategy(context: self, url: url)
+        let isPlayableByAVKit = await avKitStrategy.isSupported(url: url)
+
+        let strategy: NCMediaCoordinatorStrategy
+        if isPlayableByAVKit {
+            strategy = avKitStrategy
+        } else {
+            let vlcStrategy = NCMediaCoordinatorVLCStrategy(context: self)
+            vlcStrategy.delegate = delegate
+            strategy = vlcStrategy
+        }
+
+        if let viewToPutVideoOutputView {
+            strategy.putVideoOutputView(in: viewToPutVideoOutputView)
+        }
+        isPictureInPictureSupported = strategy.isPictureInPictureSupported
+        return strategy
+    }
+}
+
+extension NCMediaCoordinator: NCMediaCoordinatorVLCStrategyContext, NCMediaCoordinatorAVKitStrategyContext {
+    var currentItem: tableMetadata? { item }
+
+    func savedPosition(for metadata: tableMetadata) -> Float? {
+        database.getVideoOrAudio(metadata: metadata)?.position
+    }
+
+    func handleMediaPlayerStateChanged(isPlaying: Bool, state: NCPlayerState) {
+        updateNowPlayingPlaybackRate(isPlaying: isPlaying)
+        isPlayingSubject.send(isPlaying)
+        self.state = state
+        switch state {
+        case .ended:
+            if playRepeat {
+                self.play(restart: true)
+            } else {
+                onItemPlaybackEnded()
+            }
+        default: break
+        }
+    }
+
+    func handleMediaPlayerTimeChanged() {
+        updateNowPlayingTime()
+        positionSubject.send(position)
+    }
+
+    func handlePictureInPictureStateChanged(isActive: Bool, dueToPlaybackEnded: Bool) {
+        guard isPictureInPictureActive != isActive else { return }
+        if !isActive && !dueToPlaybackEnded {
+            pause()
+        }
+        isPictureInPictureActive = isActive
+    }
+
+    func restoreUserInterfaceForPictureInPictureStop() {
+        guard let metadata = item, metadata.isVideo else { return }
+
+        Task { @MainActor in
+            // Resolve the tab bar controller for the scene where this media was opened
+            let controller: NCMainTabBarController?
+            if let sceneIdentifier = metadata.sceneIdentifier {
+                controller = SceneManager.shared.getController(sceneIdentifier: sceneIdentifier)
+            } else {
+                controller = SceneManager.shared.getControllers().first
+            }
+
+            guard let tabBarController = controller,
+                  let navigationController = tabBarController.currentNavigationController() else { return }
+
+            if let existingViewer = navigationController.viewControllers.last as? NCViewerMediaPage,
+               existingViewer.currentViewController.metadata.ocId == metadata.ocId {
+                return
+            }
+
+            guard let viewerMediaPageContainer = await NCViewer().getViewerController(metadata: metadata) else {
+                return
+            }
+
+            navigationController.pushViewController(viewerMediaPageContainer, animated: true)
+        }
+    }
+}

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinator.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinator.swift
@@ -624,7 +624,7 @@ class NCMediaCoordinator: NSObject {
     @MainActor
     private func createStrategy(for url: URL) async -> NCMediaCoordinatorStrategy {
         let avKitStrategy = NCMediaCoordinatorAVKitStrategy(context: self, url: url)
-        let isPlayableByAVKit = await avKitStrategy.isSupported(url: url)
+        let isPlayableByAVKit = await avKitStrategy.isSupported()
 
         let strategy: NCMediaCoordinatorStrategy
         if isPlayableByAVKit {

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorAVKitStrategy.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorAVKitStrategy.swift
@@ -47,7 +47,7 @@ class NCMediaCoordinatorAVKitStrategy: NSObject, NCMediaCoordinatorStrategy {
     private var playbackEndedObserver: Any?
     private var playingTimeControlStatusObserver: NSKeyValueObservation?
 
-    private var pictureInPictureController: AVPictureInPictureController?
+    private let pictureInPictureController: AVPictureInPictureController?
 
     private var isAudioSessionActive: Bool = false
     private let session = AVAudioSession.sharedInstance()
@@ -62,13 +62,17 @@ class NCMediaCoordinatorAVKitStrategy: NSObject, NCMediaCoordinatorStrategy {
         self.context = context
         self.url = url
         self.playerItem = AVPlayerItem(url: url)
+        self.pictureInPictureController = AVPictureInPictureController(playerLayer: videoOutputView.playerLayer)
+        self.pictureInPictureController?.canStartPictureInPictureAutomaticallyFromInline = true
+        super.init()
+        self.pictureInPictureController?.delegate = self
     }
 
     deinit {
         removeObservers()
     }
 
-    func isSupported(url: URL) async -> Bool {
+    func isSupported() async -> Bool {
         let isPlayable = try? await playerItem?.asset.load(.isPlayable)
         return isPlayable == true
     }
@@ -237,7 +241,6 @@ class NCMediaCoordinatorAVKitStrategy: NSObject, NCMediaCoordinatorStrategy {
         player?.seek(to: .zero)
         removeObservers()
         pictureInPictureController?.stopPictureInPicture()
-        pictureInPictureController = nil
         player = nil
         playerItem = nil
         url = nil
@@ -250,7 +253,6 @@ class NCMediaCoordinatorAVKitStrategy: NSObject, NCMediaCoordinatorStrategy {
         removeObservers()
         pictureInPictureController?.stopPictureInPicture()
         context.handlePictureInPictureStateChanged(isActive: false, dueToPlaybackEnded: true)
-        pictureInPictureController = nil
         player = nil
         deactivateAudioSessionIfNeeded()
     }
@@ -278,28 +280,19 @@ class NCMediaCoordinatorAVKitStrategy: NSObject, NCMediaCoordinatorStrategy {
     func startPictureInPicture() {
         guard isPictureInPictureSupported else { return }
 
-        if pictureInPictureController == nil {
-            let controller = AVPictureInPictureController(playerLayer: videoOutputView.playerLayer)
-            controller?.canStartPictureInPictureAutomaticallyFromInline = true
-            controller?.delegate = self
-            pictureInPictureController = controller
-        }
-
-        guard let controller = pictureInPictureController,
-              !controller.isPictureInPictureActive else {
+        if pictureInPictureController?.isPictureInPictureActive ?? false {
             return
         }
 
-        controller.startPictureInPicture()
+        pictureInPictureController?.startPictureInPicture()
     }
 
     func stopPictureInPicture() {
-        guard let controller = pictureInPictureController,
-              controller.isPictureInPictureActive else {
+        guard pictureInPictureController?.isPictureInPictureActive ?? false else {
             return
         }
 
-        controller.stopPictureInPicture()
+        pictureInPictureController?.stopPictureInPicture()
     }
 
     func play() {
@@ -533,12 +526,10 @@ extension NCMediaCoordinatorAVKitStrategy: AVPictureInPictureControllerDelegate 
     }
 
     func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-        self.pictureInPictureController = nil
         context.handlePictureInPictureStateChanged(isActive: false, dueToPlaybackEnded: false)
     }
 
     func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
-        self.pictureInPictureController = nil
         context.handlePictureInPictureStateChanged(isActive: false, dueToPlaybackEnded: false)
     }
 

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorAVKitStrategy.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorAVKitStrategy.swift
@@ -1,0 +1,551 @@
+// SPDX-FileCopyrightText: STRATO GmbH
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import AVKit
+import AVFoundation
+import UIKit
+
+protocol NCMediaCoordinatorAVKitStrategyContext: AnyObject {
+    var currentItem: tableMetadata? { get }
+
+    func play(item: tableMetadata)
+    func savedPosition(for metadata: tableMetadata) -> Float?
+
+    func handleMediaPlayerStateChanged(isPlaying: Bool, state: NCPlayerState)
+    func handleMediaPlayerTimeChanged()
+
+    func handlePictureInPictureStateChanged(isActive: Bool, dueToPlaybackEnded: Bool)
+    func restoreUserInterfaceForPictureInPictureStop()
+}
+
+private class NCMediaCoordinatorAVKitVideoView: UIView {
+    override class var layerClass: AnyClass {
+        AVPlayerLayer.self
+    }
+
+    var playerLayer: AVPlayerLayer {
+        // swiftlint:disable force_cast
+        return layer as! AVPlayerLayer
+        // swiftlint:enable force_cast
+    }
+}
+
+class NCMediaCoordinatorAVKitStrategy: NSObject, NCMediaCoordinatorStrategy {
+
+    private static let preferredTimescale: CMTimeScale = 600
+
+    private let context: NCMediaCoordinatorAVKitStrategyContext
+
+    private let videoOutputView = NCMediaCoordinatorAVKitVideoView()
+    private var player: AVPlayer?
+    private var playerItem: AVPlayerItem?
+
+    private var positionToSeekToOnFirstPlay: Double = Double.nan
+
+    private var timeObserverToken: Any?
+    private var playbackEndedObserver: Any?
+    private var playingTimeControlStatusObserver: NSKeyValueObservation?
+
+    private var pictureInPictureController: AVPictureInPictureController?
+
+    private var isAudioSessionActive: Bool = false
+    private let session = AVAudioSession.sharedInstance()
+
+    private(set) var state: NCPlayerState = .stopped
+
+    var isPictureInPictureSupported: Bool {
+        return AVPictureInPictureController.isPictureInPictureSupported()
+    }
+
+    init(context: NCMediaCoordinatorAVKitStrategyContext, url: URL) {
+        self.context = context
+        self.url = url
+        self.playerItem = AVPlayerItem(url: url)
+    }
+
+    deinit {
+        removeObservers()
+    }
+
+    func isSupported(url: URL) async -> Bool {
+        let isPlayable = try? await playerItem?.asset.load(.isPlayable)
+        return isPlayable == true
+    }
+
+    // MARK: - NCMediaCoordinatorStrategy
+
+    var url: URL? {
+        didSet(oldValue) {
+            guard oldValue != url else { return }
+            if let url {
+                playerItem = AVPlayerItem(url: url)
+            } else {
+                playerItem = nil
+            }
+        }
+    }
+
+    var position: Float {
+        get {
+            guard isVideoDurationAvailable(), let currentItem = player?.currentItem else {
+                    return 0
+                }
+
+            let currentTime = player?.currentTime() ?? .zero
+            let ratio = currentTime.seconds / currentItem.duration.seconds
+            return Float(ratio)
+        }
+        set {
+            guard isVideoDurationAvailable(), let currentItem = player?.currentItem else {
+                return
+            }
+
+            let seconds = currentItem.duration.seconds * Double(newValue)
+            let time = CMTime(seconds: max(0, seconds), preferredTimescale: Self.preferredTimescale)
+            player?.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+        }
+    }
+
+    var length: Float {
+        guard let duration = player?.currentItem?.duration, duration.isNumeric else { return 0 }
+        return Float(duration.seconds * 1000)
+    }
+
+    var isPlaying: Bool {
+        return player?.timeControlStatus == .playing
+    }
+
+    var currentAudioTrackIndex: Int32 {
+        get {
+            guard let item = player?.currentItem,
+                let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .audible),
+                let selected = item.currentMediaSelection.selectedMediaOption(in: group),
+                let index = group.options.firstIndex(of: selected) else {
+                    return 0
+            }
+            return Int32(index)
+        }
+        set {
+            guard let item = player?.currentItem,
+                let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .audible) else {
+                return
+            }
+
+            let options = group.options
+            let idx = Int(newValue)
+            guard options.indices.contains(idx) else { return }
+
+            let option = options[idx]
+            item.select(option, in: group)
+        }
+    }
+
+    var currentVideoSubTitleIndex: Int32 {
+        get {
+            guard let item = player?.currentItem,
+                let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible),
+                let selected = item.currentMediaSelection.selectedMediaOption(in: group),
+                let index = group.options.firstIndex(of: selected) else {
+                    return 0
+            }
+            return Int32(index)
+        }
+        set {
+            guard let item = player?.currentItem,
+                let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else {
+                    return
+            }
+
+            let options = group.options
+            let idx = Int(newValue)
+            guard options.indices.contains(idx) else { return }
+
+            let option = options[idx]
+            item.select(option, in: group)
+        }
+    }
+
+    var videoSubTitlesNames: [String] {
+        guard let item = player?.currentItem,
+            let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else {
+                return []
+        }
+
+        return group.options.map { $0.displayName }
+    }
+
+    var videoSubTitlesIndexes: [Int32] {
+        guard let item = player?.currentItem,
+            let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else {
+                return []
+        }
+
+        return group.options.indices.map { Int32($0) }
+    }
+
+    var audioTrackNames: [String] {
+        guard let item = player?.currentItem,
+            let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .audible)
+        else { return [] }
+
+        return group.options.map { $0.displayName }
+    }
+
+    var audioTrackIndexes: [Int32] {
+        guard let item = player?.currentItem,
+            let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: .audible) else {
+                return []
+        }
+
+        return group.options.indices.map { Int32($0) }
+    }
+
+    var videoSize: CGSize {
+        return player?.currentItem?.presentationSize ?? .zero
+    }
+
+    var playedTimeInSeconds: Int {
+        let seconds = player?.currentTime().seconds ?? 0
+        guard seconds.isFinite && seconds >= 0 else { return 0 }
+        return Int(seconds)
+    }
+
+    var playedTime: String {
+        return formattedTime(for: player?.currentTime())
+    }
+
+    var remainingTime: String {
+        guard let item = player?.currentItem,
+            item.duration.isNumeric else {
+                return NCMediaCoordinatorConstants.emptyTime
+        }
+
+        let currentSeconds = player?.currentTime().seconds ?? 0
+        let totalSeconds = item.duration.seconds
+
+        guard totalSeconds.isFinite && totalSeconds > 0 else {
+            return NCMediaCoordinatorConstants.emptyTime
+        }
+
+        let remaining = max(0, totalSeconds - currentSeconds)
+        return "-\(formattedTime(for: CMTime(seconds: remaining, preferredTimescale: Self.preferredTimescale)))"
+    }
+
+    func finishMediaSession() {
+        player?.pause()
+        player?.seek(to: .zero)
+        removeObservers()
+        pictureInPictureController?.stopPictureInPicture()
+        pictureInPictureController = nil
+        player = nil
+        playerItem = nil
+        url = nil
+        updateState(isPlaying: false, state: .stopped)
+        deactivateAudioSessionIfNeeded()
+        videoOutputView.removeFromSuperview()
+    }
+
+    func onItemPlaybackEnded() {
+        removeObservers()
+        pictureInPictureController?.stopPictureInPicture()
+        context.handlePictureInPictureStateChanged(isActive: false, dueToPlaybackEnded: true)
+        pictureInPictureController = nil
+        player = nil
+        deactivateAudioSessionIfNeeded()
+    }
+
+    func putVideoOutputView(in view: UIView) {
+        guard videoOutputView.superview !== view else { return }
+
+        videoOutputView.removeFromSuperview()
+        videoOutputView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(videoOutputView)
+
+        NSLayoutConstraint.activate([
+            videoOutputView.topAnchor.constraint(equalTo: view.topAnchor),
+            videoOutputView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            videoOutputView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            videoOutputView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        if let player {
+            videoOutputView.playerLayer.player = player
+            videoOutputView.playerLayer.videoGravity = .resizeAspect
+        }
+    }
+
+    func startPictureInPicture() {
+        guard isPictureInPictureSupported else { return }
+
+        if pictureInPictureController == nil {
+            let controller = AVPictureInPictureController(playerLayer: videoOutputView.playerLayer)
+            controller?.canStartPictureInPictureAutomaticallyFromInline = true
+            controller?.delegate = self
+            pictureInPictureController = controller
+        }
+
+        guard let controller = pictureInPictureController,
+              !controller.isPictureInPictureActive else {
+            return
+        }
+
+        controller.startPictureInPicture()
+    }
+
+    func stopPictureInPicture() {
+        guard let controller = pictureInPictureController,
+              controller.isPictureInPictureActive else {
+            return
+        }
+
+        controller.stopPictureInPicture()
+    }
+
+    func play() {
+        player?.play()
+    }
+
+    func play(restart: Bool) {
+        guard !isPlayerInErrorState() else {
+            if let item = context.currentItem {
+                context.play(item: item)
+            }
+            return
+        }
+
+        if player == nil, let url {
+            playerItem = AVPlayerItem(url: url)
+            setUpPlayer()
+        }
+
+        if restart {
+            player?.seek(to: .zero)
+        } else if let item = context.currentItem, let savedPosition = context.savedPosition(for: item) {
+            positionToSeekToOnFirstPlay = Double(savedPosition)
+        }
+
+        activateAudioSessionIfNeeded()
+        player?.audiovisualBackgroundPlaybackPolicy = .continuesIfPossible
+        player?.play()
+    }
+
+    func pause() {
+        player?.pause()
+    }
+
+    func stop() {
+        player?.pause()
+        player?.seek(to: .zero)
+        updateState(isPlaying: false, state: .stopped)
+        deactivateAudioSessionIfNeeded()
+    }
+
+    func jumpForward(_ seconds: Int32) {
+        seek(by: TimeInterval(seconds))
+    }
+
+    func jumpBackward(_ seconds: Int32) {
+        seek(by: -TimeInterval(seconds))
+    }
+
+    func currentMediaLengthInSeconds() -> Int {
+        guard let duration = player?.currentItem?.duration, duration.isNumeric else { return 0 }
+        return Int(duration.seconds)
+    }
+
+    func currentMediaIsInPlayer() -> Bool {
+        guard let currentItem = player?.currentItem,
+            let asset = currentItem.asset as? AVURLAsset,
+            let url else {
+                return false
+        }
+
+        return asset.url == url
+    }
+
+    // MARK: - Private helpers
+
+    private func setUpPlayer() {
+        removeObservers()
+
+        guard let playerItem else { return }
+
+        let player = AVPlayer(playerItem: playerItem)
+        self.player = player
+
+        videoOutputView.playerLayer.player = player
+        videoOutputView.playerLayer.videoGravity = .resizeAspect
+
+        addObservers()
+    }
+
+    private func seek(by delta: TimeInterval) {
+        guard let player else { return }
+
+        let currentSeconds = player.currentTime().seconds
+        guard currentSeconds.isFinite else { return }
+
+        let targetSeconds = max(0, currentSeconds + delta)
+        let time = CMTime(seconds: targetSeconds, preferredTimescale: Self.preferredTimescale)
+        player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    private func isPlayerInErrorState() -> Bool {
+        switch state {
+        case .error: return true
+        default: return false
+        }
+    }
+
+    private func addObservers() {
+        guard let player else { return }
+
+        timeObserverToken = player.addPeriodicTimeObserver(
+            forInterval: CMTime(seconds: 0.5, preferredTimescale: Self.preferredTimescale),
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.seekToPositionToSeekToOnFirstPlay()
+            self.context.handleMediaPlayerTimeChanged()
+        }
+
+        playbackEndedObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: player.currentItem,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.updateState(isPlaying: false, state: .ended)
+            self.context.handleMediaPlayerTimeChanged()
+        }
+
+        playingTimeControlStatusObserver = player.observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
+            guard let self = self else { return }
+            switch player.timeControlStatus {
+            case .playing:
+                self.updateState(isPlaying: true, state: .playing)
+            case .paused:
+                self.updateState(isPlaying: false, state: .paused)
+            case .waitingToPlayAtSpecifiedRate:
+                self.updateState(isPlaying: false, state: .buffering)
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    private func seekToPositionToSeekToOnFirstPlay() {
+        guard !positionToSeekToOnFirstPlay.isNaN,
+              isVideoDurationAvailable(),
+              let currentItem = player?.currentItem else {
+            return
+        }
+        let seconds = currentItem.duration.seconds * positionToSeekToOnFirstPlay
+        let time = CMTime(seconds: max(0, seconds), preferredTimescale: Self.preferredTimescale)
+        player?.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+        positionToSeekToOnFirstPlay = Double.nan
+    }
+
+    private func isVideoDurationAvailable() -> Bool {
+        guard let currentItem = player?.currentItem,
+                currentItem.duration.isNumeric,
+                currentItem.duration.seconds > 0 else {
+                return false
+            }
+        return true
+    }
+
+    private func removeObservers() {
+        if let token = timeObserverToken {
+            player?.removeTimeObserver(token)
+            timeObserverToken = nil
+        }
+
+        if let playbackEndedObserver {
+            NotificationCenter.default.removeObserver(playbackEndedObserver)
+            self.playbackEndedObserver = nil
+        }
+
+        if let playingTimeControlStatusObserver {
+            playingTimeControlStatusObserver.invalidate()
+            self.playingTimeControlStatusObserver = nil
+        }
+    }
+
+    private func updateState(isPlaying: Bool, state: NCPlayerState) {
+        self.state = state
+        context.handleMediaPlayerStateChanged(isPlaying: isPlaying, state: state)
+    }
+
+    private func activateAudioSessionIfNeeded() {
+        guard !isAudioSessionActive else { return }
+
+        do {
+            try session.setCategory(.playback, mode: .moviePlayback)
+            try session.setActive(true)
+            isAudioSessionActive = true
+        } catch {
+            isAudioSessionActive = false
+            #if DEBUG
+            print("Failed to activate AVAudioSession: \(error)")
+            #endif
+        }
+    }
+
+    private func deactivateAudioSessionIfNeeded() {
+        guard isAudioSessionActive else { return }
+
+        do {
+            pause()
+            try session.setActive(false)
+            isAudioSessionActive = false
+        } catch {
+            #if DEBUG
+            print("Failed to deactivate AVAudioSession: \(error)")
+            #endif
+        }
+    }
+
+    private func formattedTime(for time: CMTime?) -> String {
+        guard let time,
+              time.isNumeric else {
+            return NCMediaCoordinatorConstants.emptyTime
+        }
+
+        let totalSeconds = Int(time.seconds)
+        let seconds = totalSeconds % 60
+        let minutes = (totalSeconds / 60) % 60
+        let hours = totalSeconds / 3600
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            return String(format: "%02d:%02d", minutes, seconds)
+        }
+    }
+}
+
+extension NCMediaCoordinatorAVKitStrategy: AVPictureInPictureControllerDelegate {
+
+    func pictureInPictureControllerWillStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        context.handlePictureInPictureStateChanged(isActive: true, dueToPlaybackEnded: false)
+    }
+
+    func pictureInPictureControllerDidStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        self.pictureInPictureController = nil
+        context.handlePictureInPictureStateChanged(isActive: false, dueToPlaybackEnded: false)
+    }
+
+    func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
+        self.pictureInPictureController = nil
+        context.handlePictureInPictureStateChanged(isActive: false, dueToPlaybackEnded: false)
+    }
+
+    func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController,
+                                    restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void) {
+        context.handlePictureInPictureStateChanged(isActive: false, dueToPlaybackEnded: false)
+        context.restoreUserInterfaceForPictureInPictureStop()
+        completionHandler(true)
+    }
+}

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorConstants.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorConstants.swift
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: STRATO GmbH
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+enum NCMediaCoordinatorConstants {
+    static let emptyTime: String = "--:--"
+}

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorStrategy.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorStrategy.swift
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: STRATO GmbH
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+protocol NCMediaCoordinatorStrategy {
+
+    var url: URL? { get set }
+
+    var position: Float { get set }
+    var length: Float { get }
+    var isPlaying: Bool { get }
+    var currentAudioTrackIndex: Int32 { get set }
+    var currentVideoSubTitleIndex: Int32 { get set }
+    var videoSubTitlesNames: [String] { get }
+    var videoSubTitlesIndexes: [Int32] { get }
+    var audioTrackNames: [String] { get }
+    var audioTrackIndexes: [Int32] { get }
+    var videoSize: CGSize { get }
+
+    var playedTimeInSeconds: Int { get }
+    var playedTime: String { get }
+    var remainingTime: String { get }
+
+    var state: NCPlayerState { get }
+
+    var isPictureInPictureSupported: Bool { get }
+    func startPictureInPicture()
+    func stopPictureInPicture()
+
+    func finishMediaSession()
+
+    func onItemPlaybackEnded()
+
+    func putVideoOutputView(in view: UIView)
+
+    func play()
+    func play(restart: Bool)
+    func pause()
+    func stop()
+    func jumpForward(_ seconds: Int32)
+    func jumpBackward(_ seconds: Int32)
+
+    func currentMediaLengthInSeconds() -> Int
+    func currentMediaIsInPlayer() -> Bool
+}

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorVLCStrategy.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaCoordinator/NCMediaCoordinatorVLCStrategy.swift
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: STRATO GmbH
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import MobileVLCKit
+import UIKit
+
+private class PassThroughVLCVideoView: UIView {
+    override func addSubview(_ view: UIView) {
+        super.addSubview(view)
+        view.isUserInteractionEnabled = false
+    }
+}
+
+protocol NCMediaCoordinatorVLCStrategyContext: AnyObject {
+    var currentItem: tableMetadata? { get }
+
+    func play(item: tableMetadata)
+    func savedPosition(for metadata: tableMetadata) -> Float?
+
+    func handleMediaPlayerStateChanged(isPlaying: Bool, state: NCPlayerState)
+    func handleMediaPlayerTimeChanged()
+}
+
+protocol NCMediaCoordinatorVLCStrategyDelegate: AnyObject {
+    func showError(withTitle title: String, message: String)
+    func showAlert(alert: UIAlertController)
+    func showLogin(withTitle title: String, message: String, defaultUsername username: String?, askingForStorage: Bool, withReference reference: NSValue)
+    func showProgress(withTitle title: String, message: String, isIndeterminate: Bool, position: Float, cancel cancelString: String?, withReference reference: NSValue)
+    func updateProgress(withReference reference: NSValue, message: String?, position: Float)
+    func cancelDialog(withReference reference: NSValue)
+}
+
+extension NCPlayerState {
+    init(vlcState: VLCMediaPlayerState) {
+        switch vlcState {
+        case .stopped: self = .stopped
+        case .opening: self = .opening
+        case .buffering: self = .buffering
+        case .ended: self = .ended
+        case .error: self = .error(error: nil)
+        case .playing: self = .playing
+        case .paused: self = .paused
+        case .esAdded: self = .streamAdded
+        default: self = .stopped
+        }
+    }
+}
+
+extension NCMediaCoordinator.MediaTrackType {
+    var vlcType: VLCMediaPlaybackSlaveType {
+        switch self {
+        case .audio: return .audio
+        case .subtitle: return .subtitle
+        }
+    }
+}
+
+class NCMediaCoordinatorVLCStrategy: NSObject, NCMediaCoordinatorStrategy {
+
+    var context: NCMediaCoordinatorVLCStrategyContext
+    var delegate: NCMediaCoordinatorVLCStrategyDelegate?
+
+    private var dialogProvider: VLCDialogProvider?
+
+    private let videoOutputView = PassThroughVLCVideoView()
+
+    // VLC-specific properties moved from NCMediaCoordinator
+    private var media: VLCMedia?
+    private var player: VLCMediaPlayer?
+
+    // Exposed accessors for coordinator
+    var drawableView: UIView {
+        videoOutputView
+    }
+
+    var vlcMedia: VLCMedia? {
+        get { media }
+        set { media = newValue }
+    }
+
+    var vlcPlayer: VLCMediaPlayer? {
+        get { player }
+        set { player = newValue }
+    }
+
+    var url: URL? {
+        didSet {
+            if let url = url {
+                media = VLCMedia(url: url)
+                media?.addOption(":http-user-agent=\(userAgent)")
+            } else {
+                media = nil
+            }
+        }
+    }
+
+    var position: Float {
+        get {
+            return player?.position ?? 0
+        }
+        set {
+            player?.position = newValue
+        }
+    }
+
+    var length: Float {
+        return Float(media?.length.intValue ?? 0)
+    }
+
+    var isPlaying: Bool {
+        return player?.isPlaying ?? false
+    }
+
+    var currentAudioTrackIndex: Int32 {
+        get { return player?.currentAudioTrackIndex ?? 0 }
+        set { player?.currentAudioTrackIndex = newValue }
+    }
+
+    var currentVideoSubTitleIndex: Int32 {
+        get { return player?.currentVideoSubTitleIndex ?? 0 }
+        set { player?.currentVideoSubTitleIndex = newValue }
+    }
+
+    var videoSubTitlesNames: [String] {
+        return player?.videoSubTitlesNames.compactMap { $0 as? String } ?? []
+    }
+
+    var videoSubTitlesIndexes: [Int32] {
+        return player?.videoSubTitlesIndexes.compactMap { $0 as? Int32 } ?? []
+    }
+
+    var audioTrackNames: [String] {
+        return player?.audioTrackNames.compactMap { $0 as? String } ?? []
+    }
+
+    var audioTrackIndexes: [Int32] {
+        return player?.audioTrackIndexes.compactMap { $0 as? Int32 } ?? []
+    }
+
+    var videoSize: CGSize {
+        return player?.videoSize ?? .zero
+    }
+
+    var playedTimeInSeconds: Int {
+        return Int(player?.time.intValue ?? 0) / 1000
+    }
+
+    var playedTime: String {
+        return player?.time.stringValue ?? ""
+    }
+
+    var remainingTime: String {
+        return player?.remainingTime?.stringValue ?? ""
+    }
+
+    var state: NCPlayerState {
+        return NCPlayerState(vlcState: player?.state ?? .stopped)
+    }
+
+    var isPictureInPictureSupported: Bool {
+        return false
+    }
+
+    func startPictureInPicture() {
+        // Not supported
+    }
+
+    func stopPictureInPicture() {
+        // Not supported
+    }
+
+    init(context: NCMediaCoordinatorVLCStrategyContext) {
+        self.context = context
+    }
+
+    func finishMediaSession() {
+        player?.stop()
+        position = 0
+        player = nil
+        url = nil
+        dialogProvider = nil
+        videoOutputView.removeFromSuperview()
+    }
+
+    func onItemPlaybackEnded() {
+        player = nil
+        position = 0
+    }
+
+    func putVideoOutputView(in view: UIView) {
+        guard videoOutputView.superview != view else { return }
+        videoOutputView.removeFromSuperview()
+        videoOutputView.translatesAutoresizingMaskIntoConstraints = false
+        videoOutputView.isUserInteractionEnabled = false
+        view.addSubview(videoOutputView)
+        NSLayoutConstraint.activate([
+            videoOutputView.topAnchor.constraint(equalTo: view.topAnchor),
+            videoOutputView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            videoOutputView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            videoOutputView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    func play(restart: Bool) {
+        guard !isPlayerInErrorState() else {
+            if let item = context.currentItem {
+                context.play(item: item)
+            }
+            return
+        }
+        guard let player, currentMediaIsInPlayer() && !restart else {
+            stop()
+            setUpDialogProvider()
+            player = VLCMediaPlayer()
+            player?.drawable = drawableView
+            player?.media = vlcMedia
+            player?.delegate = self
+
+            var position: Float = 0
+            if !restart, let item = context.currentItem, let resultPosition = context.savedPosition(for: item) {
+                position = resultPosition
+            }
+
+            player?.play()
+            player?.position = position
+            return
+        }
+        player.play()
+    }
+
+    private func isPlayerInErrorState() -> Bool {
+        switch state {
+        case .error: return true
+        default: return false
+        }
+    }
+
+    func play() {
+        player?.play()
+    }
+
+    func pause() {
+        player?.pause()
+    }
+
+    func stop() {
+        player?.stop()
+    }
+
+    func jumpForward(_ seconds: Int32) {
+        player?.jumpForward(seconds)
+    }
+
+    func jumpBackward(_ seconds: Int32) {
+        player?.jumpBackward(seconds)
+    }
+
+    func currentMediaLengthInSeconds() -> Int {
+        return media?.lengthInSeconds ?? 0
+    }
+
+    func currentMediaIsInPlayer() -> Bool {
+        guard let player else { return false }
+        return (player.media?.compare(media) == .orderedSame)
+    }
+
+    func addPlaybackTrack(_ trackURL: URL,
+                          type mediaTrackType: NCMediaCoordinator.MediaTrackType,
+                          enforce enforceSelection: Bool) {
+        guard let player else { return }
+        player.addPlaybackSlave(trackURL, type: mediaTrackType.vlcType, enforce: enforceSelection)
+    }
+}
+
+extension NCMediaCoordinatorVLCStrategy: VLCMediaPlayerDelegate {
+    func mediaPlayerStateChanged(_ aNotification: Notification) {
+        context.handleMediaPlayerStateChanged(isPlaying: isPlaying, state: state)
+    }
+
+    func mediaPlayerTimeChanged(_ aNotification: Notification) {
+        context.handleMediaPlayerTimeChanged()
+    }
+}
+
+private extension VLCMedia {
+    var lengthInSeconds: Int {
+        return Int(length.intValue) / 1000
+    }
+}
+
+extension NCMediaCoordinatorVLCStrategy: VLCCustomDialogRendererProtocol {
+    private func setUpDialogProvider() {
+        guard dialogProvider == nil else { return }
+        dialogProvider = VLCDialogProvider(library: VLCLibrary.shared(), customUI: true)
+        dialogProvider?.customRenderer = self
+    }
+
+    func showError(withTitle error: String, message: String) {
+        delegate?.showError(withTitle: error, message: message)
+    }
+
+    func showLogin(withTitle title: String, message: String, defaultUsername username: String?, askingForStorage: Bool, withReference reference: NSValue) {
+        delegate?.showLogin(withTitle: title, message: message, defaultUsername: username, askingForStorage: askingForStorage, withReference: reference)
+    }
+
+    func showQuestion(withTitle title: String, message: String, type questionType: VLCDialogQuestionType, cancel cancelString: String?, action1String: String?, action2String: String?, withReference reference: NSValue) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
+        if let action1String = action1String {
+            alert.addAction(UIAlertAction(title: action1String, style: .default, handler: { _ in
+                self.dialogProvider?.postAction(1, forDialogReference: reference)
+            }))
+        }
+        if let action2String = action2String {
+            alert.addAction(UIAlertAction(title: action2String, style: .default, handler: { _ in
+                self.dialogProvider?.postAction(2, forDialogReference: reference)
+            }))
+        }
+        if let cancelString = cancelString {
+            alert.addAction(UIAlertAction(title: cancelString, style: .cancel, handler: { _ in
+                self.dialogProvider?.postAction(3, forDialogReference: reference)
+            }))
+        }
+
+        delegate?.showAlert(alert: alert)
+    }
+
+    func showProgress(withTitle title: String, message: String, isIndeterminate: Bool, position: Float, cancel cancelString: String?, withReference reference: NSValue) {
+        delegate?.showProgress(withTitle: title, message: message, isIndeterminate: isIndeterminate, position: position, cancel: cancelString, withReference: reference)
+    }
+
+    func updateProgress(withReference reference: NSValue, message: String?, position: Float) {
+        delegate?.updateProgress(withReference: reference, message: message, position: position)
+    }
+
+    func cancelDialog(withReference reference: NSValue) {
+        delegate?.cancelDialog(withReference: reference)
+    }
+}

--- a/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayer.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayer.swift
@@ -1,338 +1,110 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
 // SPDX-FileCopyrightText: 2021 Marino Faggiana
+// SPDX-FileCopyrightText: 2025 STRATO GmbH
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import Foundation
 import NextcloudKit
 import UIKit
 import MobileVLCKit
+import Combine
 
-class NCPlayer: NSObject, VLCMediaDelegate {
-    internal var url: URL?
-    internal var player = VLCMediaPlayer()
-    internal var dialogProvider: VLCDialogProvider?
-    internal var metadata: tableMetadata
-    internal var singleTapGestureRecognizer: UITapGestureRecognizer?
-    internal var activityIndicator: UIActivityIndicatorView
+class NCPlayer: NSObject {
+    private var mediaCoordinator = NCMediaCoordinator.shared
+    private var metadata: tableMetadata
     internal let database = NCManageDatabase.shared
     internal var width: Int?
     internal var height: Int?
     internal var length: Int?
-    internal var pauseAfterPlay: Bool = false
 
-    internal weak var playerToolBar: NCPlayerToolBar?
+    private weak var playerToolBar: NCPlayerToolBar?
     internal weak var viewerMediaPage: NCViewerMediaPage?
-
-    weak var imageVideoContainer: UIImageView?
-
-    internal var counterSeconds: Double = 0
 
     // MARK: - View Life Cycle
 
-    init(imageVideoContainer: UIImageView, playerToolBar: NCPlayerToolBar?, metadata: tableMetadata, viewerMediaPage: NCViewerMediaPage?) {
-        self.imageVideoContainer = imageVideoContainer
+    init(playerToolBar: NCPlayerToolBar?, metadata: tableMetadata, viewerMediaPage: NCViewerMediaPage?) {
         self.playerToolBar = playerToolBar
         self.metadata = metadata
         self.viewerMediaPage = viewerMediaPage
 
-        self.activityIndicator = UIActivityIndicatorView(style: .large)
-        self.activityIndicator.color = .white
-        self.activityIndicator.hidesWhenStopped = true
-        self.activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-
-        if let viewerMediaPage = viewerMediaPage {
-            viewerMediaPage.view.addSubview(activityIndicator)
-            NSLayoutConstraint.activate([
-                activityIndicator.centerXAnchor.constraint(equalTo: viewerMediaPage.view.centerXAnchor),
-                activityIndicator.centerYAnchor.constraint(equalTo: viewerMediaPage.view.centerYAnchor)
-            ])
-        }
-
         super.init()
+
+        configurePlayingUI()
     }
 
     deinit {
-        player.stop()
         print("deinit NCPlayer with ocId \(metadata.ocId)")
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterPlayerStoppedPlaying)
     }
 
-    func openAVPlayer(url: URL, autoplay: Bool = false) {
-        var position: Float = 0
-        let userAgent = userAgent
-
-        self.url = url
-        self.singleTapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didSingleTapWith(gestureRecognizer:)))
-
-        print("Playing URL: \(url)")
-        let media = VLCMedia(url: url)
-
-        media.parse(options: url.isFileURL ? .fetchLocal : .fetchNetwork)
-
-        player.media = media
-        player.delegate = self
-
-        dialogProvider = VLCDialogProvider(library: VLCLibrary.shared(), customUI: true)
-        dialogProvider?.customRenderer = self
-
-        player.media?.addOption(":http-user-agent=\(userAgent)")
-
-        if let result = self.database.getVideo(metadata: metadata),
-           let resultPosition = result.position {
-            position = resultPosition
-        }
-
-        if metadata.isVideo {
-            player.drawable = imageVideoContainer
-            if let view = player.drawable as? UIView, let singleTapGestureRecognizer = singleTapGestureRecognizer {
-                view.isUserInteractionEnabled = true
-                view.addGestureRecognizer(singleTapGestureRecognizer)
-            }
-        }
-
-        player.play()
-        player.position = position
-
-        if autoplay {
-            pauseAfterPlay = false
-        } else {
-            pauseAfterPlay = true
-        }
-
-        playerToolBar?.setBarPlayer(position: position, ncplayer: self, metadata: metadata, viewerMediaPage: viewerMediaPage)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground(_:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
-    }
-
-    func restartAVPlayer(position: Float, pauseAfterPlay: Bool) {
-        if let url = self.url, !player.isPlaying {
-
-            player.media = VLCMedia(url: url)
-            player.position = position
-            playerToolBar?.setBarPlayer(position: position)
-            viewerMediaPage?.changeScreenMode(mode: .normal)
-            self.pauseAfterPlay = pauseAfterPlay
-            player.play()
-
-            if metadata.isVideo {
-                if position == 0 {
-                    imageVideoContainer?.image = NCUtility().getImage(ocId: metadata.ocId, etag: metadata.etag, ext: NCGlobal.shared.previewExt1024, userId: metadata.userId, urlBase: metadata.urlBase)
-                } else {
-                    imageVideoContainer?.image = nil
-                }
-            }
-        }
-    }
-
-    // MARK: - UIGestureRecognizerDelegate
-
-    @objc func didSingleTapWith(gestureRecognizer: UITapGestureRecognizer) {
-        changeScreenMode()
-    }
-
-    func changeScreenMode() {
-        guard let viewerMediaPage = viewerMediaPage else { return }
-
-        if viewerMediaScreenMode == .full {
-            viewerMediaPage.changeScreenMode(mode: .normal)
-        } else {
-            viewerMediaPage.changeScreenMode(mode: .full)
-        }
-    }
-
-    // MARK: - NotificationCenter
-
-    @objc func applicationDidEnterBackground(_ notification: NSNotification) {
-        if metadata.isVideo {
-            playerPause()
-        }
+    private func configurePlayingUI() {
+        playerToolBar?.setBarPlayer(position: 0, ncplayer: self, metadata: metadata, viewerMediaPage: viewerMediaPage)
+        playerToolBar?.playerButtonView?.isHidden = false
     }
 
     // MARK: -
 
     func isPlaying() -> Bool {
-        return player.isPlaying
+        return mediaCoordinator.isPlaying
     }
 
     func playerPlay() {
+        guard metadata.ocId == mediaCoordinator.item?.ocId else {
+            mediaCoordinator.play(item: metadata)
+            return
+        }
         playerToolBar?.playbackSliderEvent = .began
 
-        if let result = self.database.getVideo(metadata: metadata), let position = result.position {
-            player.position = position
-            playerToolBar?.playbackSliderEvent = .moved
-        }
-
-        player.play()
+        mediaCoordinator.play()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             self.playerToolBar?.playbackSliderEvent = .ended
         }
     }
 
-    @objc func playerStop() {
-        savePosition()
-        player.stop()
-    }
-
     @objc func playerPause() {
-        savePosition()
-        player.pause()
+        mediaCoordinator.pause()
     }
 
     func playerPosition(_ position: Float) {
-        self.database.addVideo(metadata: metadata, position: position)
-        player.position = position
-    }
-
-    func savePosition() {
-        guard metadata.isVideo, isPlaying() else { return }
-        self.database.addVideo(metadata: metadata, position: player.position)
+        mediaCoordinator.position = position
     }
 
     func jumpForward(_ seconds: Int32) {
-        player.play()
-        player.jumpForward(seconds)
+        mediaCoordinator.jumpForward(seconds)
     }
 
     func jumpBackward(_ seconds: Int32) {
-        player.play()
-        player.jumpBackward(seconds)
-    }
-}
-
-extension NCPlayer: VLCMediaPlayerDelegate {
-    func mediaPlayerStateChanged(_ aNotification: Notification) {
-
-        if player.state == .buffering && player.isPlaying {
-            activityIndicator.startAnimating()
-        } else {
-            activityIndicator.stopAnimating()
-        }
-
-        switch player.state {
-        case .stopped:
-            playerToolBar?.showPlayButton()
-
-            NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterPlayerStoppedPlaying)
-
-            print("Player mode: STOPPED")
-        case .opening:
-            print("Player mode: OPENING")
-        case .buffering:
-            print("Player mode: BUFFERING")
-        case .ended:
-            self.database.addVideo(metadata: self.metadata, position: 0)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                if let playRepeat = self.playerToolBar?.playRepeat {
-                    self.restartAVPlayer(position: 0, pauseAfterPlay: !playRepeat)
-                }
-            }
-            playerToolBar?.showPlayButton()
-            print("Player mode: ENDED")
-        case .error:
-            print("Player mode: ERROR")
-        case .playing:
-            guard let playerToolBar = playerToolBar else { return }
-            if playerToolBar.playerButtonView.isHidden {
-                playerToolBar.playerButtonView.isHidden = false
-                viewerMediaPage?.changeScreenMode(mode: .normal)
-            }
-            if pauseAfterPlay {
-                player.pause()
-                pauseAfterPlay = false
-                self.viewerMediaPage?.updateCommandCenter(ncplayer: self, title: metadata.fileNameView)
-            } else {
-                playerToolBar.showPauseButton()
-                // Set track audio/subtitle
-                let data = self.database.getVideo(metadata: metadata)
-                if let currentAudioTrackIndex = data?.currentAudioTrackIndex {
-                    player.currentAudioTrackIndex = Int32(currentAudioTrackIndex)
-                }
-                if let currentVideoSubTitleIndex = data?.currentVideoSubTitleIndex {
-                    player.currentVideoSubTitleIndex = Int32(currentVideoSubTitleIndex)
-                }
-            }
-            let size = player.videoSize
-            if let mediaLength = player.media?.length.intValue {
-                self.length = Int(mediaLength)
-            }
-            self.width = Int(size.width)
-            self.height = Int(size.height)
-            playerToolBar.updatePlaybackPosition()
-            playerToolBar.updateTopToolBar(videoSubTitlesIndexes: player.videoSubTitlesIndexes, audioTrackIndexes: player.audioTrackIndexes)
-            self.database.addVideo(metadata: metadata, width: self.width, height: self.height, length: self.length)
-
-            NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterPlayerIsPlaying)
-
-            print("Player mode: PLAYING")
-        case .paused:
-            NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterPlayerStoppedPlaying)
-
-            playerToolBar?.showPlayButton()
-            print("Player mode: PAUSED")
-        default: break
-        }
+        mediaCoordinator.jumpBackward(seconds)
     }
 
-    func mediaPlayerTimeChanged(_ aNotification: Notification) {
-        activityIndicator.stopAnimating()
-        playerToolBar?.updatePlaybackPosition()
-    }
-}
-
-extension NCPlayer: VLCMediaThumbnailerDelegate {
-    func mediaThumbnailerDidTimeOut(_ mediaThumbnailer: VLCMediaThumbnailer) { }
-    func mediaThumbnailer(_ mediaThumbnailer: VLCMediaThumbnailer, didFinishThumbnail thumbnail: CGImage) { }
-}
-
-extension NCPlayer: VLCCustomDialogRendererProtocol {
-    func showError(withTitle error: String, message: String) {
-        let alert = UIAlertController(title: error, message: message, preferredStyle: .alert)
-
-        alert.addAction(UIAlertAction(title: NSLocalizedString("_ok_", comment: ""), style: .default, handler: { _ in
-            self.playerToolBar?.removeFromSuperview()
-            self.viewerMediaPage?.navigationController?.popViewController(animated: true)
-        }))
-
-        self.viewerMediaPage?.present(alert, animated: true)
+    var videoSubTitlesNames: [Any] {
+        mediaCoordinator.videoSubTitlesNames
     }
 
-    func showLogin(withTitle title: String, message: String, defaultUsername username: String?, askingForStorage: Bool, withReference reference: NSValue) {
-        // UIAlertController other states...
+    var videoSubTitlesIndexes: [Any] {
+        mediaCoordinator.videoSubTitlesIndexes
     }
 
-    func showQuestion(withTitle title: String, message: String, type questionType: VLCDialogQuestionType, cancel cancelString: String?, action1String: String?, action2String: String?, withReference reference: NSValue) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-
-        if let action1String = action1String {
-            alert.addAction(UIAlertAction(title: action1String, style: .default, handler: { _ in
-                self.dialogProvider?.postAction(1, forDialogReference: reference)
-            }))
-        }
-        if let action2String = action2String {
-            alert.addAction(UIAlertAction(title: action2String, style: .default, handler: { _ in
-                self.dialogProvider?.postAction(2, forDialogReference: reference)
-            }))
-        }
-        if let cancelString = cancelString {
-            alert.addAction(UIAlertAction(title: cancelString, style: .cancel, handler: { _ in
-                self.dialogProvider?.postAction(3, forDialogReference: reference)
-            }))
-        }
-
-        self.viewerMediaPage?.present(alert, animated: true)
+    var currentVideoSubTitleIndex: Int32 {
+        get { mediaCoordinator.currentVideoSubTitleIndex }
+        set { mediaCoordinator.currentVideoSubTitleIndex = newValue }
     }
 
-    func showProgress(withTitle title: String, message: String, isIndeterminate: Bool, position: Float, cancel cancelString: String?, withReference reference: NSValue) {
-        // UIAlertController other states...
+    var audioTrackNames: [Any] {
+        mediaCoordinator.audioTrackNames
     }
 
-    func updateProgress(withReference reference: NSValue, message: String?, position: Float) {
-        // UIAlertController other states...
+    var audioTrackIndexes: [Any] {
+        mediaCoordinator.audioTrackIndexes
     }
 
-    func cancelDialog(withReference reference: NSValue) {
-        // UIAlertController other states...
+    var currentAudioTrackIndex: Int32 {
+        get { mediaCoordinator.currentAudioTrackIndex }
+        set { mediaCoordinator.currentAudioTrackIndex = newValue }
+    }
+
+    func addPlaybackTrack(_ trackURL: URL, type mediaTrackType: NCMediaCoordinator.MediaTrackType, enforce enforceSelection: Bool) {
+        mediaCoordinator.addPlaybackTrack(trackURL, type: mediaTrackType, enforce: enforceSelection)
     }
 }

--- a/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.swift
@@ -1,22 +1,21 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
 // SPDX-FileCopyrightText: 2021 Marino Faggiana
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import Foundation
 import NextcloudKit
-import CoreMedia
 import UIKit
-import AVKit
-import MediaPlayer
-import MobileVLCKit
 import Alamofire
 import LucidBanner
+import Combine
 
 class NCPlayerToolBar: UIView {
     @IBOutlet weak var utilityView: UIView!
     @IBOutlet weak var fullscreenButton: UIButton!
     @IBOutlet weak var subtitleButton: UIButton!
     @IBOutlet weak var audioButton: UIButton!
+    @IBOutlet weak var pictureInPictureButton: UIButton!
 
     @IBOutlet weak var playerButtonView: UIStackView!
     @IBOutlet weak var backButton: UIButton!
@@ -29,6 +28,8 @@ class NCPlayerToolBar: UIView {
     @IBOutlet weak var labelCurrentTime: UILabel!
     @IBOutlet weak var repeatButton: UIButton!
 
+    private var mediaCoordinator = NCMediaCoordinator.shared
+
     enum sliderEventType {
         case none
         case began
@@ -38,11 +39,17 @@ class NCPlayerToolBar: UIView {
 
     var playbackSliderEvent: sliderEventType = .none
     var isFullscreen: Bool = false
-    var playRepeat: Bool = false
+    var playRepeat: Bool {
+        get {
+            mediaCoordinator.playRepeat
+        }
+        set {
+            mediaCoordinator.playRepeat = newValue
+        }
+    }
 
     private var ncplayer: NCPlayer?
     private var metadata: tableMetadata?
-    private let audioSession = AVAudioSession.sharedInstance()
     private var pointSize: CGFloat = 0
     private let utilityFileSystem = NCUtilityFileSystem()
     private let utility = NCUtility()
@@ -50,6 +57,8 @@ class NCPlayerToolBar: UIView {
     private let database = NCManageDatabase.shared
     private weak var viewerMediaPage: NCViewerMediaPage?
     private var buttonImage = UIImage()
+
+    private var cancellables = Set<AnyCancellable>()
 
     // MARK: - View Life Cycle
 
@@ -67,6 +76,11 @@ class NCPlayerToolBar: UIView {
         audioButton.setImage(utility.loadImage(named: "speaker.zzz", colors: [.white]), for: .normal)
         audioButton.isEnabled = false
         audioButton.showsMenuAsPrimaryAction = true
+
+        pictureInPictureButton.setImage(UIImage(systemName: "pip.enter")!.withTintColor(.white,
+                                                                                         renderingMode: .alwaysOriginal),
+                                         for: .normal)
+        pictureInPictureButton.isHidden = true
 
         if UIDevice.current.userInterfaceIdiom == .pad {
             pointSize = 60
@@ -91,7 +105,7 @@ class NCPlayerToolBar: UIView {
         playbackSlider.value = 0
         playbackSlider.tintColor = .white
         playbackSlider.addTarget(self, action: #selector(playbackValChanged(slider:event:)), for: .valueChanged)
-        repeatButton.setImage(utility.loadImage(named: "repeat", colors: [NCBrandColor.shared.iconImageColor2]), for: .normal)
+        updateRepeatButtonImage()
 
         utilityView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tap(gestureRecognizer:))))
         playbackSliderView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tap(gestureRecognizer:))))
@@ -104,6 +118,23 @@ class NCPlayerToolBar: UIView {
         // Normally hide
         self.alpha = 0
         self.isHidden = true
+
+        NCMediaCoordinator.shared.isPictureInPictureSupportedPublisher.sink { [weak self] isPictureInPictureSupported in
+            self?.pictureInPictureButton.isHidden = !isPictureInPictureSupported
+        }.store(in: &cancellables)
+
+        NCMediaCoordinator.shared.isPictureInPictureActivePublisher.sink { [weak self] isPictureInPictureActive in
+            self?.updatePictureInPictureButtonImage(isPictureInPictureActive)
+        }.store(in: &cancellables)
+
+        NCMediaCoordinator.shared.metadataSwitchPublisher.sink { [weak self] _, newItem in
+            self?.subtitleButton.isEnabled = newItem?.isVideo == true
+            self?.audioButton.isEnabled = newItem?.isVideo == true
+        }.store(in: &cancellables)
+
+        NCMediaCoordinator.shared.isPlayingPublisher.sink { [weak self] isPlaying in
+            self?.updatePlayButtonImage(isPlaying)
+        }.store(in: &cancellables)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -134,8 +165,8 @@ class NCPlayerToolBar: UIView {
 
         playbackSlider.value = position
 
-        labelCurrentTime.text = "--:--"
-        labelLeftTime.text = "--:--"
+        labelCurrentTime.text = NCMediaCoordinatorConstants.emptyTime
+        labelLeftTime.text = NCMediaCoordinatorConstants.emptyTime
 
         if viewerMediaScreenMode == .normal {
             show()
@@ -143,45 +174,17 @@ class NCPlayerToolBar: UIView {
             hide()
         }
 
-        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = position
-
         setupSubtitleButton()
         setupAudioButton()
     }
 
-    public func updatePlaybackPosition() {
-        guard let ncplayer = self.ncplayer,
-              let media = ncplayer.player.media else {
-            return
-        }
-
-        let length = media.length.intValue
-
-        let position = ncplayer.player.position
-
-        let currentSeconds = Double(position) * (Double(length) / 1000.0)
-
-        let currentTimeObj = VLCTime(int: Int32(currentSeconds * 1000))
-        let remainingTimeObj = VLCTime(int: Int32((Double(length) / 1000.0) - currentSeconds) * 1000)
-
-        labelCurrentTime.text = currentTimeObj.stringValue == "--:--" ? "00:00" : currentTimeObj.stringValue
-
-        let remaining = remainingTimeObj.stringValue
-        labelLeftTime.text = "-\(remaining)"
-
-        if playbackSliderEvent == .ended {
+    public func update(position: Float, length: Float, playedTime: String, remainingTime: String?) {
+        // SLIDER & TIME
+        if playbackSliderEvent != .began && playbackSliderEvent != .moved {
             playbackSlider.value = position
         }
-
-        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyPlaybackDuration] = length / 1000
-        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentSeconds
-    }
-
-    public func updateTopToolBar(videoSubTitlesIndexes: [Any], audioTrackIndexes: [Any]) {
-        if let metadata = metadata, metadata.isVideo {
-            self.subtitleButton.isEnabled = true
-            self.audioButton.isEnabled = true
-        }
+        labelCurrentTime.text = playedTime
+        labelLeftTime.text = remainingTime
     }
 
     // MARK: -
@@ -202,16 +205,24 @@ class NCPlayerToolBar: UIView {
         })
     }
 
-    func showPauseButton() {
-        buttonImage = UIImage(systemName: "pause.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: pointSize))!.withTintColor(.white, renderingMode: .alwaysOriginal)
-        playButton.setImage(buttonImage, for: .normal)
-        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = 1
+    // MARK: - Update Play Button Image
+
+    private func updatePlayButtonImage(_ isPlaying: Bool) {
+        if isPlaying && (mediaCoordinator.item?.ocId == metadata?.ocId) {
+            showPauseButton()
+        } else {
+            showPlayButton()
+        }
     }
 
-    func showPlayButton() {
+    private func showPauseButton() {
+        buttonImage = UIImage(systemName: "pause.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: pointSize))!.withTintColor(.white, renderingMode: .alwaysOriginal)
+        playButton.setImage(buttonImage, for: .normal)
+    }
+
+    private func showPlayButton() {
         buttonImage = UIImage(systemName: "play.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: pointSize))!.withTintColor(.white, renderingMode: .alwaysOriginal)
         playButton.setImage(buttonImage, for: .normal)
-        MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPNowPlayingInfoPropertyPlaybackRate] = 0
     }
 
     // MARK: - Event / Gesture
@@ -257,47 +268,59 @@ class NCPlayerToolBar: UIView {
         viewerMediaPage?.changeScreenMode(mode: viewerMediaScreenMode)
     }
 
+    @IBAction func tapPictureInPicture(_ sender: Any) {
+        mediaCoordinator.switchPictureInPicture()
+    }
+
+    private func updatePictureInPictureButtonImage(_ isPictureInPictureActive: Bool) {
+        if isPictureInPictureActive {
+            pictureInPictureButton.setImage(UIImage(systemName: "pip.exit")?.withTintColor(.white, renderingMode: .alwaysOriginal), for: .normal)
+        } else {
+            pictureInPictureButton.setImage(UIImage(systemName: "pip.enter")?.withTintColor(.white, renderingMode: .alwaysOriginal), for: .normal)
+        }
+    }
+
     private func setupSubtitleButton() {
-        guard let player = ncplayer?.player else { return }
+          guard let player = ncplayer else { return }
 
-        var currentIndex: Int?
-        if let data = database.getVideo(metadata: metadata), let idx = data.currentVideoSubTitleIndex {
-            currentIndex = idx
-        } else {
-            currentIndex = Int(player.currentVideoSubTitleIndex)
-        }
+          var currentIndex: Int?
+          if let data = database.getVideoOrAudio(metadata: metadata), let idx = data.currentVideoSubTitleIndex {
+              currentIndex = idx
+          } else {
+              currentIndex = Int(player.currentVideoSubTitleIndex)
+          }
 
-        subtitleButton.menu = NCContextMenuPlayerTracks(
-            trackType: .subtitle,
-            tracks: player.videoSubTitlesNames,
-            trackIndexes: player.videoSubTitlesIndexes,
-            currentIndex: currentIndex,
-            ncplayer: ncplayer,
-            metadata: metadata,
-            viewerMediaPage: viewerMediaPage
-        ).viewMenu()
-    }
+          subtitleButton.menu = NCContextMenuPlayerTracks(
+              trackType: .subtitle,
+              tracks: player.videoSubTitlesNames,
+              trackIndexes: player.videoSubTitlesIndexes,
+              currentIndex: currentIndex,
+              ncplayer: ncplayer,
+              metadata: metadata,
+              viewerMediaPage: viewerMediaPage
+          ).viewMenu()
+      }
 
-    private func setupAudioButton() {
-        guard let player = ncplayer?.player else { return }
+      private func setupAudioButton() {
+          guard let player = ncplayer else { return }
 
-        var currentIndex: Int?
-        if let data = database.getVideo(metadata: metadata), let idx = data.currentAudioTrackIndex {
-            currentIndex = idx
-        } else {
-            currentIndex = Int(player.currentAudioTrackIndex)
-        }
+          var currentIndex: Int?
+          if let data = database.getVideoOrAudio(metadata: metadata), let idx = data.currentAudioTrackIndex {
+              currentIndex = idx
+          } else {
+              currentIndex = Int(player.currentAudioTrackIndex)
+          }
 
-        audioButton.menu = NCContextMenuPlayerTracks(
-            trackType: .audio,
-            tracks: player.audioTrackNames,
-            trackIndexes: player.audioTrackIndexes,
-            currentIndex: currentIndex,
-            ncplayer: ncplayer,
-            metadata: metadata,
-            viewerMediaPage: viewerMediaPage
-        ).viewMenu()
-    }
+          audioButton.menu = NCContextMenuPlayerTracks(
+              trackType: .audio,
+              tracks: player.audioTrackNames,
+              trackIndexes: player.audioTrackIndexes,
+              currentIndex: currentIndex,
+              ncplayer: ncplayer,
+              metadata: metadata,
+              viewerMediaPage: viewerMediaPage
+          ).viewMenu()
+      }
 
     @IBAction func tapPlayerPause(_ sender: Any) {
         guard let ncplayer = ncplayer else { return }
@@ -326,12 +349,15 @@ class NCPlayerToolBar: UIView {
     }
 
     @IBAction func tapRepeat(_ sender: Any) {
+        playRepeat.toggle()
+        updateRepeatButtonImage()
+    }
+
+    private func updateRepeatButtonImage() {
         if playRepeat {
-            playRepeat = false
-            repeatButton.setImage(utility.loadImage(named: "repeat", colors: [NCBrandColor.shared.iconImageColor2]), for: .normal)
-        } else {
-            playRepeat = true
             repeatButton.setImage(utility.loadImage(named: "repeat", colors: [.white]), for: .normal)
+        } else {
+            repeatButton.setImage(utility.loadImage(named: "repeat", colors: [NCBrandColor.shared.iconImageColor2]), for: .normal)
         }
     }
 }
@@ -343,7 +369,7 @@ extension NCPlayerToolBar: NCSelectDelegate {
             let scene = SceneManager.shared.getWindow(controller: viewerMediaPage.tabBarController)?.windowScene
 
             if utilityFileSystem.fileProviderStorageExists(metadata) {
-                addPlaybackSlave(type: type, metadata: metadata)
+                addPlaybackTrack(type: type, metadata: metadata)
             } else {
                 var downloadRequest: DownloadRequest?
                 let token = showHudBanner(scene: scene,
@@ -387,7 +413,7 @@ extension NCPlayerToolBar: NCSelectDelegate {
                                                                     etag: etag)
 
                         if error == .success {
-                            self.addPlaybackSlave(type: type, metadata: metadata)
+                            self.addPlaybackTrack(type: type, metadata: metadata)
                         } else if error.errorCode != 200 {
                             await showErrorBanner(scene: scene, text: error.errorDescription, errorCode: error.errorCode)
                         }
@@ -398,14 +424,14 @@ extension NCPlayerToolBar: NCSelectDelegate {
     }
 
     // swiftlint:disable inclusive_language
-    func addPlaybackSlave(type: String, metadata: tableMetadata) {
+    func addPlaybackTrack(type: String, metadata: tableMetadata) {
         // swiftlint:enable inclusive_language
         let fileNameLocalPath = utilityFileSystem.getDirectoryProviderStorageOcId(metadata.ocId, fileName: metadata.fileNameView, userId: metadata.userId, urlBase: metadata.urlBase)
 
         if type == "subtitle" {
-            self.ncplayer?.player.addPlaybackSlave(URL(fileURLWithPath: fileNameLocalPath), type: .subtitle, enforce: true)
+            self.ncplayer?.addPlaybackTrack(URL(fileURLWithPath: fileNameLocalPath), type: .subtitle, enforce: true)
         } else if type == "audio" {
-            self.ncplayer?.player.addPlaybackSlave(URL(fileURLWithPath: fileNameLocalPath), type: .audio, enforce: true)
+            self.ncplayer?.addPlaybackTrack(URL(fileURLWithPath: fileNameLocalPath), type: .audio, enforce: true)
         }
     }
 }

--- a/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.xib
+++ b/iOSClient/Viewer/NCViewerMedia/NCPlayer/NCPlayerToolBar.xib
@@ -16,16 +16,6 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="orv-9i-XUs">
                     <rect key="frame" x="20" y="0.0" width="335" height="50"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qqZ-QN-TsW">
-                            <rect key="frame" x="217" y="10" width="22.333333333333343" height="22"/>
-                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                            <state key="normal" image="captions.bubble" catalog="system"/>
-                        </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sMY-qo-4CE">
-                            <rect key="frame" x="264.33333333333331" y="10" width="25.666666666666686" height="22"/>
-                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                            <state key="normal" image="speaker.zzz" catalog="system"/>
-                        </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oOw-fT-A3E">
                             <rect key="frame" x="315" y="10" width="20" height="22"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -34,12 +24,32 @@
                                 <action selector="tapFullscreen:" destination="iN0-l3-epB" eventType="touchUpInside" id="HC5-4P-VQi"/>
                             </connections>
                         </button>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sMY-qo-4CE">
+                            <rect key="frame" x="264.33333333333331" y="10" width="25.666666666666686" height="22"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" image="speaker.zzz" catalog="system"/>
+                        </button>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qqZ-QN-TsW">
+                            <rect key="frame" x="217" y="10" width="22.333333333333343" height="22"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" image="captions.bubble" catalog="system"/>
+                        </button>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A0u-7d-WVF">
+                            <rect key="frame" x="171.33333333333334" y="10" width="25.666666666666657" height="22"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" image="pip.enter" catalog="system"/>
+                            <connections>
+                                <action selector="tapPictureInPicture:" destination="iN0-l3-epB" eventType="touchUpInside" id="AEg-cV-Exf"/>
+                            </connections>
+                        </button>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstItem="sMY-qo-4CE" firstAttribute="top" secondItem="orv-9i-XUs" secondAttribute="top" constant="10" id="JN8-3O-was"/>
+                        <constraint firstItem="qqZ-QN-TsW" firstAttribute="leading" secondItem="A0u-7d-WVF" secondAttribute="trailing" constant="20" id="O2w-oa-kcj"/>
                         <constraint firstAttribute="height" constant="50" id="OaO-1q-P0D"/>
                         <constraint firstItem="sMY-qo-4CE" firstAttribute="leading" secondItem="qqZ-QN-TsW" secondAttribute="trailing" constant="25" id="Rwi-4K-cTW"/>
+                        <constraint firstItem="A0u-7d-WVF" firstAttribute="top" secondItem="orv-9i-XUs" secondAttribute="top" constant="10" id="bq3-zS-NdZ"/>
                         <constraint firstItem="qqZ-QN-TsW" firstAttribute="top" secondItem="orv-9i-XUs" secondAttribute="top" constant="10" id="fZd-j6-JA8"/>
                         <constraint firstItem="oOw-fT-A3E" firstAttribute="leading" secondItem="sMY-qo-4CE" secondAttribute="trailing" constant="25" id="gqw-nr-jbR"/>
                         <constraint firstAttribute="trailing" secondItem="oOw-fT-A3E" secondAttribute="trailing" id="ttU-3o-teH"/>
@@ -139,6 +149,7 @@
                 <outlet property="fullscreenButton" destination="oOw-fT-A3E" id="D9a-Tf-vzm"/>
                 <outlet property="labelCurrentTime" destination="OHB-2J-Gqb" id="pFy-CJ-x2A"/>
                 <outlet property="labelLeftTime" destination="svM-TQ-AyQ" id="UDV-Lh-12z"/>
+                <outlet property="pictureInPictureButton" destination="A0u-7d-WVF" id="lV4-tI-nHj"/>
                 <outlet property="playButton" destination="qo0-x8-OfL" id="m4a-gb-D0J"/>
                 <outlet property="playbackSlider" destination="MY0-FC-j88" id="bVe-Kc-80k"/>
                 <outlet property="playbackSliderView" destination="85m-50-8yp" id="SOs-XA-Mgh"/>
@@ -155,6 +166,7 @@
         <image name="10.arrow.trianglehead.counterclockwise" catalog="system" width="119" height="128"/>
         <image name="arrow.up.left.and.arrow.down.right" catalog="system" width="128" height="115"/>
         <image name="captions.bubble" catalog="system" width="128" height="110"/>
+        <image name="pip.enter" catalog="system" width="128" height="98"/>
         <image name="play.fill" catalog="system" width="120" height="128"/>
         <image name="repeat" catalog="system" width="128" height="98"/>
         <image name="speaker.zzz" catalog="system" width="128" height="83"/>

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMedia.swift
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: STRATO GmbH
 // SPDX-FileCopyrightText: 2020 Marino Faggiana
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import UIKit
@@ -8,9 +10,11 @@ import EasyTipView
 import SwiftUI
 import MobileVLCKit
 import Alamofire
+import Combine
 import LucidBanner
 
-public protocol NCViewerMediaViewDelegate: AnyObject {
+protocol NCViewerMediaViewDelegate: AnyObject {
+	func movedToAnotherItem(oldItem: tableMetadata, newItem: tableMetadata)
     func didOpenDetail()
     func didCloseDetail()
 }
@@ -25,7 +29,7 @@ class NCViewerMedia: UIViewController {
     @IBOutlet weak var statusLabel: UILabel!
     @IBOutlet weak var detailView: NCViewerMediaDetailView!
 
-    private let player = VLCMediaPlayer()
+    private let player = VLCMediaPlayer() // Live photos display
     private let appDelegate = (UIApplication.shared.delegate as? AppDelegate)!
     let utilityFileSystem = NCUtilityFileSystem()
     let utility = NCUtility()
@@ -35,7 +39,8 @@ class NCViewerMedia: UIViewController {
     weak var viewerMediaPage: NCViewerMediaPage?
     var playerToolBar: NCPlayerToolBar?
     var ncplayer: NCPlayer?
-    var image: UIImage? {
+    private let mediaCoordinator = NCMediaCoordinator.shared
+    private(set) var image: UIImage? {
         didSet {
             if metadata.isImage {
                 analyzeCurrentImage()
@@ -48,13 +53,17 @@ class NCViewerMedia: UIViewController {
     var imageViewConstraint: CGFloat = 0
     var isDetailViewInitializze: Bool = false
     weak var delegate: NCViewerMediaViewDelegate?
+    private var hudToken: Int?
 
     private var allowOpeningDetails = true
     private var tipView: EasyTipView?
+    private var activityIndicator: UIActivityIndicatorView?
 
     var sceneIdentifier: String {
         (self.tabBarController as? NCMainTabBarController)?.sceneIdentifier ?? ""
     }
+
+    private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - View Life Cycle
 
@@ -98,7 +107,22 @@ class NCViewerMedia: UIViewController {
                 playerToolBar.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
             }
 
-            self.ncplayer = NCPlayer(imageVideoContainer: self.imageVideoContainer, playerToolBar: self.playerToolBar, metadata: self.metadata, viewerMediaPage: self.viewerMediaPage)
+            activityIndicator = UIActivityIndicatorView(style: .large)
+            activityIndicator?.color = .white
+            activityIndicator?.hidesWhenStopped = true
+            activityIndicator?.translatesAutoresizingMaskIntoConstraints = false
+
+            if let activityIndicator = activityIndicator {
+                view.addSubview(activityIndicator)
+                NSLayoutConstraint.activate([
+                    activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                    activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+                ])
+            }
+
+            mediaCoordinator.delegate = self
+
+            self.ncplayer = NCPlayer(playerToolBar: self.playerToolBar, metadata: self.metadata, viewerMediaPage: self.viewerMediaPage)
         }
 
         detailViewTopConstraint.constant = 0
@@ -140,61 +164,20 @@ class NCViewerMedia: UIViewController {
             await NCNetworking.shared.transferDispatcher.addDelegate(self)
         }
 
-        viewerMediaPage?.clearCommandCenter()
-
         if metadata.isAudioOrVideo {
-            if let ncplayer = self.ncplayer {
-                if ncplayer.url == nil {
-                    NCActivityIndicator.shared.startActivity(backgroundView: self.view, style: .medium)
-                    self.networking.getVideoUrl(metadata: metadata) { url, autoplay, error in
-                        NCActivityIndicator.shared.stop()
-                        if error == .success, let url = url {
-                            ncplayer.openAVPlayer(url: url, autoplay: autoplay)
-                        } else {
-                            Task { @MainActor in
-                                guard let metadata = await self.database.setMetadataSessionInWaitDownloadAsync(ocId: self.metadata.ocId,
-                                                                                                               session: self.networking.sessionDownload,
-                                                                                                               selector: "") else {
-                                    return
-                                }
-                                let scene = SceneManager.shared.getWindow(controller: self.tabBarController)?.windowScene
-                                var downloadRequest: DownloadRequest?
-                                let token = showHudBanner(scene: scene,
-                                                          title: NSLocalizedString("_download_in_progress_", comment: ""),
-                                                          stage: .button) {
-                                    if let request = downloadRequest {
-                                        request.cancel()
-                                    }
-                                }
-
-                                let results = await self.networking.downloadFile(metadata: metadata) { request in
-                                    downloadRequest = request
-                                } progressHandler: { progress in
-                                    Task {@MainActor in
-                                        LucidBanner.shared.update(
-                                            payload: LucidBannerPayload.Update(progress: progress.fractionCompleted),
-                                            for: token)
-                                    }
-                                }
-                                LucidBanner.shared.dismiss()
-
-                                if results.nkError == .success {
-                                    if self.utilityFileSystem.fileProviderStorageExists(self.metadata) {
-                                        let url = URL(fileURLWithPath: self.utilityFileSystem.getDirectoryProviderStorageOcId(self.metadata.ocId, fileName: self.metadata.fileNameView, userId: self.metadata.userId, urlBase: self.metadata.urlBase))
-                                        ncplayer.openAVPlayer(url: url, autoplay: autoplay)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    var position: Float = 0
-                    if let result = self.database.getVideo(metadata: metadata), let resultPosition = result.position {
-                        position = resultPosition
-                    }
-                    ncplayer.restartAVPlayer(position: position, pauseAfterPlay: true)
+            mediaCoordinator.metadataSwitchPublisher.sink { [weak self] old, new in
+                guard let old, let new else { return }
+                self?.playerMovedToAnotherItem(oldItem: old, newItem: new)
+            }.store(in: &cancellables)
+            mediaCoordinator.statePublisher.sink { [weak self] state in
+                DispatchQueue.main.async {
+                    self?.mediaCoordinator(changedPlaybackState: state)
                 }
-            }
+            }.store(in: &cancellables)
+            mediaCoordinator.positionPublisher.sink { [weak self] position in
+                self?.mediaCoordinator(didChangePosition: position)
+            }.store(in: &cancellables)
+            mediaCoordinator.putVideoOutputView(in: self.imageVideoContainer)
         } else if metadata.isImage {
             DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 self.showTip()
@@ -212,13 +195,8 @@ class NCViewerMedia: UIViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-
         Task {
             await NCNetworking.shared.transferDispatcher.removeDelegate(self)
-        }
-
-        if let ncplayer, ncplayer.isPlaying() {
-            ncplayer.playerPause()
         }
     }
 
@@ -457,6 +435,12 @@ class NCViewerMedia: UIViewController {
 }
 
 extension NCViewerMedia {
+    @objc func playerMovedToAnotherItem(oldItem: tableMetadata, newItem: tableMetadata) {
+        guard oldItem.ocId == metadata.ocId else { return }
+
+		delegate?.movedToAnotherItem(oldItem: oldItem, newItem: newItem)
+	}
+
     @objc func openDetail(_ notification: NSNotification) {
         if let userInfo = notification.userInfo as NSDictionary?, let ocId = userInfo["ocId"] as? String, ocId == metadata.ocId {
             allowOpeningDetails = true
@@ -545,6 +529,94 @@ extension NCViewerMedia {
                 self.showDetailView(exif: exif)
             }
         }
+    }
+
+    // MARK: - Activity Indicator
+
+    func startActivityIndicator() {
+        activityIndicator?.startAnimating()
+    }
+
+    func stopActivityIndicator() {
+        activityIndicator?.stopAnimating()
+    }
+
+    // MARK: - Media Coordinator Events
+
+    func mediaCoordinator(changedPlaybackState state: NCPlayerState) {
+        if (state == .buffering) || (state == .gettingURL) {
+            startActivityIndicator()
+        } else {
+            stopActivityIndicator()
+        }
+
+        switch state {
+        case .stopped:
+            NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterPlayerStoppedPlaying)
+        case .downloading(let progress):
+            addDownloadHudIfNeeded()
+            LucidBanner.shared.update(
+                payload: LucidBannerPayload.Update(progress: progress),
+                for: hudToken
+            )
+        case .error(let error):
+            addDownloadHudIfNeeded()
+            if let nkError = error {
+                completeHudBannerError(subtitle: nkError.errorDescription, token: hudToken)
+            } else {
+                completeHudBannerError(token: hudToken)
+            }
+            hudToken = nil
+        case .downloaded:
+            addDownloadHudIfNeeded()
+            completeHudBannerSuccess(token: hudToken)
+            hudToken = nil
+        case .playing:
+            guard let playerToolBar = playerToolBar else { return }
+            if playerToolBar.playerButtonView.isHidden {
+                playerToolBar.playerButtonView.isHidden = false
+                viewerMediaPage?.changeScreenMode(mode: .normal)
+            }
+            // Set track audio/subtitle
+            let data = database.getVideoOrAudio(metadata: metadata)
+            if let currentAudioTrackIndex = data?.currentAudioTrackIndex {
+                mediaCoordinator.currentAudioTrackIndex = Int32(currentAudioTrackIndex)
+            }
+            if let currentVideoSubTitleIndex = data?.currentVideoSubTitleIndex {
+                mediaCoordinator.currentVideoSubTitleIndex = Int32(currentVideoSubTitleIndex)
+            }
+            let size = mediaCoordinator.videoSize
+            ncplayer?.length = Int(mediaCoordinator.length)
+            ncplayer?.width = Int(size.width)
+            ncplayer?.height = Int(size.height)
+            database.addVideoOrAudio(metadata: metadata, width: ncplayer?.width, height: ncplayer?.height, length: ncplayer?.length)
+
+            NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterPlayerIsPlaying)
+        case .paused:
+            NotificationCenter.default.postOnMainThread(name: NCGlobal.shared.notificationCenterPlayerStoppedPlaying)
+        default: break
+        }
+    }
+
+    func mediaCoordinator(didChangePosition position: Float) {
+        stopActivityIndicator()
+        guard metadata.ocId == mediaCoordinator.item?.ocId else { return }
+        playerToolBar?.update(position: position,
+                              length: Float(mediaCoordinator.length / 1000),
+                              playedTime: mediaCoordinator.playedTime,
+                              remainingTime: mediaCoordinator.remainingTime)
+    }
+
+    private func addDownloadHudIfNeeded() {
+        if hudToken != nil { return }
+
+        let scene = SceneManager.shared.getWindow(controller: self.tabBarController)?.windowScene
+        hudToken = showHudBanner(
+            scene: scene,
+            title: NSLocalizedString("_downloading_", comment: ""),
+            stage: .button) { [weak self] in
+                self?.mediaCoordinator.cancelDownload()
+            }
     }
 }
 
@@ -641,5 +713,44 @@ extension NCViewerMedia: NCTransferDelegate {
                 self.closeDetail()
             }
         }
+    }
+}
+
+// MARK: - NCMediaCoordinatorDelegate
+
+extension NCViewerMedia: NCMediaCoordinatorVLCStrategyDelegate {
+    func showError(withTitle title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
+        alert.addAction(UIAlertAction(title: NSLocalizedString("_ok_", comment: ""),
+                                      style: .default,
+                                      handler: { [weak self] _ in
+            guard let self = self else { return }
+            self.playerToolBar?.removeFromSuperview()
+            self.viewerMediaPage?.navigationController?.popViewController(animated: true)
+            self.mediaCoordinator.finishMediaSession()
+        }))
+
+        self.present(alert, animated: true)
+    }
+
+    func showAlert(alert: UIAlertController) {
+        self.present(alert, animated: true)
+    }
+
+    func showLogin(withTitle title: String, message: String, defaultUsername username: String?, askingForStorage: Bool, withReference reference: NSValue) {
+        // UIAlertController other states...
+    }
+
+    func showProgress(withTitle title: String, message: String, isIndeterminate: Bool, position: Float, cancel cancelString: String?, withReference reference: NSValue) {
+        // UIAlertController other states...
+    }
+
+    func updateProgress(withReference reference: NSValue, message: String?, position: Float) {
+        // UIAlertController other states...
+    }
+
+    func cancelDialog(withReference reference: NSValue) {
+        // UIAlertController other states...
     }
 }

--- a/iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCViewerMediaPage.swift
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
 // SPDX-FileCopyrightText: 2020 Marino Faggiana
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import UIKit
@@ -18,19 +19,14 @@ class NCViewerMediaPage: UIViewController {
     // Parameters
     var ocIds: [String] = []
     var currentIndex: Int = 0
-    var delegateViewController: UIViewController?
 
     var modifiedOcId: [String] = []
-    var nextIndex: Int?
+    private var nextIndex: Int?
     var panGestureRecognizer: UIPanGestureRecognizer!
     var singleTapGestureRecognizer: UITapGestureRecognizer!
     var longtapGestureRecognizer: UILongPressGestureRecognizer!
-    var playCommand: Any?
-    var pauseCommand: Any?
-    var skipForwardCommand: Any?
-    var skipBackwardCommand: Any?
-    var nextTrackCommand: Any?
-    var previousTrackCommand: Any?
+    var textColor: UIColor = NCBrandColor.shared.textColor
+
     let utilityFileSystem = NCUtilityFileSystem()
     let global = NCGlobal.shared
     let database = NCManageDatabase.shared
@@ -152,21 +148,13 @@ class NCViewerMediaPage: UIViewController {
         super.viewWillAppear(animated)
 
         changeScreenMode(mode: viewerMediaScreenMode)
-
-        if #available(iOS 18.0, *) {
-            self.tabBarController?.setTabBarHidden(true, animated: true)
-        } else {
-            self.tabBarController?.tabBar.isHidden = true
-        }
+        tabBarController?.tabBar.isHidden = true
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        Task {
-            await NCNetworking.shared.transferDispatcher.addDelegate(self)
-        }
-
+        changeScreenMode(mode: viewerMediaScreenMode)
         startTimerAutoHide()
     }
 
@@ -174,24 +162,13 @@ class NCViewerMediaPage: UIViewController {
         super.viewWillDisappear(animated)
 
         changeScreenMode(mode: .normal)
-
-        if #available(iOS 18.0, *) {
-            self.tabBarController?.setTabBarHidden(false, animated: true)
-        } else {
-            self.tabBarController?.tabBar.isHidden = false
-        }
+        tabBarController?.tabBar.isHidden = false
     }
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
 
-        Task {
-            await NCNetworking.shared.transferDispatcher.removeDelegate(self)
-        }
-
-        currentViewController.ncplayer?.playerStop()
         timerAutoHide?.invalidate()
-        clearCommandCenter()
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -210,7 +187,7 @@ class NCViewerMediaPage: UIViewController {
         return hideStatusBar
     }
 
-    func getViewerMedia(index: Int, metadata: tableMetadata) -> NCViewerMedia {
+    private func getViewerMedia(index: Int, metadata: tableMetadata) -> NCViewerMedia {
         // swiftlint:disable force_cast
         let viewerMedia = UIStoryboard(name: "NCViewerMediaPage", bundle: nil).instantiateViewController(withIdentifier: "NCViewerMedia") as! NCViewerMedia
         // swiftlint:enable force_cast
@@ -302,100 +279,6 @@ class NCViewerMediaPage: UIViewController {
         progressView.progress = 0
         changeScreenMode(mode: .normal)
     }
-
-    // MARK: - Command Center
-
-    func updateCommandCenter(ncplayer: NCPlayer, title: String) {
-        var nowPlayingInfo = [String: Any]()
-
-        UIApplication.shared.beginReceivingRemoteControlEvents()
-
-        // Add handler for Play Command
-        MPRemoteCommandCenter.shared().playCommand.isEnabled = true
-        playCommand = MPRemoteCommandCenter.shared().playCommand.addTarget { _ in
-
-            if !ncplayer.isPlaying() {
-                ncplayer.playerPlay()
-                return .success
-            }
-            return .commandFailed
-        }
-
-        // Add handler for Pause Command
-        MPRemoteCommandCenter.shared().pauseCommand.isEnabled = true
-        pauseCommand = MPRemoteCommandCenter.shared().pauseCommand.addTarget { _ in
-
-            if ncplayer.isPlaying() {
-                ncplayer.playerPause()
-                return .success
-            }
-            return .commandFailed
-        }
-
-        // >>
-        MPRemoteCommandCenter.shared().skipForwardCommand.isEnabled = true
-        skipForwardCommand = MPRemoteCommandCenter.shared().skipForwardCommand.addTarget { event in
-
-            let seconds = Int32((event as? MPSkipIntervalCommandEvent)?.interval ?? 0)
-            ncplayer.player.jumpForward(seconds)
-            return.success
-        }
-
-        // <<
-        MPRemoteCommandCenter.shared().skipBackwardCommand.isEnabled = true
-        skipBackwardCommand = MPRemoteCommandCenter.shared().skipBackwardCommand.addTarget { event in
-
-            let seconds = Int32((event as? MPSkipIntervalCommandEvent)?.interval ?? 0)
-            ncplayer.player.jumpBackward(seconds)
-            return.success
-        }
-
-        nowPlayingInfo[MPMediaItemPropertyTitle] = title
-        if let image = currentViewController.image {
-            nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size) { _ in
-                return image
-            }
-        }
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-    }
-
-    func clearCommandCenter() {
-
-        UIApplication.shared.endReceivingRemoteControlEvents()
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
-
-        MPRemoteCommandCenter.shared().playCommand.isEnabled = false
-        MPRemoteCommandCenter.shared().pauseCommand.isEnabled = false
-        MPRemoteCommandCenter.shared().skipForwardCommand.isEnabled = false
-        MPRemoteCommandCenter.shared().skipBackwardCommand.isEnabled = false
-        MPRemoteCommandCenter.shared().nextTrackCommand.isEnabled = false
-        MPRemoteCommandCenter.shared().previousTrackCommand.isEnabled = false
-
-        if let playCommand = playCommand {
-            MPRemoteCommandCenter.shared().playCommand.removeTarget(playCommand)
-            self.playCommand = nil
-        }
-        if let pauseCommand = pauseCommand {
-            MPRemoteCommandCenter.shared().pauseCommand.removeTarget(pauseCommand)
-            self.pauseCommand = nil
-        }
-        if let skipForwardCommand = skipForwardCommand {
-            MPRemoteCommandCenter.shared().skipForwardCommand.removeTarget(skipForwardCommand)
-            self.skipForwardCommand = nil
-        }
-        if let skipBackwardCommand = skipBackwardCommand {
-            MPRemoteCommandCenter.shared().skipBackwardCommand.removeTarget(skipBackwardCommand)
-            self.skipBackwardCommand = nil
-        }
-        if let nextTrackCommand = nextTrackCommand {
-            MPRemoteCommandCenter.shared().nextTrackCommand.removeTarget(nextTrackCommand)
-            self.nextTrackCommand = nil
-        }
-        if let previousTrackCommand = previousTrackCommand {
-            MPRemoteCommandCenter.shared().previousTrackCommand.removeTarget(previousTrackCommand)
-            self.previousTrackCommand = nil
-        }
-    }
 }
 
 // MARK: - UIPageViewController Delegate Datasource
@@ -406,16 +289,14 @@ extension NCViewerMediaPage: UIPageViewControllerDelegate, UIPageViewControllerD
         guard currentIndex > 0,
               let metadata = database.getMetadataFromOcId(ocIds[currentIndex - 1]) else { return nil }
 
-        let viewerMedia = getViewerMedia(index: currentIndex - 1, metadata: metadata)
-        return viewerMedia
+        return getViewerMedia(index: currentIndex - 1, metadata: metadata)
     }
 
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         guard currentIndex < ocIds.count - 1,
               let metadata = database.getMetadataFromOcId(ocIds[currentIndex + 1]) else { return nil }
 
-        let viewerMedia = getViewerMedia(index: currentIndex + 1, metadata: metadata)
-        return viewerMedia
+        return getViewerMedia(index: currentIndex + 1, metadata: metadata)
     }
 
     // START TRANSITION
@@ -450,12 +331,13 @@ extension NCViewerMediaPage: UIPageViewControllerDelegate, UIPageViewControllerD
         if completed && nextIndex != nil {
             previousViewControllers.forEach { viewController in
                 let viewerMedia = viewController as? NCViewerMedia
-                viewerMedia?.ncplayer?.playerStop()
                 viewerMedia?.closeDetail()
             }
             currentIndex = nextIndex!
         }
-
+        if completed {
+            NCMediaCoordinator.shared.finishMediaSession(clearQueue: false)
+        }
         changeScreenMode(mode: viewerMediaScreenMode)
         startTimerAutoHide()
 
@@ -550,6 +432,14 @@ extension UIPageViewController {
 }
 
 extension NCViewerMediaPage: NCViewerMediaViewDelegate {
+    func movedToAnotherItem(oldItem: tableMetadata, newItem: tableMetadata) {
+        guard currentIndex < ocIds.count - 1 else { return }
+
+        currentIndex = NCMediaCoordinator.shared.currentItemIndex ?? 0
+        let viewerMedia = getViewerMedia(index: currentIndex, metadata: newItem)
+        pageViewController.setViewControllers([viewerMedia], direction: .forward, animated: false)
+    }
+
     func didOpenDetail() {
         changeScreenMode(mode: .normal)
         imageDetailNavigationItem.image = NCUtility().loadImage(named: "info.circle.fill")
@@ -616,18 +506,13 @@ extension NCViewerMediaPage: NCTransferDelegate {
                 self.progressView.progress = 0
 
                 if metadata.isAudioOrVideo, let ncplayer = self.currentViewController.ncplayer {
-                    let url = URL(fileURLWithPath: self.utilityFileSystem.getDirectoryProviderStorageOcId(metadata.ocId,
-                                                                                                          fileName: metadata.fileNameView,
-                                                                                                          userId: metadata.userId,
-                                                                                                          urlBase: metadata.urlBase))
                     if ncplayer.isPlaying() {
                         ncplayer.playerPause()
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                            ncplayer.openAVPlayer(url: url)
                             ncplayer.playerPlay()
                         }
                     } else {
-                        ncplayer.openAVPlayer(url: url)
+                        ncplayer.playerPlay()
                     }
                 } else if metadata.isImage {
                     await self.currentViewController.loadImage()

--- a/iOSClient/Viewer/NCViewerProviderContextMenu.swift
+++ b/iOSClient/Viewer/NCViewerProviderContextMenu.swift
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
 // SPDX-FileCopyrightText: 2021 Marino Faggiana
+// SPDX-FileCopyrightText: 2025 Serhii Kaliberda
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import UIKit
@@ -179,7 +180,10 @@ class NCViewerProviderContextMenu: UIViewController {
     }
 
     private func viewVideo(metadata: tableMetadata) {
-        self.networking.getVideoUrl(metadata: metadata) { url, _, _ in
+        if NCMediaCoordinator.shared.isPlaying {
+            return
+        }
+        self.networking.getVideoUrl(metadata: metadata) { url, _ in
             if let url = url {
                 self.player.media = VLCMedia(url: url)
                 self.player.delegate = self


### PR DESCRIPTION
Hi team,

After discussing media queue and Picture-in-Picture in the [pull request](https://github.com/nextcloud/ios/pull/4007), we agreed to use two libraries for media playback so that Picture-in-Picture will work. The media player uses AVKit for videos when the format is supported; otherwise, it uses MobileVLCKit.

This approach allowed us to preserve all existing functionality while also adding new features, such as a media queue for audio files and Picture-in-Picture for video files.

We implemented this logic in this pull request, and we’d like to hear your opinion on the implementation. Could you review the code and share your feedback?