### PR TITLE
feat: add DirectEditing for mobile app support

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 		F72CA05C2F5051DB002E2F06 /* AlertActionBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72CA05B2F5051DB002E2F06 /* AlertActionBannerView.swift */; };
 		F72CD63A25C19EBF00F46F9A /* NCAutoUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72CD63925C19EBF00F46F9A /* NCAutoUpload.swift */; };
 		F72D1007210B6882009C96B7 /* NCPushNotificationEncryption.m in Sources */ = {isa = PBXBuildFile; fileRef = F72D1005210B6882009C96B7 /* NCPushNotificationEncryption.m */; };
-		F72D404923D2082500A97FD0 /* NCViewerNextcloudText.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72D404823D2082500A97FD0 /* NCViewerNextcloudText.swift */; };
+		F72D404923D2082500A97FD0 /* NCViewerDirectEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72D404823D2082500A97FD0 /* NCViewerDirectEditing.swift */; };
 		F72D7EB7263B1207000B3DFC /* MarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = F72D7EB6263B1207000B3DFC /* MarkdownKit */; };
 		F72DA9B425F53E4E00B87DB1 /* SwiftRichString in Frameworks */ = {isa = PBXBuildFile; productRef = F72DA9B325F53E4E00B87DB1 /* SwiftRichString */; };
 		F72EA95228B7BA2A00C88F0C /* DashboardWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72EA95128B7BA2A00C88F0C /* DashboardWidgetProvider.swift */; };
@@ -339,7 +339,7 @@
 		F7386E482DA90E0F009A00F6 /* NCAppVersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7386E452DA90E02009A00F6 /* NCAppVersionManager.swift */; };
 		F73BC74F2F23811E003170C2 /* WarningBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7DF7B3E2F1A2EE400514020 /* WarningBannerView.swift */; };
 		F73CB3B222E072A000AD728E /* NCShareHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = F73CB3B122E072A000AD728E /* NCShareHeaderView.xib */; };
-		F73D11FA253C5F4800DF9BEC /* NCViewerNextcloudText.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F73D11F9253C5F4800DF9BEC /* NCViewerNextcloudText.storyboard */; };
+		F73D11FA253C5F4800DF9BEC /* NCViewerDirectEditing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F73D11F9253C5F4800DF9BEC /* NCViewerDirectEditing.storyboard */; };
 		F73EF7A72B0223900087E6E9 /* NCManageDatabase+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73EF7A62B0223900087E6E9 /* NCManageDatabase+Comments.swift */; };
 		F73EF7A82B0223900087E6E9 /* NCManageDatabase+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73EF7A62B0223900087E6E9 /* NCManageDatabase+Comments.swift */; };
 		F73EF7A92B0223900087E6E9 /* NCManageDatabase+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73EF7A62B0223900087E6E9 /* NCManageDatabase+Comments.swift */; };
