### PR TITLE
fix: Interactive pop gesture recognizer interfering with OnlyOffice text selection

### DIFF
--- a/iOSClient/Viewer/NCViewerNextcloudText/NCViewerNextcloudText.swift
+++ b/iOSClient/Viewer/NCViewerNextcloudText/NCViewerNextcloudText.swift
@@ -56,6 +56,11 @@ class NCViewerNextcloudText: UIViewController, WKNavigationDelegate, WKScriptMes
         navigationItem.trailingItemGroups = [group]
         navigationItem.leftBarButtonItems = nil
 
+        // Prevent back navigation gesture of iOS/iPadOS >= 26 as that will interfere with the possibility to mark text in onlyoffice
+        if #available(iOS 26.0, *) {
+            navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
+        }
+
         let config = WKWebViewConfiguration()
         config.websiteDataStore = WKWebsiteDataStore.nonPersistent()
         let contentController = config.userContentController


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/fa63051a-63e2-46f5-8485-ec42eb29fadd

After:

https://github.com/user-attachments/assets/c760df58-33f9-463d-9969-4568b4b1c23c

Might make sense to have that on other WKWebViews as well, not sure.