### PR TITLE
Add OAEP notification encryption

### DIFF
--- a/iOSClient/PushNotification/NCPushNotificationEncryption.m
+++ b/iOSClient/PushNotification/NCPushNotificationEncryption.m
@@ -108,16 +108,25 @@
 
     // Decrypt the message
     unsigned char *decrypted = (unsigned char *) malloc(4096);
-    
+
+    // Try decrypting with RSA PKCS#1 v1.5 padding
     int decrypted_length = RSA_private_decrypt((int)[decodedData length], [decodedData bytes], decrypted, rsa, RSA_PKCS1_PADDING);
-    if(decrypted_length == -1) {
+    NSString *decryptString = decrypted_length == -1 ? nil : [[NSString alloc] initWithBytes:decrypted length:decrypted_length encoding:NSUTF8StringEncoding];
+
+    // Try decrypting with RSA OAEP padding
+    if(decrypted_length == -1 || decryptString == nil) {
+        ERR_clear_error();
+        decrypted_length = RSA_private_decrypt((int)[decodedData length], [decodedData bytes], decrypted, rsa, RSA_PKCS1_OAEP_PADDING);
+        decryptString = decrypted_length == -1 ? nil : [[NSString alloc] initWithBytes:decrypted length:decrypted_length encoding:NSUTF8StringEncoding];
+    }
+
+    // Could not decrypt
+    if(decrypted_length == -1 || decryptString == nil) {
         char buffer[500];
         ERR_error_string(ERR_get_error(), buffer);
         NSLog(@"%@",[NSString stringWithUTF8String:buffer]);
         return nil;
     }
-    
-    NSString *decryptString = [[NSString alloc] initWithBytes:decrypted length:decrypted_length encoding:NSUTF8StringEncoding];
     
     if (decrypted)
         free(decrypted);

--- a/iOSClient/PushNotification/NCPushNotificationEncryption.m
+++ b/iOSClient/PushNotification/NCPushNotificationEncryption.m
@@ -109,14 +109,14 @@
     // Decrypt the message
     unsigned char *decrypted = (unsigned char *) malloc(4096);
 
-    // Try decrypting with RSA PKCS#1 v1.5 padding
-    int decrypted_length = RSA_private_decrypt((int)[decodedData length], [decodedData bytes], decrypted, rsa, RSA_PKCS1_PADDING);
+    // Try decrypting with RSA OAEP padding
+    int decrypted_length = RSA_private_decrypt((int)[decodedData length], [decodedData bytes], decrypted, rsa, RSA_PKCS1_OAEP_PADDING);
     NSString *decryptString = decrypted_length == -1 ? nil : [[NSString alloc] initWithBytes:decrypted length:decrypted_length encoding:NSUTF8StringEncoding];
 
-    // Try decrypting with RSA OAEP padding
+    // Try decrypting with RSA PKCS#1 v1.5 padding
     if(decrypted_length == -1 || decryptString == nil) {
         ERR_clear_error();
-        decrypted_length = RSA_private_decrypt((int)[decodedData length], [decodedData bytes], decrypted, rsa, RSA_PKCS1_OAEP_PADDING);
+        decrypted_length = RSA_private_decrypt((int)[decodedData length], [decodedData bytes], decrypted, rsa, RSA_PKCS1_PADDING);
         decryptString = decrypted_length == -1 ? nil : [[NSString alloc] initWithBytes:decrypted length:decrypted_length encoding:NSUTF8StringEncoding];
     }
 


### PR DESCRIPTION
Implements: https://github.com/nextcloud/files-clients/issues/124

First tries to decrypt with RSA PKCS#1 v1.5, then OAEP.

Tested on local instance with both encryption methods.