### PR TITLE
fix: only convert camera roll compatibility formats to JPEG

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C0DECA022F65000100C0D001 /* NCCameraRollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */; };
 		2C1D5D7623E2DE3300334ABB /* NCManageDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7BAADB51ED5A87C00B7EAD4 /* NCManageDatabase.swift */; };
 		2C1D5D7923E2DE9100334ABB /* NCBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76B3CCD1EAE01BD00921AC9 /* NCBrand.swift */; };
 		2C33C48223E2C475005F963B /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C33C48123E2C475005F963B /* NotificationService.swift */; };
@@ -1200,6 +1201,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCCameraRollTests.swift; sourceTree = "<group>"; };
 		2C33C47F23E2C475005F963B /* Notification Service Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Notification Service Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C33C48123E2C475005F963B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		2C33C48A23E2CC26005F963B /* Notification_Service_Extension-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Notification_Service_Extension-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -2178,6 +2180,7 @@
 			isa = PBXGroup;
 			children = (
 				F34BDB3B2F574A58007A222C /* BidiSafeFilenameTests.swift */,
+				C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */,
 				AA52EB452D42AC5A0089C348 /* Placeholder.swift */,
 			);
 			path = NextcloudUnitTests;
@@ -4464,6 +4467,7 @@
 			files = (
 				AA52EB472D42AC9E0089C348 /* Placeholder.swift in Sources */,
 				F34BDB3C2F574A58007A222C /* BidiSafeFilenameTests.swift in Sources */,
+				C0DECA022F65000100C0D001 /* NCCameraRollTests.swift in Sources */,
 				F372087D2BAB4C0F006B5430 /* TestConstants.swift in Sources */,
 				F78E2D6C29AF02DB0024D4F3 /* Database.swift in Sources */,
 			);

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C0DECA022F65000100C0D001 /* NCCameraRollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */; };
 		2C1D5D7623E2DE3300334ABB /* NCManageDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7BAADB51ED5A87C00B7EAD4 /* NCManageDatabase.swift */; };
 		2C1D5D7923E2DE9100334ABB /* NCBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76B3CCD1EAE01BD00921AC9 /* NCBrand.swift */; };
 		2C33C48223E2C475005F963B /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C33C48123E2C475005F963B /* NotificationService.swift */; };
@@ -92,6 +91,7 @@
 		AFCE353527E4ED5900FEA6C2 /* DateFormatter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE353427E4ED5900FEA6C2 /* DateFormatter+Extension.swift */; };
 		AFCE353727E4ED7B00FEA6C2 /* NCShareCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE353627E4ED7B00FEA6C2 /* NCShareCells.swift */; };
 		AFCE353927E5DE0500FEA6C2 /* Shareable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE353827E5DE0400FEA6C2 /* Shareable.swift */; };
+		C0DECA022F65000100C0D001 /* NCCameraRollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */; };
 		CB3666201AF7550816B5CD6A /* NCContextMenuComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8932E90EC4278026D86CCCC9 /* NCContextMenuComment.swift */; };
 		D5B6AA7827200C7200D49C24 /* NCActivityTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B6AA7727200C7200D49C24 /* NCActivityTableViewCell.swift */; };
 		F31165022F9674A1009A1E37 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = F31165012F9674A1009A1E37 /* AppIcon.icon */; };
