### PR TITLE
Fix unwanted gesture back action

### DIFF
--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -103,8 +103,6 @@ jobs:
         ./server/occ config:system:set hashing_default_password --value=true --type=boolean
         ./server/occ config:system:set auth.bruteforce.protection.enabled --value false --type bool
         ./server/occ config:system:set ratelimit.protection.enabled --value false --type bool
-        ./server/occ config:system:set memcache.local --value="\\OC\\Memcache\\APCu"
-        ./server/occ config:system:set memcache.distributed --value="\\OC\\Memcache\\APCu"
         ./server/occ app:enable files_downloadlimit
         ./server/occ background:cron
         PHP_CLI_SERVER_WORKERS=5 php -S localhost:8080 -t server/ &

--- a/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.swift
+++ b/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.swift
@@ -82,11 +82,6 @@ class NCViewerDirectEditing: UIViewController, WKNavigationDelegate, WKScriptMes
         bottomConstraint = webView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 70)
         bottomConstraint?.isActive = true
 
-        if #available(iOS 26.0, *) {
-//            webView.inputViewController?.navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
-
-        }
-
         if editor == "onlyoffice" {
             webView.customUserAgent = utility.getCustomUserAgentOnlyOffice()
         } else if editor == "nextcloud text" {

--- a/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.swift
+++ b/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.swift
@@ -218,7 +218,7 @@ class NCViewerDirectEditing: UIViewController, WKNavigationDelegate, WKScriptMes
         if #available(iOS 26.0, *) {
             navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
         }
-        
+
         NCActivityIndicator.shared.stop()
     }
 

--- a/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.swift
+++ b/iOSClient/Viewer/NCViewerDirectEditing/NCViewerDirectEditing.swift
@@ -56,7 +56,7 @@ class NCViewerDirectEditing: UIViewController, WKNavigationDelegate, WKScriptMes
         navigationItem.trailingItemGroups = [group]
         navigationItem.leftBarButtonItems = nil
 
-        // Prevent back navigation gesture of iOS/iPadOS >= 26 as that will interfere with the possibility to mark text in onlyoffice
+        // Prevent back navigation gesture of iOS >= 26 as that can cause unintended swipe backs
         if #available(iOS 26.0, *) {
             navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
         }
@@ -81,6 +81,11 @@ class NCViewerDirectEditing: UIViewController, WKNavigationDelegate, WKScriptMes
         webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0).isActive = true
         bottomConstraint = webView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 70)
         bottomConstraint?.isActive = true
+
+        if #available(iOS 26.0, *) {
+//            webView.inputViewController?.navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
+
+        }
 
         if editor == "onlyoffice" {
             webView.customUserAgent = utility.getCustomUserAgentOnlyOffice()
@@ -210,6 +215,10 @@ class NCViewerDirectEditing: UIViewController, WKNavigationDelegate, WKScriptMes
     }
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if #available(iOS 26.0, *) {
+            navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
+        }
+        
         NCActivityIndicator.shared.stop()
     }
 

--- a/iOSClient/Viewer/NCViewerRichdocument/NCViewerRichDocument.swift
+++ b/iOSClient/Viewer/NCViewerRichdocument/NCViewerRichDocument.swift
@@ -121,7 +121,7 @@ class NCViewerRichDocument: UIViewController, WKNavigationDelegate, WKScriptMess
             tabBarController?.tabBar.isHidden = false
         }
 
-        // Prevent back navigation gesture of iOS/iPadOS >= 26 as that can cause unintended swipe backs
+        // Prevent back navigation gesture of iOS >= 26 as that can cause unintended swipe backs
         if #available(iOS 26.0, *) {
             navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
         }
@@ -393,6 +393,10 @@ class NCViewerRichDocument: UIViewController, WKNavigationDelegate, WKScriptMess
     }
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        if #available(iOS 26.0, *) {
+            navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
+        }
+
         NCActivityIndicator.shared.stop()
     }
 

--- a/iOSClient/Viewer/NCViewerRichdocument/NCViewerRichDocument.swift
+++ b/iOSClient/Viewer/NCViewerRichdocument/NCViewerRichDocument.swift
@@ -121,6 +121,11 @@ class NCViewerRichDocument: UIViewController, WKNavigationDelegate, WKScriptMess
             tabBarController?.tabBar.isHidden = false
         }
 
+        // Prevent back navigation gesture of iOS/iPadOS >= 26 as that can cause unintended swipe backs
+        if #available(iOS 26.0, *) {
+            navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
+        }
+
         Task {
             await NCNetworking.shared.transferDispatcher.removeDelegate(self)
         }


### PR DESCRIPTION
Fixes an iOS 26+ issue where content back gesture action is enabled by default, causing unwanted swipe backs while opening documents or moving them around. 