### PR TITLE
fix: preserve media viewer floating title color

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		AABBCC0630A8000100F0A001 /* NCVideoPlaybackPresentationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0530A8000100F0A001 /* NCVideoPlaybackPresentationContext.swift */; };
 		AABBCC0830A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0730A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift */; };
 		AABBCC0A30A8000100F0A001 /* NCMediaViewerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0930A8000100F0A001 /* NCMediaViewerModelTests.swift */; };
+		F0A1B2C430B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C330B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift */; };
 		AABD0C8A2D5F67A400F009E6 /* XCUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD0C892D5F67A200F009E6 /* XCUIElement.swift */; };
 		AAE330042D2ED20200B04903 /* NCShareNavigationTitleSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE330032D2ED1FF00B04903 /* NCShareNavigationTitleSetting.swift */; };
 		AAFC0D042F9AA10000F0A001 /* NCFocusedAutoUploadIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFC0D012F9AA10000F0A001 /* NCFocusedAutoUploadIntroView.swift */; };
@@ -1287,6 +1288,7 @@
 		AABBCC0530A8000100F0A001 /* NCVideoPlaybackPresentationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCVideoPlaybackPresentationContext.swift; sourceTree = "<group>"; };
 		AABBCC0730A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCVideoPlaybackPresentationContextTests.swift; sourceTree = "<group>"; };
 		AABBCC0930A8000100F0A001 /* NCMediaViewerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerModelTests.swift; sourceTree = "<group>"; };
+		F0A1B2C330B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerFloatingTitleViewTests.swift; sourceTree = "<group>"; };
 		AABD0C862D5F58C400F009E6 /* Server.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Server.sh; sourceTree = "<group>"; };
 		AABD0C892D5F67A200F009E6 /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
 		AACCAB522CFE041F00DA1786 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Intent.strings; sourceTree = "<group>"; };
@@ -2188,6 +2190,7 @@
 				AABBCC0330A8000100F0A001 /* NCMediaPlaybackOptionsTests.swift */,
 				AABBCC0730A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift */,
 				AABBCC0930A8000100F0A001 /* NCMediaViewerModelTests.swift */,
+				F0A1B2C330B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift */,
 				F34BDB3B2F574A58007A222C /* BidiSafeFilenameTests.swift */,
 				C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */,
 			);
@@ -4477,6 +4480,7 @@
 				AABBCC0430A8000100F0A001 /* NCMediaPlaybackOptionsTests.swift in Sources */,
 				AABBCC0830A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift in Sources */,
 				AABBCC0A30A8000100F0A001 /* NCMediaViewerModelTests.swift in Sources */,
+				F0A1B2C430B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift in Sources */,
 				F34BDB3C2F574A58007A222C /* BidiSafeFilenameTests.swift in Sources */,
 				C0DECA022F65000100C0D001 /* NCCameraRollTests.swift in Sources */,
 				F372087D2BAB4C0F006B5430 /* TestConstants.swift in Sources */,