@@ -1201,7 +1201,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCCameraRollTests.swift; sourceTree = "<group>"; };
 		2C33C47F23E2C475005F963B /* Notification Service Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Notification Service Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C33C48123E2C475005F963B /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		2C33C48A23E2CC26005F963B /* Notification_Service_Extension-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Notification_Service_Extension-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1335,6 +1334,7 @@
 		BB7697C94BA14450A0867940 /* NCContextMenuProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCContextMenuProfile.swift; sourceTree = "<group>"; };
 		C0046CDA2A17B98400D87C9D /* NextcloudUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextcloudUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C04E2F202A17BB4D001BAD85 /* NextcloudIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NextcloudIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCCameraRollTests.swift; sourceTree = "<group>"; };
 		D5B6AA7727200C7200D49C24 /* NCActivityTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCActivityTableViewCell.swift; sourceTree = "<group>"; };
 		F31165012F9674A1009A1E37 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder.iconcomposer.icon; path = AppIcon.icon; sourceTree = "<group>"; };
 		F317C82D2E844C5300761AEA /* ClientIntegrationUIViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientIntegrationUIViewer.swift; sourceTree = "<group>"; };
@@ -6311,7 +6311,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 0;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = NKUJUXUJ3B;
@@ -6338,7 +6338,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 34.1.1;
+				MARKETING_VERSION = 34.1.2;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-v";
 				OTHER_LDFLAGS = "";
@@ -6379,7 +6379,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 0;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = NKUJUXUJ3B;
@@ -6404,7 +6404,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 34.1.1;
+				MARKETING_VERSION = 34.1.2;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-v";
 				OTHER_LDFLAGS = "";

--- a/Tests/NextcloudUnitTests/NCCameraRollTests.swift
+++ b/Tests/NextcloudUnitTests/NCCameraRollTests.swift
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+import AVFoundation
 import Foundation
 import Testing
 @testable import Nextcloud
@@ -65,5 +66,13 @@ struct NCCameraRollTests {
                 nativeFormat: false
             ) == "2026-08-04 09-30-00.jpg"
         )
+    }
+
+    @Test("Video passthrough retains its original container")
+    func videoContainerPreserved() {
+        #expect(NCCameraRoll.videoOutputFileType(fileExtension: "mov") == .mov)
+        #expect(NCCameraRoll.videoOutputFileType(fileExtension: "MP4") == .mp4)
+        #expect(NCCameraRoll.videoOutputFileType(fileExtension: "m4v") == .m4v)
+        #expect(NCCameraRoll.videoOutputFileType(fileExtension: "jpg") == nil)
     }
 }

--- a/Tests/NextcloudUnitTests/NCCameraRollTests.swift
+++ b/Tests/NextcloudUnitTests/NCCameraRollTests.swift
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+import Testing
+@testable import Nextcloud
+
+@Suite("NCCameraRoll image format conversion")
+struct NCCameraRollTests {
+
+    @Test("Animated and lossless formats retain their filenames")
+    func formatsPreserved() {
+        for fileName in ["animation.gif", "image.png", "animation.webp", "image.tiff", "image.jpg"] {
+            let fileExtension = (fileName as NSString).pathExtension
+
+            #expect(!NCCameraRoll.shouldConvertToJPEG(fileExtension: fileExtension, nativeFormat: false))
+            #expect(
+                NCCameraRoll.outputFileName(
+                    for: fileName,
+                    sourceFileExtension: fileExtension,
+                    nativeFormat: false
+                ) == fileName
+            )
+        }
+    }
+
+    @Test("Compatibility formats are converted to JPEG")
+    func compatibilityFormatsConverted() {
+        for fileName in ["image.heic", "image.heif", "image.dng"] {
+            let fileExtension = (fileName as NSString).pathExtension
+
+            #expect(NCCameraRoll.shouldConvertToJPEG(fileExtension: fileExtension, nativeFormat: false))
+            #expect(
+                NCCameraRoll.outputFileName(
+                    for: fileName,
+                    sourceFileExtension: fileExtension,
+                    nativeFormat: false
+                ) == "image.jpg"
+            )
+        }
+    }
+
+    @Test("Native format preserves HEIC, HEIF and RAW filenames")
+    func nativeFormatsPreserved() {
+        for fileName in ["image.heic", "image.heif", "image.dng"] {
+            let fileExtension = (fileName as NSString).pathExtension
+
+            #expect(!NCCameraRoll.shouldConvertToJPEG(fileExtension: fileExtension, nativeFormat: true))
+            #expect(
+                NCCameraRoll.outputFileName(
+                    for: fileName,
+                    sourceFileExtension: fileExtension,
+                    nativeFormat: true
+                ) == fileName
+            )
+        }
+    }
+
+    @Test("Generated upload names keep their base name")
+    func generatedNameConverted() {
+        #expect(
+            NCCameraRoll.outputFileName(
+                for: "2026-08-04 09-30-00.heic",
+                sourceFileExtension: "heic",
+                nativeFormat: false
+            ) == "2026-08-04 09-30-00.jpg"
+        )
+    }
+}

--- a/iOSClient/Networking/NCAutoUpload.swift
+++ b/iOSClient/Networking/NCAutoUpload.swift
@@ -103,8 +103,12 @@ class NCAutoUpload: NSObject {
         for (index, asset) in assets.enumerated() {
             let fileName = fileNames[index]
 
-            // Convert HEIC if compatibility mode is on
-            let fileNameCompatible = formatCompatibility && (fileName as NSString).pathExtension.lowercased() == "heic" ? (fileName as NSString).deletingPathExtension + ".jpg" : fileName
+            let sourceFileExtension = (fileName as NSString).pathExtension.lowercased()
+            let fileNameCompatible = NCCameraRoll.outputFileName(
+                for: fileName,
+                sourceFileExtension: sourceFileExtension,
+                nativeFormat: !formatCompatibility
+            )
 
             if skipFileNames.contains(fileNameCompatible) || skipFileNames.contains(fileName) {
                 continue
@@ -117,7 +121,7 @@ class NCAutoUpload: NSObject {
             let uploadSession = onWWAN ? self.networking.sessionUploadBackgroundWWan : self.networking.sessionUploadBackground
 
             let metadata = await NCManageDatabaseCreateMetadata().createMetadataAsync(
-                fileName: fileName,
+                fileName: fileNameCompatible,
                 ocId: UUID().uuidString,
                 serverUrl: serverUrl,
                 session: session,

--- a/iOSClient/Utility/NCCameraRoll.swift
+++ b/iOSClient/Utility/NCCameraRoll.swift
@@ -4,7 +4,8 @@
 
 import Foundation
 import Photos
-import UIKit
+import CoreImage
+import ImageIO
 import NextcloudKit
 import AVFoundation
 import UniformTypeIdentifiers
@@ -256,10 +257,12 @@ final class NCCameraRoll: CameraRollExtractor {
         let imageData: Data = try await withCheckedThrowingContinuation { continuation in
             let options = PHImageRequestOptions()
             options.isNetworkAccessAllowed = true
-            options.deliveryMode = convertToJPEG ? .opportunistic : .highQualityFormat
+            options.deliveryMode = .highQualityFormat
             options.isSynchronous = true
             if let sourceType = UTType(filenameExtension: ext), sourceType.conforms(to: .rawImage) {
                 options.version = .original
+            } else {
+                options.version = .current
             }
 
             PHImageManager.default().requestImageDataAndOrientation(for: asset, options: options) { data, _, _, _ in
@@ -274,9 +277,16 @@ final class NCCameraRoll: CameraRollExtractor {
         // Transform only formats that require a compatibility conversion.
         let finalData: Data
         if convertToJPEG {
+            let compressionQuality = CIImageRepresentationOption(
+                rawValue: kCGImageDestinationLossyCompressionQuality as String
+            )
             guard let ciImage = CIImage(data: imageData),
                   let colorSpace = ciImage.colorSpace,
-                  let jpegData = CIContext().jpegRepresentation(of: ciImage, colorSpace: colorSpace)
+                  let jpegData = CIContext().jpegRepresentation(
+                    of: ciImage,
+                    colorSpace: colorSpace,
+                    options: [compressionQuality: 1.0]
+                  )
             else {
                 throw NSError(domain: "ExtractAssetError", code: 3, userInfo: [NSLocalizedDescriptionKey: "JPEG conversion failed"])
             }
@@ -294,6 +304,7 @@ final class NCCameraRoll: CameraRollExtractor {
                 let options = PHVideoRequestOptions()
                 options.isNetworkAccessAllowed = true
                 options.version = .current
+                options.deliveryMode = .highQualityFormat
 
                 PHImageManager.default().requestAVAsset(forVideo: asset, options: options) { asset, _, _ in
                     if let asset = asset {
@@ -309,10 +320,17 @@ final class NCCameraRoll: CameraRollExtractor {
 
         if let urlAsset = videoAsset as? AVURLAsset {
             try FileManager.default.copyItem(at: urlAsset.url, to: URL(fileURLWithPath: filePath))
-        } else if let composition = videoAsset as? AVComposition, composition.tracks.count > 1,
+        } else if let composition = videoAsset as? AVComposition,
                   let exporter = AVAssetExportSession(asset: composition, presetName: AVAssetExportPresetPassthrough) {
+            let fileExtension = (filePath as NSString).pathExtension
+            guard let outputFileType = Self.videoOutputFileType(fileExtension: fileExtension),
+                  exporter.supportedFileTypes.contains(outputFileType)
+            else {
+                throw NSError(domain: "ExtractAssetError", code: 6, userInfo: [NSLocalizedDescriptionKey: "Unsupported video container"])
+            }
+
             exporter.outputURL = URL(fileURLWithPath: filePath)
-            exporter.outputFileType = .mp4
+            exporter.outputFileType = outputFileType
             exporter.shouldOptimizeForNetworkUse = true
             nonisolated(unsafe) let localExporter = exporter
 
@@ -332,6 +350,16 @@ final class NCCameraRoll: CameraRollExtractor {
         }
     }
 
+    static func videoOutputFileType(fileExtension: String) -> AVFileType? {
+        guard let contentType = UTType(filenameExtension: fileExtension),
+              contentType.conforms(to: .movie)
+        else {
+            return nil
+        }
+
+        return AVFileType(rawValue: contentType.identifier)
+    }
+
     /// Represents a camera roll extractor that creates metadata for Live Photos.
     /// This method is compatible with Swift 6, avoids non-Sendable captures,
     /// and performs safe background processing.
@@ -340,7 +368,6 @@ final class NCCameraRoll: CameraRollExtractor {
             return nil
         }
         nonisolated(unsafe) let session = NCSession.shared.getSession(account: metadata.account)
-        let options = PHLivePhotoRequestOptions()
         let ocId = UUID().uuidString
         let fileName = (metadata.fileName as NSString).deletingPathExtension + ".mov"
         let fileNamePath = utilityFileSystem.getDirectoryProviderStorageOcId(ocId, fileName: fileName,
@@ -350,36 +377,17 @@ final class NCCameraRoll: CameraRollExtractor {
             ? NCGlobal.shared.chunkSizeMBEthernetOrWiFi
             : NCGlobal.shared.chunkSizeMBCellular
 
-        options.deliveryMode = .fastFormat
-        options.isNetworkAccessAllowed = true
-
-        // UIScreen.main.bounds safely in Swift 6
-        let screenSize = await MainActor.run {
-            UIScreen.main.bounds.size
-        }
-
-        // Request the live photo from the asset
-        let livePhoto = await withCheckedContinuation { (continuation: CheckedContinuation<PHLivePhoto?, Never>) in
-            PHImageManager.default().requestLivePhoto(
-                for: asset,
-                targetSize: screenSize,
-                contentMode: .default,
-                options: options
-            ) { photo, _ in
-                continuation.resume(returning: photo)
-            }
-        }
-
-        guard let livePhoto else {
-            return nil
-        }
-
-        // Find the paired video component of the Live Photo
-        let videoResource = PHAssetResource.assetResources(for: livePhoto)
-            .first(where: { $0.type == .pairedVideo })
+        // Prefer the full-size rendered component for edited Live Photos, then fall back
+        // to the original paired video when no rendered resource exists.
+        let resources = PHAssetResource.assetResources(for: asset)
+        let videoResource = resources.first(where: { $0.type == .fullSizePairedVideo })
+            ?? resources.first(where: { $0.type == .pairedVideo })
         guard let resource = videoResource else {
             return nil
         }
+
+        let options = PHAssetResourceRequestOptions()
+        options.isNetworkAccessAllowed = true
 
         do {
             try FileManager.default.removeItem(atPath: fileNamePath)
@@ -401,7 +409,7 @@ final class NCCameraRoll: CameraRollExtractor {
 
         // Write video resource to file and create metadata
         return await withCheckedContinuation { (continuation: CheckedContinuation<tableMetadata?, Never>) in
-            PHAssetResourceManager.default().writeData(for: resource, toFile: URL(fileURLWithPath: fileNamePath), options: nil ) { error in
+            PHAssetResourceManager.default().writeData(for: resource, toFile: URL(fileURLWithPath: fileNamePath), options: options) { error in
                 guard error == nil else {
                     continuation.resume(returning: nil)
                     return

--- a/iOSClient/Utility/NCCameraRoll.swift
+++ b/iOSClient/Utility/NCCameraRoll.swift
@@ -7,6 +7,7 @@ import Photos
 import UIKit
 import NextcloudKit
 import AVFoundation
+import UniformTypeIdentifiers
 
 /// Structure representing an extracted asset result
 struct ExtractedAsset {
@@ -167,22 +168,27 @@ final class NCCameraRoll: CameraRollExtractor {
 
         // Determine file extension and prepare filename
         let ext = (asset.originalFilename as NSString).pathExtension.lowercased()
-        let fileName = metadataUpdatedFilename(for: asset, original: metadata.fileNameView, ext: ext, native: metadata.nativeFormat)
+        let convertToJPEG = Self.shouldConvertToJPEG(fileExtension: ext, nativeFormat: metadata.nativeFormat)
+        let fileName = Self.outputFileName(
+            for: metadata.fileNameView,
+            sourceFileExtension: ext,
+            nativeFormat: metadata.nativeFormat
+        )
         let filePath = NSTemporaryDirectory() + fileName
 
         metadata.fileName = fileName
         metadata.fileNameView = fileName
         metadata.serverUrlFileName = utilityFileSystem.createServerUrl(serverUrl: metadata.serverUrl, fileName: metadata.fileName)
 
-        // Safely set the content type if available
-        if let type = contentType(for: asset, ext: ext) {
-            metadata.contentType = type
+        if convertToJPEG {
+            metadata.contentType = UTType.jpeg.preferredMIMEType ?? "image/jpeg"
+            metadata.typeIdentifier = UTType.jpeg.identifier
         }
 
         // Extract file data from asset
         switch asset.mediaType {
         case .image:
-            try await extractImage(asset: asset, ext: ext, filePath: filePath, compatibilityFormat: !metadata.nativeFormat)
+            try await extractImage(asset: asset, ext: ext, filePath: filePath, convertToJPEG: convertToJPEG)
         case .video:
             try await extractVideo( asset: asset, filePath: filePath)
         default:
@@ -206,18 +212,24 @@ final class NCCameraRoll: CameraRollExtractor {
         }
     }
 
-    private func metadataUpdatedFilename(for asset: PHAsset, original: String, ext: String, native: Bool) -> String {
-        if asset.mediaType == .image && (ext == "heic" || ext == "dng") && !native {
-            return (original as NSString).deletingPathExtension + ".jpg"
+    static func shouldConvertToJPEG(fileExtension: String, nativeFormat: Bool) -> Bool {
+        guard !nativeFormat,
+              let sourceType = UTType(filenameExtension: fileExtension)
+        else {
+            return false
         }
-        return original
+
+        return sourceType == .heic ||
+            sourceType == .heif ||
+            sourceType.conforms(to: .rawImage)
     }
 
-    private func contentType(for asset: PHAsset, ext: String) -> String? {
-        if asset.mediaType == .image && (ext == "heic" || ext == "dng") {
-            return "image/jpeg"
+    static func outputFileName(for fileName: String, sourceFileExtension: String, nativeFormat: Bool) -> String {
+        guard shouldConvertToJPEG(fileExtension: sourceFileExtension, nativeFormat: nativeFormat) else {
+            return fileName
         }
-        return nil
+
+        return (fileName as NSString).deletingPathExtension + ".jpg"
     }
 
     private func updateMetadataForUpload(metadata: tableMetadata, size: Int, chunkSize: Int) -> tableMetadata? {
@@ -240,13 +252,15 @@ final class NCCameraRoll: CameraRollExtractor {
         return await self.database.addAndReturnMetadataAsync(metadata)
     }
 
-    private func extractImage(asset: PHAsset, ext: String, filePath: String, compatibilityFormat: Bool) async throws {
+    private func extractImage(asset: PHAsset, ext: String, filePath: String, convertToJPEG: Bool) async throws {
         let imageData: Data = try await withCheckedThrowingContinuation { continuation in
             let options = PHImageRequestOptions()
             options.isNetworkAccessAllowed = true
-            options.deliveryMode = compatibilityFormat ? .opportunistic : .highQualityFormat
+            options.deliveryMode = convertToJPEG ? .opportunistic : .highQualityFormat
             options.isSynchronous = true
-            if ext == "dng" { options.version = .original }
+            if let sourceType = UTType(filenameExtension: ext), sourceType.conforms(to: .rawImage) {
+                options.version = .original
+            }
 
             PHImageManager.default().requestImageDataAndOrientation(for: asset, options: options) { data, _, _, _ in
                 if let data {
@@ -257,9 +271,9 @@ final class NCCameraRoll: CameraRollExtractor {
             }
         }
 
-        // Transform only if compatibilityFormat is requested
+        // Transform only formats that require a compatibility conversion.
         let finalData: Data
-        if compatibilityFormat {
+        if convertToJPEG {
             guard let ciImage = CIImage(data: imageData),
                   let colorSpace = ciImage.colorSpace,
                   let jpegData = CIContext().jpegRepresentation(of: ciImage, colorSpace: colorSpace)


### PR DESCRIPTION
Preserve animated and lossless image formats during auto upload and keep upload metadata filenames in sync.

Add coverage for native and compatibility filename handling.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
