### PR TITLE
Fix VoiceOver labels in share extension folder picker

### DIFF
--- a/Share/NCShareExtension+DataSource.swift
+++ b/Share/NCShareExtension+DataSource.swift
@@ -104,6 +104,13 @@ extension NCShareExtension: UICollectionViewDataSource {
 
         cell.setTags(tags: Array(metadata.tags))
 
+        let accessibilityLabel = [metadata.fileNameView, cell.labelInfo.text, cell.labelSubinfo.text]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+        cell.setAccessibility(label: accessibilityLabel, value: "")
+        cell.accessibilityTraits = .button
+
         cell.separator.isHidden = collectionView.numberOfItems(inSection: indexPath.section) == indexPath.row + 1
 
         return cell


### PR DESCRIPTION
## Summary
- add an explicit accessibility label to folder cells in the share extension target-folder picker
- include the visible folder name and metadata text that is already shown in the cell
- expose folder rows as actionable elements for VoiceOver users

## Issue
Fixes #4099

## Testing
- Not run: iOS/Xcode build is not available in this environment
- Static inspection: verified the share extension uses NCListCell for target folders and now calls setAccessibility(label:value:) for each cell

## Accessibility impact
This should let VoiceOver announce the folder name/details while sharing a file into Nextcloud from another app, instead of focusing unnamed selectable rows.
