### PR TITLE
set-unset-e2ee

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -6007,7 +6007,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 0;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = NKUJUXUJ3B;
@@ -6034,7 +6034,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.0.9;
+				MARKETING_VERSION = 33.0.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-v";
 				OTHER_LDFLAGS = "";
@@ -6075,7 +6075,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 0;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = NKUJUXUJ3B;
@@ -6100,7 +6100,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 33.0.9;
+				MARKETING_VERSION = 33.0.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-v";
 				OTHER_LDFLAGS = "";
@@ -6360,8 +6360,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nextcloud/NextcloudKit";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = exactVersion;
+				version = 7.3.3;
 			};
 		};
 		F788ECC5263AAAF900ADC67F /* XCRemoteSwiftPackageReference "MarkdownKit" */ = {

--- a/iOSClient/Data/NCManageDatabase+Metadata.swift
+++ b/iOSClient/Data/NCManageDatabase+Metadata.swift
@@ -227,7 +227,6 @@ extension tableMetadata {
         return session.isEmpty && !isDirectoryE2EE && !e2eEncrypted
     }
 
-    // Return if is sharable
     func isSharable() -> Bool {
         guard let capabilities = NCNetworking.shared.capabilities[account] else {
             return false
@@ -1378,6 +1377,14 @@ extension NCManageDatabase {
                 .filter(predicate)
                 .first != nil
         } ?? false
+    }
+
+    func countMetadatasFor(serverUrl: String) -> Int {
+        core.performRealmRead { realm in
+            let results = realm.objects(tableMetadata.self)
+                .filter("serverUrl == %@", serverUrl)
+            return results.count
+        } ?? 0
     }
 
     // MARK: - helpers

--- a/iOSClient/Menu/NCContextMenuMain.swift
+++ b/iOSClient/Menu/NCContextMenuMain.swift
@@ -214,9 +214,12 @@ class NCContextMenuMain: NSObject {
         capabilities: NKCapabilities.Capabilities,
         mainActionsMenu: inout [UIMenuElement]
     ) {
+        let numItems = NCManageDatabase.shared.countMetadatasFor(serverUrl: metadata.serverUrlFileName)
+
         // Set folder E2EE
         if NCNetworking.shared.isOnline,
            metadata.directory,
+           numItems == 0,
            metadata.size == 0,
            !metadata.e2eEncrypted,
            NCPreferences().isEndToEndEnabled(account: metadata.account),
@@ -226,6 +229,7 @@ class NCContextMenuMain: NSObject {
 
         // Unset folder E2EE
         if NCNetworking.shared.isOnline,
+           numItems == 0,
            metadata.canUnsetDirectoryAsE2EE {
             mainActionsMenu.append(makeUnsetFolderE2EEAction(metadata: metadata))
         }


### PR DESCRIPTION
### Summary

This pull request fixes an issue where the context menu incorrectly showed the Encrypt option for an apparently empty parent folder, even when that folder contained subfolders.

In this case, starting the encryption process failed with a "Folder not found" error because the folder was not actually eligible for encryption.

### Changes

- Updated the E2EE availability check for folders.
- Prevented the Encrypt action from being shown when the folder is not really empty or cannot be encrypted safely.

### Result

The Encrypt option is no longer displayed for parent folders that contain subfolders, avoiding a failing encryption flow and the misleading "Folder not found" error.