### PR TITLE
4181 swiping down any amount closes image preview even when zoomed in

### DIFF
--- a/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageViewerContentView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageViewerContentView.swift
@@ -13,6 +13,7 @@ struct NCImageViewerContentView: View {
     let fullURL: URL?
     let backgroundStyle: NCViewerBackgroundStyle
     let allowsImageAnalysis: Bool
+    let onZoomChanged: (Bool) -> Void
 
     @State private var currentImage: UIImage?
     @State private var loadedPreviewURL: URL?
@@ -30,13 +31,15 @@ struct NCImageViewerContentView: View {
         previewURL: URL?,
         fullURL: URL?,
         backgroundStyle: NCViewerBackgroundStyle = .system,
-        allowsImageAnalysis: Bool = true
+        allowsImageAnalysis: Bool = true,
+        onZoomChanged: @escaping (Bool) -> Void = { _ in }
     ) {
         self.identifier = identifier
         self.previewURL = previewURL
         self.fullURL = fullURL
         self.backgroundStyle = backgroundStyle
         self.allowsImageAnalysis = allowsImageAnalysis
+        self.onZoomChanged = onZoomChanged
     }
 
     var body: some View {
@@ -48,7 +51,8 @@ struct NCImageViewerContentView: View {
                 NCImageZoomView(
                     image: currentImage,
                     backgroundStyle: backgroundStyle,
-                    allowsImageAnalysis: shouldAllowImageAnalysis
+                    allowsImageAnalysis: shouldAllowImageAnalysis,
+                    onZoomChanged: onZoomChanged
                 )
                 .ignoresSafeArea()
             } else if let failedMessage {

--- a/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageZoomView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageZoomView.swift
@@ -11,6 +11,7 @@ struct NCImageZoomView: UIViewRepresentable {
     let image: UIImage
     let backgroundStyle: NCViewerBackgroundStyle
     let allowsImageAnalysis: Bool
+    let onZoomChanged: (Bool) -> Void
 
     private let minimumZoomScale: CGFloat = 1
     private let maximumZoomScale: CGFloat = 5
@@ -19,11 +20,13 @@ struct NCImageZoomView: UIViewRepresentable {
     init(
         image: UIImage,
         backgroundStyle: NCViewerBackgroundStyle = .system,
-        allowsImageAnalysis: Bool = true
+        allowsImageAnalysis: Bool = true,
+        onZoomChanged: @escaping (Bool) -> Void = { _ in }
     ) {
         self.image = image
         self.backgroundStyle = backgroundStyle
         self.allowsImageAnalysis = allowsImageAnalysis
+        self.onZoomChanged = onZoomChanged
     }
 
     // MARK: - UIViewRepresentable
@@ -60,6 +63,7 @@ struct NCImageZoomView: UIViewRepresentable {
         context.coordinator.minimumZoomScale = minimumZoomScale
         context.coordinator.maximumZoomScale = maximumZoomScale
         context.coordinator.doubleTapZoomScale = doubleTapZoomScale
+        context.coordinator.onZoomChanged = onZoomChanged
 
         if allowsImageAnalysis {
             analyzeImageIfAvailable(
@@ -95,6 +99,7 @@ struct NCImageZoomView: UIViewRepresentable {
         context.coordinator.minimumZoomScale = minimumZoomScale
         context.coordinator.maximumZoomScale = maximumZoomScale
         context.coordinator.doubleTapZoomScale = doubleTapZoomScale
+        context.coordinator.onZoomChanged = onZoomChanged
 
         scrollView.backgroundColor = .ncViewerBackground(backgroundStyle)
         scrollView.minimumZoomScale = minimumZoomScale
@@ -151,6 +156,7 @@ struct NCImageZoomView: UIViewRepresentable {
         var minimumZoomScale: CGFloat = 1
         var maximumZoomScale: CGFloat = 5
         var doubleTapZoomScale: CGFloat = 2.5
+        var onZoomChanged: (Bool) -> Void = { _ in }
 
         private var lastBoundsSize: CGSize = .zero
 
@@ -161,6 +167,10 @@ struct NCImageZoomView: UIViewRepresentable {
 
         func scrollViewDidZoom(_ scrollView: UIScrollView) {
             centerImageView()
+
+            onZoomChanged(
+                scrollView.zoomScale > scrollView.minimumZoomScale + 0.01
+            )
         }
 
         // MARK: - Layout

--- a/iOSClient/Viewer/NCViewerMedia/Content/Image/NCLivePhotoViewerContentView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Image/NCLivePhotoViewerContentView.swift
@@ -17,6 +17,7 @@ struct NCLivePhotoViewerContentView: View {
     let videoURL: URL?
     let backgroundStyle: NCViewerBackgroundStyle
     let topOverlayInset: CGFloat
+    let onZoomChanged: (Bool) -> Void
 
     @State private var livePhoto: PHLivePhoto?
     @State private var isPlayingLivePhoto = false
@@ -28,7 +29,8 @@ struct NCLivePhotoViewerContentView: View {
         fullURL: URL?,
         videoURL: URL?,
         backgroundStyle: NCViewerBackgroundStyle = .system,
-        topOverlayInset: CGFloat = 0
+        topOverlayInset: CGFloat = 0,
+        onZoomChanged: @escaping (Bool) -> Void = { _ in }
     ) {
         self.identifier = identifier
         self.previewURL = previewURL
@@ -36,6 +38,7 @@ struct NCLivePhotoViewerContentView: View {
         self.videoURL = videoURL
         self.backgroundStyle = backgroundStyle
         self.topOverlayInset = topOverlayInset
+        self.onZoomChanged = onZoomChanged
     }
 
     var body: some View {
@@ -95,7 +98,8 @@ struct NCLivePhotoViewerContentView: View {
             previewURL: previewURL,
             fullURL: fullURL,
             backgroundStyle: backgroundStyle,
-            allowsImageAnalysis: false
+            allowsImageAnalysis: false,
+            onZoomChanged: onZoomChanged
         )
     }
 

--- a/iOSClient/Viewer/NCViewerMedia/Content/Video/AVPlayer/NCVideoAVPlayerPresenter.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Video/AVPlayer/NCVideoAVPlayerPresenter.swift
@@ -8,7 +8,6 @@ import NextcloudKit
 // MARK: - AVPlayer Presenter
 @MainActor
 enum NCVideoAVPlayerPresenter {
-
     // MARK: - State
     private static weak var currentViewController: NCVideoAVPlayerViewController?
     private static var currentURL: URL?

--- a/iOSClient/Viewer/NCViewerMedia/Content/Video/AVPlayer/NCVideoAVPlayerViewControls.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Video/AVPlayer/NCVideoAVPlayerViewControls.swift
@@ -8,7 +8,6 @@ import UIKit
 // MARK: - Playback Controls
 
 extension NCVideoAVPlayerViewController {
-
     private func seek(bySeconds seconds: Double) {
         guard let duration = player.currentItem?.duration.seconds,
               duration.isFinite,

--- a/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerModel.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerModel.swift
@@ -23,14 +23,21 @@ enum NCMediaViewerPageState {
 
 // MARK: - Page Model
 
-struct NCMediaViewerPageModel: Identifiable {
+@MainActor
+final class NCMediaViewerPageModel: ObservableObject, Identifiable {
     let id: String
     let index: Int
     let ocId: String
-    var metadata: tableMetadata?
-    var state: NCMediaViewerPageState
 
-    init(index: Int, ocId: String, metadata: tableMetadata? = nil, state: NCMediaViewerPageState = .idle) {
+    @Published var metadata: tableMetadata?
+    @Published var state: NCMediaViewerPageState
+
+    init(
+        index: Int,
+        ocId: String,
+        metadata: tableMetadata? = nil,
+        state: NCMediaViewerPageState = .idle
+    ) {
         self.id = ocId
         self.index = index
         self.ocId = ocId
@@ -250,7 +257,12 @@ final class NCMediaViewerModel: ObservableObject {
             return cachedPage
         }
 
-        let page = NCMediaViewerPageModel(index: index, ocId: ocId, metadata: nil, state: .idle)
+        let page = NCMediaViewerPageModel(
+            index: index,
+            ocId: ocId,
+            metadata: nil,
+            state: .idle
+        )
 
         cachedPagesByOcId[ocId] = page
         return page
@@ -381,11 +393,18 @@ final class NCMediaViewerModel: ObservableObject {
             await self.loadPage(index: index)
         }
 
-        loadingTasksByOcId[ocId] = NCMediaViewerLoadingTask(identifier: identifier, kind: .selected, task: task)
+        loadingTasksByOcId[ocId] = NCMediaViewerLoadingTask(
+            identifier: identifier,
+            kind: .selected,
+            task: task
+        )
 
         await task.value
 
-        clearLoadingTaskIfCurrent(ocId: ocId, identifier: identifier)
+        clearLoadingTaskIfCurrent(
+            ocId: ocId,
+            identifier: identifier
+        )
     }
 
     /// Reloads the page from the beginning, forcing a fresh metadata resolution before rebuilding the preview and media state.
@@ -455,11 +474,20 @@ final class NCMediaViewerModel: ObservableObject {
         isChromeHidden.toggle()
     }
 
-    func previewURL(for metadata: tableMetadata, ext: String) async -> URL? {
-        await loader.previewURL(for: metadata, ext: ext)
+    func previewURL(
+        for metadata: tableMetadata,
+        ext: String
+    ) async -> URL? {
+        await loader.previewURL(
+            for: metadata,
+            ext: ext
+        )
     }
 
-    func localPreviewURL(for metadata: tableMetadata, ext: String) -> URL? {
+    func localPreviewURL(
+        for metadata: tableMetadata,
+        ext: String
+    ) -> URL? {
         let localPath = utilityFileSystem.getDirectoryProviderStorageImageOcId(
             metadata.ocId,
             etag: metadata.etag,
@@ -475,7 +503,9 @@ final class NCMediaViewerModel: ObservableObject {
         return URL(fileURLWithPath: localPath)
     }
 
-    func resolveMetadataForThumbnail(at index: Int) async -> tableMetadata? {
+    func resolveMetadataForThumbnail(
+        at index: Int
+    ) async -> tableMetadata? {
         guard let ocId = ocId(at: index) else {
             return nil
         }
@@ -844,7 +874,8 @@ final class NCMediaViewerModel: ObservableObject {
             return
         }
 
-        if metadata.classFile == NKTypeClassFile.image.rawValue, let previewURL {
+        if metadata.classFile == NKTypeClassFile.image.rawValue,
+           let previewURL {
             setState(
                 .image(
                     previewURL: previewURL,
@@ -932,7 +963,9 @@ final class NCMediaViewerModel: ObservableObject {
         )
     }
 
-    private func pageState(for ocId: String) -> NCMediaViewerPageState {
+    private func pageState(
+        for ocId: String
+    ) -> NCMediaViewerPageState {
         cachedPagesByOcId[ocId]?.state ?? .idle
     }
 
@@ -963,7 +996,9 @@ final class NCMediaViewerModel: ObservableObject {
         }
     }
 
-    private func shouldLoadPreview(for metadata: tableMetadata) -> Bool {
+    private func shouldLoadPreview(
+        for metadata: tableMetadata
+    ) -> Bool {
         switch metadata.classFile {
         case NKTypeClassFile.image.rawValue,
              NKTypeClassFile.audio.rawValue,
@@ -975,13 +1010,19 @@ final class NCMediaViewerModel: ObservableObject {
         }
     }
 
-    private func setMetadata(_ metadata: tableMetadata, for ocId: String) {
+    private func setMetadata(
+        _ metadata: tableMetadata,
+        for ocId: String
+    ) {
         updatePage(ocId: ocId) { page in
             page.metadata = metadata
         }
     }
 
-    private func setState(_ state: NCMediaViewerPageState, for ocId: String) {
+    private func setState(
+        _ state: NCMediaViewerPageState,
+        for ocId: String
+    ) {
         updatePage(ocId: ocId) { page in
             page.state = state
         }
@@ -1079,29 +1120,38 @@ final class NCMediaViewerModel: ObservableObject {
     private func updatePage(
         ocId: String,
         publishRevision: Bool = true,
-        mutation: (inout NCMediaViewerPageModel) -> Void
+        mutation: (NCMediaViewerPageModel) -> Void
     ) {
         guard let index = ocIds.firstIndex(of: ocId) else {
             return
         }
 
-        var page = cachedPagesByOcId[ocId] ?? NCMediaViewerPageModel(
-            index: index,
-            ocId: ocId,
-            metadata: nil,
-            state: .idle
-        )
+        let page: NCMediaViewerPageModel
 
-        mutation(&page)
+        if let cachedPage = cachedPagesByOcId[ocId] {
+            page = cachedPage
+        } else {
+            page = NCMediaViewerPageModel(
+                index: index,
+                ocId: ocId,
+                metadata: nil,
+                state: .idle
+            )
 
-        cachedPagesByOcId[ocId] = page
+            cachedPagesByOcId[ocId] = page
+        }
+
+        mutation(page)
 
         if publishRevision {
             revision &+= 1
         }
     }
 
-    private func setThumbnailMetadata(_ metadata: tableMetadata, for ocId: String) {
+    private func setThumbnailMetadata(
+        _ metadata: tableMetadata,
+        for ocId: String
+    ) {
         updatePage(
             ocId: ocId,
             publishRevision: false
@@ -1120,7 +1170,6 @@ final class NCMediaViewerModel: ObservableObject {
 
         loadingTasksByOcId[ocId] = nil
     }
-
 }
 
 // MARK: - NCMediaViewerPageState Helpers

--- a/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerView.swift
@@ -12,6 +12,7 @@ struct NCMediaViewerView: View {
     let contextMenuController: NCMainTabBarController?
     let navigationBar: UINavigationBar?
     let onVisibleMetadataChanged: (_ metadata: tableMetadata?, _ backgroundColor: UIColor) -> Void
+    let onZoomChanged: (Bool) -> Void
     let onClose: (_ ocId: String?) -> Void
 
     /// Creates the media viewer view.
@@ -20,12 +21,14 @@ struct NCMediaViewerView: View {
         contextMenuController: NCMainTabBarController? = nil,
         navigationBar: UINavigationBar? = nil,
         onVisibleMetadataChanged: @escaping (_ metadata: tableMetadata?, _ backgroundColor: UIColor) -> Void = { _, _ in },
+        onZoomChanged: @escaping (Bool) -> Void = { _ in },
         onClose: @escaping (_ ocId: String?) -> Void = { _ in }
     ) {
         _model = StateObject(wrappedValue: model)
         self.contextMenuController = contextMenuController
         self.navigationBar = navigationBar
         self.onVisibleMetadataChanged = onVisibleMetadataChanged
+        self.onZoomChanged = onZoomChanged
         self.onClose = onClose
     }
 
@@ -39,6 +42,7 @@ struct NCMediaViewerView: View {
                 contextMenuController: contextMenuController,
                 navigationBar: navigationBar,
                 onVisibleMetadataChanged: onVisibleMetadataChanged,
+                onZoomChanged: onZoomChanged,
                 onClose: onClose
             )
             .ignoresSafeArea()

--- a/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// Main SwiftUI media viewer.
 struct NCMediaViewerView: View {
     @StateObject private var model: NCMediaViewerModel
+
     let contextMenuController: NCMainTabBarController?
     let navigationBar: UINavigationBar?
     let onVisibleMetadataChanged: (_ metadata: tableMetadata?, _ backgroundColor: UIColor) -> Void

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaViewerHostingController.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaViewerHostingController.swift
@@ -13,6 +13,7 @@ import NextcloudKit
 @MainActor
 final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerView>, UIAdaptivePresentationControllerDelegate {
     private let model: NCMediaViewerModel
+    private let onZoomChanged: (Bool) -> Void
     private let onClose: (_ ocId: String?) -> Void
     private weak var contextMenuController: NCMainTabBarController?
 
@@ -77,10 +78,12 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
     init(
         model: NCMediaViewerModel,
         contextMenuController: NCMainTabBarController?,
+        onZoomChanged: @escaping (Bool) -> Void,
         onClose: @escaping (_ ocId: String?) -> Void
     ) {
         self.model = model
         self.contextMenuController = contextMenuController
+        self.onZoomChanged = onZoomChanged
         self.onClose = onClose
 
         super.init(
@@ -89,6 +92,7 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
                 contextMenuController: contextMenuController,
                 navigationBar: nil,
                 onVisibleMetadataChanged: { _, _ in },
+                onZoomChanged: onZoomChanged,
                 onClose: { _ in }
             )
         )
@@ -190,6 +194,7 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
                     backgroundColor: backgroundColor
                 )
             },
+            onZoomChanged: onZoomChanged,
             onClose: { [weak self] ocId in
                 self?.close(ocId: ocId)
             }

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaViewerPresenter.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaViewerPresenter.swift
@@ -121,6 +121,7 @@ final class NCMediaViewerPresenter: NSObject {
     private weak var dismissPanGestureView: UIView?
     private var isTrackingDismissPan = false
     private var isDismissing = false
+    private var isCurrentImageZoomed = false
 
     private override init() {
         super.init()
@@ -147,10 +148,14 @@ final class NCMediaViewerPresenter: NSObject {
         self.closingTransitionSourceProvider = closingTransitionSourceProvider
         forcedClosingOcId = nil
         isDismissing = false
+        isCurrentImageZoomed = false
 
         let hostingController = NCMediaViewerHostingController(
             model: model,
             contextMenuController: contextMenuController,
+            onZoomChanged: { [weak self] isZoomed in
+                self?.isCurrentImageZoomed = isZoomed
+            },
             onClose: { [weak self] ocId in
                 guard let self else {
                     return
@@ -520,6 +525,7 @@ final class NCMediaViewerPresenter: NSObject {
         currentModel = nil
         closingTransitionSourceProvider = nil
         forcedClosingOcId = nil
+        isCurrentImageZoomed = false
     }
 
     // MARK: - Helpers
@@ -571,6 +577,9 @@ extension NCMediaViewerPresenter: UIGestureRecognizerDelegate {
               let panGesture = gestureRecognizer as? UIPanGestureRecognizer,
               let view = panGesture.view else {
             return true
+        }
+        guard !isCurrentImageZoomed else {
+            return false
         }
 
         let velocity = panGesture.velocity(in: view)

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
@@ -8,11 +8,11 @@ import NextcloudKit
 // MARK: - Media Viewer Page View
 
 struct NCMediaViewerPageView: View {
+    @ObservedObject var model: NCMediaViewerModel
     @ObservedObject var page: NCMediaViewerPageModel
 
     let isChromeHidden: Bool
     let onToggleChrome: () -> Void
-    let isSelected: Bool
 
     let canGoPrevious: Bool
     let canGoNext: Bool
@@ -25,6 +25,10 @@ struct NCMediaViewerPageView: View {
 
     let contextMenuController: NCMainTabBarController?
     let navigationBar: UINavigationBar?
+
+    private var isSelected: Bool {
+        model.selectedIndex == page.index
+    }
 
     // MARK: - Body
 

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
@@ -23,6 +23,7 @@ struct NCMediaViewerPageView: View {
     let onNextPage: (_ shouldAutoPlay: Bool) -> Void
     let onClose: (_ ocId: String?) -> Void
     let onAutoPlayConsumed: () -> Void
+    let onZoomChanged: (Bool) -> Void
 
     let contextMenuController: NCMainTabBarController?
     let navigationBar: UINavigationBar?
@@ -389,7 +390,8 @@ struct NCMediaViewerPageView: View {
                 fullURL: localURL,
                 videoURL: livePhotoURL,
                 backgroundStyle: backgroundStyle,
-                topOverlayInset: livePhotoTopOverlayInset
+                topOverlayInset: livePhotoTopOverlayInset,
+                onZoomChanged: onZoomChanged
             )
             .background(Color.ncViewerBackground(backgroundStyle))
             .contentShape(Rectangle())
@@ -399,7 +401,8 @@ struct NCMediaViewerPageView: View {
                 identifier: page.ocId,
                 previewURL: previewURL,
                 fullURL: localURL,
-                backgroundStyle: backgroundStyle
+                backgroundStyle: backgroundStyle,
+                onZoomChanged: onZoomChanged
             )
             .contentShape(Rectangle())
             .gesture(chromeToggleGesture())
@@ -412,7 +415,8 @@ struct NCMediaViewerPageView: View {
             identifier: page.ocId,
             previewURL: previewURL,
             fullURL: nil,
-            backgroundStyle: backgroundStyle
+            backgroundStyle: backgroundStyle,
+            onZoomChanged: onZoomChanged
         )
         .contentShape(Rectangle())
         .gesture(chromeToggleGesture())

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
@@ -8,10 +8,8 @@ import NextcloudKit
 // MARK: - Media Viewer Page View
 
 struct NCMediaViewerPageView: View {
+    @ObservedObject var page: NCMediaViewerPageModel
 
-    // MARK: - Properties
-
-    let page: NCMediaViewerPageModel
     let isChromeHidden: Bool
     let onToggleChrome: () -> Void
     let isSelected: Bool

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPagingView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPagingView.swift
@@ -336,6 +336,7 @@ final class NCMediaViewerPagingCoordinator: NSObject,
 
         let didChangePage = lastVisibleIndex != index
         lastVisibleIndex = index
+
         if didChangePage {
             onZoomChanged(false)
         }
@@ -344,6 +345,16 @@ final class NCMediaViewerPagingCoordinator: NSObject,
             index,
             animated: animated
         )
+
+        if !animated {
+            isUserPaging = false
+            model.setSelectedIndex(index)
+            refreshVisibleCells()
+
+            Task {
+                await model.displayPage(at: index)
+            }
+        }
 
         updateCollectionBackground(for: index)
         updateVisibleMetadataTitle(for: index)
@@ -442,13 +453,11 @@ final class NCMediaViewerPagingCoordinator: NSObject,
         )
     }
 
-    private func configure(
-        cell: NCMediaViewerPagingCell,
-        page: NCMediaViewerPageModel
-    ) {
+    private func configure(cell: NCMediaViewerPagingCell, page: NCMediaViewerPageModel) {
         let pageBackgroundColor = backgroundColor(for: page)
 
         cell.configure(
+            model: model,
             page: page,
             isSelected: !isUserPaging && page.index == model.selectedIndex,
             isChromeHidden: model.isChromeHidden,
@@ -735,6 +744,7 @@ final class NCMediaViewerPagingCell: UICollectionViewCell {
     // MARK: - Configuration
 
     func configure(
+        model: NCMediaViewerModel,
         page: NCMediaViewerPageModel,
         isSelected: Bool,
         isChromeHidden: Bool,
@@ -756,10 +766,10 @@ final class NCMediaViewerPagingCell: UICollectionViewCell {
 
         let view = AnyView(
             NCMediaViewerPageView(
+                model: model,
                 page: page,
                 isChromeHidden: isChromeHidden,
                 onToggleChrome: onToggleChrome,
-                isSelected: isSelected,
                 canGoPrevious: canGoPrevious,
                 canGoNext: canGoNext,
                 shouldAutoPlay: shouldAutoPlay,

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPagingView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPagingView.swift
@@ -14,6 +14,7 @@ struct NCMediaViewerPagingView: UIViewRepresentable {
     let contextMenuController: NCMainTabBarController?
     let navigationBar: UINavigationBar?
     let onVisibleMetadataChanged: (_ metadata: tableMetadata?, _ backgroundColor: UIColor) -> Void
+    let onZoomChanged: (Bool) -> Void
     let onClose: (_ ocId: String?) -> Void
 
     // MARK: - UIViewRepresentable
@@ -67,6 +68,7 @@ struct NCMediaViewerPagingView: UIViewRepresentable {
         context.coordinator.model = model
         context.coordinator.navigationBar = navigationBar
         context.coordinator.onVisibleMetadataChanged = onVisibleMetadataChanged
+        context.coordinator.onZoomChanged = onZoomChanged
         context.coordinator.onClose = onClose
         context.coordinator.updateCollectionBackground()
 
@@ -93,6 +95,7 @@ struct NCMediaViewerPagingView: UIViewRepresentable {
             contextMenuController: contextMenuController,
             navigationBar: navigationBar,
             onVisibleMetadataChanged: onVisibleMetadataChanged,
+            onZoomChanged: onZoomChanged,
             onClose: onClose
         )
     }
@@ -120,6 +123,7 @@ final class NCMediaViewerPagingCoordinator: NSObject,
     let contextMenuController: NCMainTabBarController?
     weak var navigationBar: UINavigationBar?
     var onVisibleMetadataChanged: (_ metadata: tableMetadata?, _ backgroundColor: UIColor) -> Void
+    var onZoomChanged: (Bool) -> Void
     var onClose: (_ ocId: String?) -> Void
 
     private var didScrollToInitialIndex = false
@@ -136,12 +140,14 @@ final class NCMediaViewerPagingCoordinator: NSObject,
         contextMenuController: NCMainTabBarController?,
         navigationBar: UINavigationBar?,
         onVisibleMetadataChanged: @escaping (_ metadata: tableMetadata?, _ backgroundColor: UIColor) -> Void,
+        onZoomChanged: @escaping (Bool) -> Void,
         onClose: @escaping (_ ocId: String?) -> Void
     ) {
         self.model = model
         self.contextMenuController = contextMenuController
         self.navigationBar = navigationBar
         self.onVisibleMetadataChanged = onVisibleMetadataChanged
+        self.onZoomChanged = onZoomChanged
         self.onClose = onClose
 
         super.init()
@@ -328,7 +334,11 @@ final class NCMediaViewerPagingCoordinator: NSObject,
             return
         }
 
+        let didChangePage = lastVisibleIndex != index
         lastVisibleIndex = index
+        if didChangePage {
+            onZoomChanged(false)
+        }
 
         jumpToIndex(
             index,
@@ -421,7 +431,6 @@ final class NCMediaViewerPagingCoordinator: NSObject,
 
         // Selection is finalized when the scroll animation ends.
         isUserPaging = true
-        lastVisibleIndex = targetIndex
 
         updateCollectionBackground(for: targetIndex)
         updateVisibleMetadataTitle(for: targetIndex)
@@ -462,11 +471,20 @@ final class NCMediaViewerPagingCoordinator: NSObject,
                     shouldAutoPlay: shouldAutoPlay
                 )
             },
-            onClose: { [weak self] ocId in
-                self?.onClose(ocId)
-            },
             onAutoPlayConsumed: { [weak model] in
                 model?.clearAutoPlayIfNeeded(for: page.index)
+            },
+            onZoomChanged: { [weak self] isZoomed in
+                guard let self,
+                      !self.isUserPaging,
+                      page.index == self.model.selectedIndex else {
+                    return
+                }
+
+                self.onZoomChanged(isZoomed)
+            },
+            onClose: { [weak self] ocId in
+                self?.onClose(ocId)
             },
             contextMenuController: contextMenuController,
             navigationBar: navigationBar
@@ -556,6 +574,7 @@ final class NCMediaViewerPagingCoordinator: NSObject,
         }
 
         lastVisibleIndex = index
+        onZoomChanged(false)
         model.setSelectedIndex(index)
         updateCollectionBackground(for: index)
         updateVisibleMetadataTitle(for: index)
@@ -617,6 +636,7 @@ final class NCMediaViewerPagingCoordinator: NSObject,
         }
 
         lastVisibleIndex = index
+        onZoomChanged(false)
         model.setSelectedIndex(index)
         updateCollectionBackground(for: index)
         updateVisibleMetadataTitle(for: index)
@@ -725,8 +745,9 @@ final class NCMediaViewerPagingCell: UICollectionViewCell {
         onToggleChrome: @escaping () -> Void,
         onPreviousPage: @escaping (_ shouldAutoPlay: Bool) -> Void,
         onNextPage: @escaping (_ shouldAutoPlay: Bool) -> Void,
-        onClose: @escaping (_ ocId: String?) -> Void,
         onAutoPlayConsumed: @escaping () -> Void,
+        onZoomChanged: @escaping (Bool) -> Void,
+        onClose: @escaping (_ ocId: String?) -> Void,
         contextMenuController: NCMainTabBarController?,
         navigationBar: UINavigationBar?
     ) {
@@ -746,6 +767,7 @@ final class NCMediaViewerPagingCell: UICollectionViewCell {
                 onNextPage: onNextPage,
                 onClose: onClose,
                 onAutoPlayConsumed: onAutoPlayConsumed,
+                onZoomChanged: onZoomChanged,
                 contextMenuController: contextMenuController,
                 navigationBar: navigationBar
             )

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPagingView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPagingView.swift
@@ -11,6 +11,7 @@ import NextcloudKit
 
 struct NCMediaViewerPagingView: UIViewRepresentable {
     @ObservedObject var model: NCMediaViewerModel
+
     let contextMenuController: NCMainTabBarController?
     let navigationBar: UINavigationBar?
     let onVisibleMetadataChanged: (_ metadata: tableMetadata?, _ backgroundColor: UIColor) -> Void
@@ -86,7 +87,6 @@ struct NCMediaViewerPagingView: UIViewRepresentable {
         }
 
         context.coordinator.jumpToSelectedIndexIfNeeded(animated: false)
-        context.coordinator.refreshVisibleCells()
     }
 
     func makeCoordinator() -> NCMediaViewerPagingCoordinator {
@@ -783,8 +783,8 @@ final class NCMediaViewerPagingCell: UICollectionViewCell {
             currentOcId = page.ocId
         }
 
-        if let hostingController {
-            hostingController.rootView = view
+        if let hostingController,
+           currentOcId == page.ocId {
             hostingController.view.backgroundColor = backgroundColor
             hostingController.view.frame = contentView.bounds
         } else {


### PR DESCRIPTION
Summary

Fixes an issue where swiping down would dismiss the image viewer even when the image was zoomed in.

Changes

* Added zoom state tracking to the image viewer.
* Prevented the swipe-to-dismiss gesture from starting while the current image is zoomed.
* Propagated zoom state changes from NCImageZoomView to the media viewer presenter.
* Introduced a dedicated callback (onZoomChanged) to synchronize zoom state across the viewer hierarchy.

Additional Improvements

* Refactored NCMediaViewerPageModel into an observable object to allow page state updates without recreating the SwiftUI view hierarchy.
* Updated page rendering to observe state changes directly instead of rebuilding the hosting view.
* Preserved SwiftUI view state (including image loading and zoom state) during page updates.
* Eliminated the visible white flash that could occur while transitioning from placeholder/loading states to the final image, especially with large images and Live Photos.

Result

* Swiping down no longer dismisses the viewer while the image is zoomed.
* Image dismissal behaves correctly once the zoom returns to its default scale.
* Page updates are smoother and no longer recreate the entire view hierarchy.
* Improved visual stability during image and Live Photo loading.