@@ -1370,7 +1370,7 @@
 		F72CD63925C19EBF00F46F9A /* NCAutoUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCAutoUpload.swift; sourceTree = "<group>"; };
 		F72D1005210B6882009C96B7 /* NCPushNotificationEncryption.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NCPushNotificationEncryption.m; sourceTree = "<group>"; };
 		F72D1006210B6882009C96B7 /* NCPushNotificationEncryption.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCPushNotificationEncryption.h; sourceTree = "<group>"; };
-		F72D404823D2082500A97FD0 /* NCViewerNextcloudText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCViewerNextcloudText.swift; sourceTree = "<group>"; };
+		F72D404823D2082500A97FD0 /* NCViewerDirectEditing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NCViewerDirectEditing.swift; sourceTree = "<group>"; };
 		F72EA95128B7BA2A00C88F0C /* DashboardWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardWidgetProvider.swift; sourceTree = "<group>"; };
 		F72EA95328B7BABA00C88F0C /* FilesWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesWidgetProvider.swift; sourceTree = "<group>"; };
 		F72EA95728B7BC4F00C88F0C /* FilesData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesData.swift; sourceTree = "<group>"; };
@@ -1397,7 +1397,7 @@
 		F7386E452DA90E02009A00F6 /* NCAppVersionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCAppVersionManager.swift; sourceTree = "<group>"; };
 		F73CB3B122E072A000AD728E /* NCShareHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = NCShareHeaderView.xib; sourceTree = "<group>"; };
 		F73CB5771ED46807005F2A5A /* NCBridgeSwift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCBridgeSwift.h; sourceTree = "<group>"; };
-		F73D11F9253C5F4800DF9BEC /* NCViewerNextcloudText.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = NCViewerNextcloudText.storyboard; sourceTree = "<group>"; };
+		F73D11F9253C5F4800DF9BEC /* NCViewerDirectEditing.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = NCViewerDirectEditing.storyboard; sourceTree = "<group>"; };
 		F73EF7A62B0223900087E6E9 /* NCManageDatabase+Comments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+Comments.swift"; sourceTree = "<group>"; };
 		F73EF7B62B0224AB0087E6E9 /* NCManageDatabase+ExternalSites.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+ExternalSites.swift"; sourceTree = "<group>"; };
 		F73EF7BE2B02250B0087E6E9 /* NCManageDatabase+GPS.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NCManageDatabase+GPS.swift"; sourceTree = "<group>"; };
@@ -2421,13 +2421,13 @@
 			path = Offline;
 			sourceTree = "<group>";
 		};
-		F73D11FF253C5F5400DF9BEC /* NCViewerNextcloudText */ = {
+		F73D11FF253C5F5400DF9BEC /* NCViewerDirectEditing */ = {
 			isa = PBXGroup;
 			children = (
-				F72D404823D2082500A97FD0 /* NCViewerNextcloudText.swift */,
-				F73D11F9253C5F4800DF9BEC /* NCViewerNextcloudText.storyboard */,
+				F72D404823D2082500A97FD0 /* NCViewerDirectEditing.swift */,
+				F73D11F9253C5F4800DF9BEC /* NCViewerDirectEditing.storyboard */,
 			);
-			path = NCViewerNextcloudText;
+			path = NCViewerDirectEditing;
 			sourceTree = "<group>";
 		};
 		F74D3DB81BAC1941000BAE4B /* Networking */ = {
@@ -2782,7 +2782,7 @@
 				F79018B1240962C7007C9B6D /* NCViewerMedia */,
 				F723986A253C9C0E00257F49 /* NCViewerQuickLook */,
 				F76D3CEF2428B3DD005DFA87 /* NCViewerPDF */,
-				F73D11FF253C5F5400DF9BEC /* NCViewerNextcloudText */,
+				F73D11FF253C5F5400DF9BEC /* NCViewerDirectEditing */,
 				F7239861253C95D500257F49 /* NCViewerRichdocument */,
 			);
 			path = Viewer;
@@ -3992,7 +3992,7 @@
 				F704B5E32430AA6F00632F5F /* NCCreateFormUploadConflict.storyboard in Resources */,
 				F7EDE509262DA9D600414FE6 /* NCSelectCommandViewSelect.xib in Resources */,
 				F732D23327CF8AED000B0F1B /* NCPlayerToolBar.xib in Resources */,
-				F73D11FA253C5F4800DF9BEC /* NCViewerNextcloudText.storyboard in Resources */,
+				F73D11FA253C5F4800DF9BEC /* NCViewerDirectEditing.storyboard in Resources */,
 				F7EDE51B262DD0C400414FE6 /* NCSelectCommandViewCopyMove.xib in Resources */,
 				F7FF2CB12842159500EBB7A1 /* NCSectionHeader.xib in Resources */,
 				F7D1612023CF19E30039EBBF /* NCViewerRichWorkspace.storyboard in Resources */,
@@ -4544,7 +4544,7 @@
 				F7D60CAF2C941ACB008FBFDD /* NCMediaPinchGesture.swift in Sources */,
 				F71916142E2901FB00E13E96 /* NCNetworking+Upload.swift in Sources */,
 				F704B5E92430C0B800632F5F /* NCCreateFormUploadConflictCell.swift in Sources */,
-				F72D404923D2082500A97FD0 /* NCViewerNextcloudText.swift in Sources */,
+				F72D404923D2082500A97FD0 /* NCViewerDirectEditing.swift in Sources */,
 				AFCE353927E5DE0500FEA6C2 /* Shareable.swift in Sources */,
 				F77BB746289984CA0090FC19 /* UIViewController+Extension.swift in Sources */,
 				F700510522DF6A89003A3356 /* NCShare.swift in Sources */,
@@ -6132,8 +6132,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nextcloud/NextcloudKit";
 			requirement = {
-				kind = exactVersion;
-				version = 7.3.1;
+				branch = whiteboard;
+				kind = branch;
 			};
 		};
 		F788ECC5263AAAF900ADC67F /* XCRemoteSwiftPackageReference "MarkdownKit" */ = {

--- a/iOSClient/Data/NCManageDatabase+Metadata.swift
+++ b/iOSClient/Data/NCManageDatabase+Metadata.swift
@@ -259,8 +259,8 @@ extension tableMetadata {
            directEditingEditors.isEmpty {
             // RichDocument: Collabora
             return true
-        } else if directEditingEditors.contains("nextcloud text") || directEditingEditors.contains("onlyoffice") {
-            // DirectEditing: Nextcloud Text - OnlyOffice
+        } else if directEditingEditors.contains("nextcloud text") || directEditingEditors.contains("onlyoffice") || directEditingEditors.contains("whiteboard") {
+            // DirectEditing: Nextcloud Text - OnlyOffice - Whiteboard
            return true
         }
         return false
@@ -284,7 +284,7 @@ extension tableMetadata {
         }
         let editors = NCUtility().editorsDirectEditing(account: account, contentType: contentType).map { $0.lowercased() }
 
-        if editors.contains("nextcloud text") || editors.contains("onlyoffice") {
+        if editors.contains("nextcloud text") || editors.contains("onlyoffice") || editors.contains("whiteboard") {
             return true
         }
         return false

--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon+UIEditMenuInteractionDelegate.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon+UIEditMenuInteractionDelegate.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import UIKit
+import UniformTypeIdentifiers
 import NextcloudKit
 import RealmSwift
 import LucidBanner
@@ -70,7 +71,14 @@ extension NCCollectionViewCommon: UIEditMenuInteractionDelegate {
             for (index, items) in UIPasteboard.general.items.enumerated() {
                 for item in items {
                     let capabilities = await NKCapabilities.shared.getCapabilities(for: session.account)
-                    let results = NKFilePropertyResolver().resolve(inUTI: item.key, capabilities: capabilities)
+                    let identifier = item.key
+                    let resolvedType = UTType(mimeType: identifier) ?? UTType(identifier)
+                    let resolvedMimeType = resolvedType?.preferredMIMEType ?? identifier
+                    let resolvedExtension = resolvedType?.preferredFilenameExtension ?? ""
+                    let results = NKFilePropertyResolver().resolve(mimeType: resolvedMimeType,
+                                                                   fileExtension: resolvedExtension,
+                                                                   typeIdentifier: resolvedType?.identifier ?? identifier,
+                                                                   capabilities: capabilities)
                     guard let data = UIPasteboard.general.data(forPasteboardType: item.key,
                                                                inItemSet: IndexSet([index]))?.first
                     else {

--- a/iOSClient/Main/NCMainNavigationController.swift
+++ b/iOSClient/Main/NCMainNavigationController.swift
@@ -294,7 +294,7 @@ class NCMainNavigationController: UINavigationController, UINavigationController
               !(topViewController is NCViewerMediaPage),
               !(topViewController is NCViewerPDF),
               !(topViewController is NCViewerRichDocument),
-              !(topViewController is NCViewerNextcloudText)
+              !(topViewController is NCViewerDirectEditing)
         else {
             return
         }

--- a/iOSClient/Viewer/NCViewer.swift
+++ b/iOSClient/Viewer/NCViewer.swift
@@ -109,12 +109,14 @@ class NCViewer: NSObject {
                     return vc
                 }
             }
-            // DirectEditing: Nextcloud Text - OnlyOffice
+
+            // DirectEditing: Nextcloud Text - OnlyOffice - Whiteboard
             if metadata.isAvailableDirectEditingEditorView {
                 var options = NKRequestOptions()
                 var editor = ""
                 var editorViewController = ""
                 let editors = utility.editorsDirectEditing(account: metadata.account, contentType: metadata.contentType).map { $0.lowercased() }
+
                 if editors.contains("nextcloud text") {
                     editor = "text"
                     editorViewController = "nextcloud text"
@@ -123,7 +125,11 @@ class NCViewer: NSObject {
                     editor = "onlyoffice"
                     editorViewController = "onlyoffice"
                     options = NKRequestOptions(customUserAgent: utility.getCustomUserAgentOnlyOffice())
+                } else if editors.contains("whiteboard") {
+                    editor = "whiteboard"
+                    editorViewController = "whiteboard"
                 }
+
                 if metadata.url.isEmpty {
                     let fileNamePath = utilityFileSystem.getRelativeFilePath(metadata.fileName, serverUrl: metadata.serverUrl, session: session)
 
@@ -144,7 +150,7 @@ class NCViewer: NSObject {
                         return nil
                     }
 
-                    let vc = UIStoryboard(name: "NCViewerNextcloudText", bundle: nil).instantiateInitialViewController() as? NCViewerNextcloudText
+                    let vc = UIStoryboard(name: "NCViewerDirectEditing", bundle: nil).instantiateInitialViewController() as? NCViewerDirectEditing
 
                     vc?.metadata = metadata
                     vc?.editor = editorViewController
@@ -154,7 +160,7 @@ class NCViewer: NSObject {
 
                     return vc
                 } else {
-                    let vc = UIStoryboard(name: "NCViewerNextcloudText", bundle: nil).instantiateInitialViewController() as? NCViewerNextcloudText
+                    let vc = UIStoryboard(name: "NCViewerDirectEditing", bundle: nil).instantiateInitialViewController() as? NCViewerDirectEditing
 
                     vc?.metadata = metadata
                     vc?.editor = editorViewController

--- a/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.storyboard
+++ b/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.storyboard
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24112" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Ov9-Mv-xPL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Ov9-Mv-xPL">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24057"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Viewer Nextcloud Text-->
+        <!--Viewer Direct Editing-->
         <scene sceneID="mqn-3b-5TY">
             <objects>
-                <viewController automaticallyAdjustsScrollViewInsets="NO" id="Ov9-Mv-xPL" customClass="NCViewerNextcloudText" customModule="Nextcloud" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="Ov9-Mv-xPL" customClass="NCViewerDirectEditing" customModule="Nextcloud" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lUw-uE-JhW">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.swift
+++ b/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.swift
@@ -6,7 +6,7 @@ import UIKit
 import NextcloudKit
 @preconcurrency import WebKit
 
-class NCViewerNextcloudText: UIViewController, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
+class NCViewerDirectEditing: UIViewController, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
     var webView = WKWebView()
     var bottomConstraint: NSLayoutConstraint?
     var link: String = ""
@@ -223,7 +223,7 @@ class NCViewerNextcloudText: UIViewController, WKNavigationDelegate, WKScriptMes
     }
 }
 
-extension NCViewerNextcloudText: UINavigationControllerDelegate {
+extension NCViewerDirectEditing: UINavigationControllerDelegate {
     override func didMove(toParent parent: UIViewController?) {
         super.didMove(toParent: parent)
 
@@ -237,7 +237,7 @@ extension NCViewerNextcloudText: UINavigationControllerDelegate {
     }
 }
 
-extension NCViewerNextcloudText: NCTransferDelegate {
+extension NCViewerDirectEditing: NCTransferDelegate {
     func transferReloadData(serverUrl: String?) { }
 
     func transferReloadDataSource(serverUrl: String?, requestData: Bool, status: Int?) { }


### PR DESCRIPTION
Implements DirectEditing for whiteboard, allowing .whiteboard files to be opened directly from the Nextcloud mobile apps.

Note: This PR focuses on the DirectEditing integration and does not include any UI polishing for mobile. Those can be addressed as follow-up.