--- a/Tests/NextcloudUnitTests/NCMediaViewerFloatingTitleViewTests.swift
+++ b/Tests/NextcloudUnitTests/NCMediaViewerFloatingTitleViewTests.swift
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Testing
+import UIKit
+@testable import Nextcloud
+
+@Suite("Media viewer floating title")
+@MainActor
+struct NCMediaViewerFloatingTitleViewTests {
+    @Test("Preserves the system foreground color")
+    func preservesSystemForegroundColor() throws {
+        let titleView = NCMediaViewerFloatingTitleView()
+
+        titleView.update(
+            primaryText: "Photo.jpg",
+            secondaryText: "13 Aug 2026 at 09:17"
+        )
+
+        let titleButton = try #require(
+            titleView.subviews.first as? UIButton
+        )
+        titleView.frame = CGRect(x: 0, y: 0, width: 300, height: 44)
+        titleView.layoutIfNeeded()
+
+        let configuration = try #require(titleButton.configuration)
+        let transformer = try #require(
+            configuration.titleTextAttributesTransformer
+        )
+        var incoming = AttributeContainer()
+        incoming.uiKit.foregroundColor = .white
+        let outgoing = transformer(incoming)
+
+        #expect(configuration.baseForegroundColor == nil)
+        #expect(titleButton.isEnabled)
+        #expect(titleButton.isUserInteractionEnabled)
+        #expect(titleButton.state == .normal)
+        #expect(titleButton.tintAdjustmentMode == .normal)
+        #expect(
+            titleView.hitTest(
+                CGPoint(x: titleView.bounds.midX, y: titleView.bounds.midY),
+                with: nil
+            ) == nil
+        )
+        #expect(titleButton.titleLabel?.text == "Photo.jpg")
+        #expect(titleButton.subtitleLabel?.text == "13 Aug 2026 at 09:17")
+        #expect(outgoing.uiKit.foregroundColor == .white)
+        #expect(
+            outgoing.uiKit.font == UIFont.systemFont(
+                ofSize: 13,
+                weight: .semibold
+            )
+        )
+
+        let normalTextColor = titleButton.titleLabel?.textColor
+        titleView.tintAdjustmentMode = .dimmed
+        titleView.layoutIfNeeded()
+
+        #expect(titleButton.isEnabled)
+        #expect(titleButton.state == .normal)
+        #expect(titleButton.tintAdjustmentMode == .normal)
+        #expect(titleButton.titleLabel?.text == "Photo.jpg")
+        #expect(titleButton.titleLabel?.textColor == normalTextColor)
+    }
+}

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerFloatingTitleView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerFloatingTitleView.swift
@@ -21,7 +21,8 @@ final class NCMediaViewerFloatingTitleView: UIView {
         }
 
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.isUserInteractionEnabled = false
+        button.isEnabled = true
+        button.tintAdjustmentMode = .normal
         button.adjustsImageSizeForAccessibilityContentSizeCategory = false
 
         return button
@@ -72,6 +73,10 @@ final class NCMediaViewerFloatingTitleView: UIView {
         )
     }
 
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        false
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
 
@@ -118,32 +123,36 @@ final class NCMediaViewerFloatingTitleView: UIView {
         )
     }
 
-    func update(primaryText: String?, secondaryText: String?) {
+    func update(
+        primaryText: String?,
+        secondaryText: String?
+    ) {
         var configuration = titleButton.configuration
-
-        configuration?.attributedTitle = AttributedString(
-            primaryText ?? "",
-            attributes: AttributeContainer([
-                .font: UIFont.systemFont(
+        configuration?.title = primaryText ?? ""
+        configuration?.titleTextAttributesTransformer =
+            UIConfigurationTextAttributesTransformer { incoming in
+                var outgoing = incoming
+                outgoing.font = UIFont.systemFont(
                     ofSize: 13,
                     weight: .semibold
                 )
-            ])
-        )
+                return outgoing
+            }
 
         if let secondaryText,
            !secondaryText.isEmpty {
-            configuration?.attributedSubtitle = AttributedString(
-                secondaryText,
-                attributes: AttributeContainer([
-                    .font: UIFont.systemFont(
+            configuration?.subtitle = secondaryText
+            configuration?.subtitleTextAttributesTransformer =
+                UIConfigurationTextAttributesTransformer { incoming in
+                    var outgoing = incoming
+                    outgoing.font = UIFont.systemFont(
                         ofSize: 11,
                         weight: .regular
                     )
-                ])
-            )
+                    return outgoing
+                }
         } else {
-            configuration?.attributedSubtitle = nil
+            configuration?.subtitle = nil
         }
         titleButton.configuration = configuration
         invalidateIntrinsicContentSize()


### PR DESCRIPTION
Keep the title button enabled while making the containing view ignore touches, preserving the system foreground color and normal tint state.

Add unit coverage for title styling and interaction behavior.



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
