### PR TITLE
fix: preserve image zoom

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		AABBCC0830A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0730A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift */; };
 		AABBCC0A30A8000100F0A001 /* NCMediaViewerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0930A8000100F0A001 /* NCMediaViewerModelTests.swift */; };
 		F0A1B2C430B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C330B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift */; };
+		F0A1B2C630B6000100D4E5F6 /* NCImageZoomViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C530B6000100D4E5F6 /* NCImageZoomViewTests.swift */; };
 		AABD0C8A2D5F67A400F009E6 /* XCUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABD0C892D5F67A200F009E6 /* XCUIElement.swift */; };
 		AAE330042D2ED20200B04903 /* NCShareNavigationTitleSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE330032D2ED1FF00B04903 /* NCShareNavigationTitleSetting.swift */; };
 		AAFC0D042F9AA10000F0A001 /* NCFocusedAutoUploadIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFC0D012F9AA10000F0A001 /* NCFocusedAutoUploadIntroView.swift */; };
@@ -1289,6 +1290,7 @@
 		AABBCC0730A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCVideoPlaybackPresentationContextTests.swift; sourceTree = "<group>"; };
 		AABBCC0930A8000100F0A001 /* NCMediaViewerModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerModelTests.swift; sourceTree = "<group>"; };
 		F0A1B2C330B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerFloatingTitleViewTests.swift; sourceTree = "<group>"; };
+		F0A1B2C530B6000100D4E5F6 /* NCImageZoomViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCImageZoomViewTests.swift; sourceTree = "<group>"; };
 		AABD0C862D5F58C400F009E6 /* Server.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Server.sh; sourceTree = "<group>"; };
 		AABD0C892D5F67A200F009E6 /* XCUIElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElement.swift; sourceTree = "<group>"; };
 		AACCAB522CFE041F00DA1786 /* sl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sl; path = sl.lproj/Intent.strings; sourceTree = "<group>"; };
@@ -2191,6 +2193,7 @@
 				AABBCC0730A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift */,
 				AABBCC0930A8000100F0A001 /* NCMediaViewerModelTests.swift */,
 				F0A1B2C330B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift */,
+				F0A1B2C530B6000100D4E5F6 /* NCImageZoomViewTests.swift */,
 				F34BDB3B2F574A58007A222C /* BidiSafeFilenameTests.swift */,
 				C0DECA012F65000100C0D001 /* NCCameraRollTests.swift */,
 			);
@@ -4481,6 +4484,7 @@
 				AABBCC0830A8000100F0A001 /* NCVideoPlaybackPresentationContextTests.swift in Sources */,
 				AABBCC0A30A8000100F0A001 /* NCMediaViewerModelTests.swift in Sources */,
 				F0A1B2C430B5000100D4E5F6 /* NCMediaViewerFloatingTitleViewTests.swift in Sources */,
+				F0A1B2C630B6000100D4E5F6 /* NCImageZoomViewTests.swift in Sources */,
 				F34BDB3C2F574A58007A222C /* BidiSafeFilenameTests.swift in Sources */,
 				C0DECA022F65000100C0D001 /* NCCameraRollTests.swift in Sources */,
 				F372087D2BAB4C0F006B5430 /* TestConstants.swift in Sources */,

--- a/Tests/NextcloudUnitTests/NCImageZoomViewTests.swift
+++ b/Tests/NextcloudUnitTests/NCImageZoomViewTests.swift
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2026 Marino Faggiana
+// SPDX-License-Identifier: GPL-3.0-or-later
+import Testing
+import UIKit
+@testable import Nextcloud
+
+@Suite("Image zoom view")
+@MainActor
+struct NCImageZoomViewTests {
+    @Test("Replacing an image preserves its zoom scale and focal point")
+    func preservesZoomStateWhenImageChanges() throws {
+        let (coordinator, scrollView, imageView) = makeZoomView(
+            imageSize: CGSize(width: 400, height: 300)
+        )
+
+        scrollView.setZoomScale(3, animated: false)
+        scrollView.contentOffset = CGPoint(x: 220, y: 70)
+
+        let zoomState = try #require(coordinator.zoomState())
+
+        imageView.image = makeImage(
+            size: CGSize(width: 300, height: 400)
+        )
+        coordinator.layoutImageView(preserving: zoomState)
+
+        let restoredZoomState = try #require(coordinator.zoomState())
+
+        #expect(abs(restoredZoomState.zoomScale - zoomState.zoomScale) < 0.001)
+        #expect(abs(restoredZoomState.normalizedCenter.x - zoomState.normalizedCenter.x) < 0.001)
+        #expect(abs(restoredZoomState.normalizedCenter.y - zoomState.normalizedCenter.y) < 0.001)
+    }
+
+    @Test("Relayout without a saved state resets zoom")
+    func resetsZoomWithoutSavedState() {
+        let (coordinator, scrollView, imageView) = makeZoomView(
+            imageSize: CGSize(width: 400, height: 300)
+        )
+
+        scrollView.setZoomScale(3, animated: false)
+        imageView.image = makeImage(
+            size: CGSize(width: 800, height: 600)
+        )
+
+        coordinator.layoutImageViewResettingZoom()
+
+        #expect(scrollView.zoomScale == scrollView.minimumZoomScale)
+        #expect(coordinator.zoomState() == nil)
+    }
+
+    private func makeZoomView(
+        imageSize: CGSize
+    ) -> (
+        NCImageZoomView.Coordinator,
+        NCImageZoomView.NCZoomScrollView,
+        UIImageView
+    ) {
+        let coordinator = NCImageZoomView.Coordinator()
+        let scrollView = NCImageZoomView.NCZoomScrollView(
+            frame: CGRect(x: 0, y: 0, width: 320, height: 480)
+        )
+        let imageView = UIImageView(
+            image: makeImage(size: imageSize)
+        )
+
+        scrollView.minimumZoomScale = 1
+        scrollView.maximumZoomScale = 5
+        scrollView.delegate = coordinator
+        scrollView.addSubview(imageView)
+
+        coordinator.minimumZoomScale = 1
+        coordinator.maximumZoomScale = 5
+        coordinator.scrollView = scrollView
+        coordinator.imageView = imageView
+        coordinator.layoutImageViewResettingZoom()
+
+        return (coordinator, scrollView, imageView)
+    }
+
+    private func makeImage(size: CGSize) -> UIImage {
+        UIGraphicsImageRenderer(size: size).image { context in
+            UIColor.black.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/Tests/NextcloudUnitTests/NCImageZoomViewTests.swift
+++ b/Tests/NextcloudUnitTests/NCImageZoomViewTests.swift
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Nextcloud GmbH
 // SPDX-FileCopyrightText: 2026 Marino Faggiana
 // SPDX-License-Identifier: GPL-3.0-or-later
+
 import Testing
 import UIKit
 @testable import Nextcloud
@@ -48,8 +49,82 @@ struct NCImageZoomViewTests {
         #expect(coordinator.zoomState() == nil)
     }
 
+    @Test("A full orientation round trip preserves zoom and focal point")
+    func preservesZoomStateAfterOrientationRoundTrip() throws {
+        let (coordinator, scrollView, _) = makeZoomView(
+            imageSize: CGSize(width: 400, height: 300)
+        )
+
+        scrollView.setZoomScale(3, animated: false)
+        scrollView.contentOffset = CGPoint(x: 0, y: 70)
+        coordinator.recordCurrentZoomState()
+
+        let zoomState = try #require(coordinator.zoomState())
+
+        for _ in 0..<3 {
+            scrollView.bounds = CGRect(
+                origin: scrollView.bounds.origin,
+                size: CGSize(width: 480, height: 320)
+            )
+            coordinator.layoutImageViewPreservingOnBoundsChange()
+
+            // UIKit can deliver automatic scrolling after a rotation finishes.
+            scrollView.contentOffset = .zero
+            coordinator.scrollViewDidScroll(scrollView)
+
+            scrollView.bounds = CGRect(
+                origin: scrollView.bounds.origin,
+                size: CGSize(width: 320, height: 480)
+            )
+            coordinator.layoutImageViewPreservingOnBoundsChange()
+
+            let restoredZoomState = try #require(coordinator.zoomState())
+            #expect(abs(restoredZoomState.zoomScale - zoomState.zoomScale) < 0.001)
+            #expect(abs(restoredZoomState.normalizedCenter.x - zoomState.normalizedCenter.x) < 0.001)
+            #expect(abs(restoredZoomState.normalizedCenter.y - zoomState.normalizedCenter.y) < 0.001)
+        }
+    }
+
+    @Test("Double-tap zoom survives view recreation and rotation")
+    func preservesDoubleTapZoomAfterViewRecreation() throws {
+        var persistedZoomState: NCImageZoomView.ZoomState?
+        let (firstCoordinator, firstScrollView, firstImageView) = makeZoomView(
+            imageSize: CGSize(width: 400, height: 300),
+            onZoomStateChanged: { persistedZoomState = $0 }
+        )
+
+        firstCoordinator.toggleZoom(
+            at: CGPoint(
+                x: firstImageView.bounds.midX,
+                y: firstImageView.bounds.midY
+            ),
+            animated: false
+        )
+
+        let expectedZoomState = try #require(persistedZoomState)
+        #expect(abs(firstScrollView.zoomScale - expectedZoomState.zoomScale) < 0.001)
+
+        let (restoredCoordinator, restoredScrollView, _) = makeZoomView(
+            imageSize: CGSize(width: 400, height: 300),
+            initialZoomState: expectedZoomState
+        )
+
+        restoredScrollView.bounds = CGRect(
+            origin: restoredScrollView.bounds.origin,
+            size: CGSize(width: 480, height: 320)
+        )
+        restoredCoordinator.layoutImageViewPreservingOnBoundsChange()
+
+        let restoredZoomState = try #require(restoredCoordinator.zoomState())
+        #expect(abs(restoredZoomState.zoomScale - expectedZoomState.zoomScale) < 0.001)
+        #expect(abs(restoredZoomState.normalizedCenter.x - expectedZoomState.normalizedCenter.x) < 0.001)
+        #expect(abs(restoredZoomState.normalizedCenter.y - expectedZoomState.normalizedCenter.y) < 0.001)
+    }
+
     private func makeZoomView(
-        imageSize: CGSize
+        imageSize: CGSize,
+        initialZoomState: NCImageZoomView.ZoomState? = nil,
+        onZoomStateChanged: @escaping (NCImageZoomView.ZoomState?) -> Void = { _ in }
     ) -> (
         NCImageZoomView.Coordinator,
         NCImageZoomView.NCZoomScrollView,
@@ -72,7 +147,9 @@ struct NCImageZoomViewTests {
         coordinator.maximumZoomScale = 5
         coordinator.scrollView = scrollView
         coordinator.imageView = imageView
-        coordinator.layoutImageViewResettingZoom()
+        coordinator.onZoomStateChanged = onZoomStateChanged
+        coordinator.restorePersistedZoomState(initialZoomState)
+        coordinator.layoutImageView(preserving: initialZoomState)
 
         return (coordinator, scrollView, imageView)
     }

--- a/Tests/NextcloudUnitTests/NCMediaViewerFloatingTitleViewTests.swift
+++ b/Tests/NextcloudUnitTests/NCMediaViewerFloatingTitleViewTests.swift
@@ -1,5 +1,6 @@
-// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: Nextcloud GmbH
+// SPDX-FileCopyrightText: 2026 Marino Faggiana
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 import Testing
 import UIKit

--- a/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageViewerContentView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageViewerContentView.swift
@@ -13,7 +13,9 @@ struct NCImageViewerContentView: View {
     let fullURL: URL?
     let backgroundStyle: NCViewerBackgroundStyle
     let allowsImageAnalysis: Bool
+    let initialZoomState: NCImageZoomView.ZoomState?
     let onZoomChanged: (Bool) -> Void
+    let onZoomStateChanged: (NCImageZoomView.ZoomState?) -> Void
 
     @State private var currentImage: UIImage?
     @State private var loadedPreviewURL: URL?
@@ -32,14 +34,18 @@ struct NCImageViewerContentView: View {
         fullURL: URL?,
         backgroundStyle: NCViewerBackgroundStyle = .system,
         allowsImageAnalysis: Bool = true,
-        onZoomChanged: @escaping (Bool) -> Void = { _ in }
+        initialZoomState: NCImageZoomView.ZoomState? = nil,
+        onZoomChanged: @escaping (Bool) -> Void = { _ in },
+        onZoomStateChanged: @escaping (NCImageZoomView.ZoomState?) -> Void = { _ in }
     ) {
         self.identifier = identifier
         self.previewURL = previewURL
         self.fullURL = fullURL
         self.backgroundStyle = backgroundStyle
         self.allowsImageAnalysis = allowsImageAnalysis
+        self.initialZoomState = initialZoomState
         self.onZoomChanged = onZoomChanged
+        self.onZoomStateChanged = onZoomStateChanged
     }
 
     var body: some View {
@@ -52,7 +58,9 @@ struct NCImageViewerContentView: View {
                     image: currentImage,
                     backgroundStyle: backgroundStyle,
                     allowsImageAnalysis: shouldAllowImageAnalysis,
-                    onZoomChanged: onZoomChanged
+                    initialZoomState: initialZoomState,
+                    onZoomChanged: onZoomChanged,
+                    onZoomStateChanged: onZoomStateChanged
                 )
                 .ignoresSafeArea()
             } else if let failedMessage {

--- a/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageZoomView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageZoomView.swift
@@ -109,15 +109,13 @@ struct NCImageZoomView: UIViewRepresentable {
         let imageChanged = context.coordinator.currentImage !== image
 
         if imageChanged {
+            let zoomState = context.coordinator.zoomState()
+
             context.coordinator.currentImage = image
             context.coordinator.resetBoundsTracking()
 
-            scrollView.setZoomScale(minimumZoomScale, animated: false)
-            scrollView.contentOffset = .zero
-            scrollView.contentInset = .zero
-
             imageView.image = image
-            context.coordinator.layoutImageViewResettingZoom()
+            context.coordinator.layoutImageView(preserving: zoomState)
 
             if allowsImageAnalysis {
                 analyzeImageIfAvailable(
@@ -148,6 +146,11 @@ struct NCImageZoomView: UIViewRepresentable {
 
     // MARK: - Coordinator
     final class Coordinator: NSObject, UIScrollViewDelegate {
+        struct ZoomState: Equatable {
+            let zoomScale: CGFloat
+            let normalizedCenter: CGPoint
+        }
+
         weak var scrollView: UIScrollView?
         weak var imageView: UIImageView?
         var currentImage: UIImage?
@@ -159,6 +162,7 @@ struct NCImageZoomView: UIViewRepresentable {
         var onZoomChanged: (Bool) -> Void = { _ in }
 
         private var lastBoundsSize: CGSize = .zero
+        private var isRestoringZoomState = false
 
         // MARK: - UIScrollViewDelegate
         func viewForZooming(in scrollView: UIScrollView) -> UIView? {
@@ -167,6 +171,10 @@ struct NCImageZoomView: UIViewRepresentable {
 
         func scrollViewDidZoom(_ scrollView: UIScrollView) {
             centerImageView()
+
+            guard !isRestoringZoomState else {
+                return
+            }
 
             onZoomChanged(
                 scrollView.zoomScale > scrollView.minimumZoomScale + 0.01
@@ -179,6 +187,37 @@ struct NCImageZoomView: UIViewRepresentable {
         }
 
         func layoutImageViewResettingZoom() {
+            layoutImageView(preserving: nil)
+        }
+
+        func zoomState() -> ZoomState? {
+            guard let scrollView,
+                  let imageView,
+                  scrollView.zoomScale > minimumZoomScale + 0.01,
+                  imageView.bounds.width > 0,
+                  imageView.bounds.height > 0 else {
+                return nil
+            }
+
+            let visibleCenter = CGPoint(
+                x: scrollView.bounds.midX,
+                y: scrollView.bounds.midY
+            )
+            let imageCenter = imageView.convert(
+                visibleCenter,
+                from: scrollView
+            )
+
+            return ZoomState(
+                zoomScale: scrollView.zoomScale,
+                normalizedCenter: CGPoint(
+                    x: min(max(imageCenter.x / imageView.bounds.width, 0), 1),
+                    y: min(max(imageCenter.y / imageView.bounds.height, 0), 1)
+                )
+            )
+        }
+
+        func layoutImageView(preserving zoomState: ZoomState?) {
             guard let scrollView,
                   let imageView,
                   let image = imageView.image else {
@@ -194,8 +233,57 @@ struct NCImageZoomView: UIViewRepresentable {
                 return
             }
 
-            let fittedSize = fittedImageSize(
+            isRestoringZoomState = true
+            defer {
+                isRestoringZoomState = false
+                onZoomChanged(
+                    scrollView.zoomScale > scrollView.minimumZoomScale + 0.01
+                )
+            }
+
+            layoutImageViewAtMinimumZoom(
                 imageSize: image.size,
+                boundsSize: boundsSize
+            )
+
+            guard let zoomState else {
+                return
+            }
+
+            let restoredZoomScale = min(
+                max(zoomState.zoomScale, minimumZoomScale),
+                maximumZoomScale
+            )
+            scrollView.setZoomScale(restoredZoomScale, animated: false)
+            centerImageView()
+
+            let imagePoint = CGPoint(
+                x: imageView.bounds.width * zoomState.normalizedCenter.x,
+                y: imageView.bounds.height * zoomState.normalizedCenter.y
+            )
+            let contentPoint = imageView.convert(imagePoint, to: scrollView)
+            let proposedContentOffset = CGPoint(
+                x: contentPoint.x - boundsSize.width * 0.5,
+                y: contentPoint.y - boundsSize.height * 0.5
+            )
+
+            scrollView.contentOffset = clampedContentOffset(
+                proposedContentOffset,
+                in: scrollView
+            )
+        }
+
+        private func layoutImageViewAtMinimumZoom(
+            imageSize: CGSize,
+            boundsSize: CGSize
+        ) {
+            guard let scrollView,
+                  let imageView else {
+                return
+            }
+
+            let fittedSize = fittedImageSize(
+                imageSize: imageSize,
                 containerSize: boundsSize
             )
 
@@ -236,24 +324,7 @@ struct NCImageZoomView: UIViewRepresentable {
                 return
             }
 
-            let fittedSize = fittedImageSize(
-                imageSize: image.size,
-                containerSize: boundsSize
-            )
-
-            scrollView.setZoomScale(minimumZoomScale, animated: false)
-            scrollView.contentInset = .zero
-            scrollView.contentOffset = .zero
-
-            imageView.frame = CGRect(
-                origin: .zero,
-                size: fittedSize
-            )
-
-            scrollView.contentSize = fittedSize
-            lastBoundsSize = boundsSize
-
-            centerImageView()
+            layoutImageViewResettingZoom()
         }
 
         private func centerImageView() {
@@ -301,6 +372,27 @@ struct NCImageZoomView: UIViewRepresentable {
             return CGSize(
                 width: imageSize.width * ratio,
                 height: imageSize.height * ratio
+            )
+        }
+
+        private func clampedContentOffset(
+            _ proposedContentOffset: CGPoint,
+            in scrollView: UIScrollView
+        ) -> CGPoint {
+            let minimumX = -scrollView.contentInset.left
+            let minimumY = -scrollView.contentInset.top
+            let maximumX = max(
+                minimumX,
+                scrollView.contentSize.width - scrollView.bounds.width + scrollView.contentInset.right
+            )
+            let maximumY = max(
+                minimumY,
+                scrollView.contentSize.height - scrollView.bounds.height + scrollView.contentInset.bottom
+            )
+
+            return CGPoint(
+                x: min(max(proposedContentOffset.x, minimumX), maximumX),
+                y: min(max(proposedContentOffset.y, minimumY), maximumY)
             )
         }
 

--- a/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageZoomView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Image/NCImageZoomView.swift
@@ -8,10 +8,17 @@ import VisionKit
 
 // MARK: - Image Zoom View
 struct NCImageZoomView: UIViewRepresentable {
+    struct ZoomState: Equatable {
+        let zoomScale: CGFloat
+        let normalizedCenter: CGPoint
+    }
+
     let image: UIImage
     let backgroundStyle: NCViewerBackgroundStyle
     let allowsImageAnalysis: Bool
+    let initialZoomState: ZoomState?
     let onZoomChanged: (Bool) -> Void
+    let onZoomStateChanged: (ZoomState?) -> Void
 
     private let minimumZoomScale: CGFloat = 1
     private let maximumZoomScale: CGFloat = 5
@@ -21,12 +28,16 @@ struct NCImageZoomView: UIViewRepresentable {
         image: UIImage,
         backgroundStyle: NCViewerBackgroundStyle = .system,
         allowsImageAnalysis: Bool = true,
-        onZoomChanged: @escaping (Bool) -> Void = { _ in }
+        initialZoomState: ZoomState? = nil,
+        onZoomChanged: @escaping (Bool) -> Void = { _ in },
+        onZoomStateChanged: @escaping (ZoomState?) -> Void = { _ in }
     ) {
         self.image = image
         self.backgroundStyle = backgroundStyle
         self.allowsImageAnalysis = allowsImageAnalysis
+        self.initialZoomState = initialZoomState
         self.onZoomChanged = onZoomChanged
+        self.onZoomStateChanged = onZoomStateChanged
     }
 
     // MARK: - UIViewRepresentable
@@ -64,6 +75,8 @@ struct NCImageZoomView: UIViewRepresentable {
         context.coordinator.maximumZoomScale = maximumZoomScale
         context.coordinator.doubleTapZoomScale = doubleTapZoomScale
         context.coordinator.onZoomChanged = onZoomChanged
+        context.coordinator.onZoomStateChanged = onZoomStateChanged
+        context.coordinator.restorePersistedZoomState(initialZoomState)
 
         if allowsImageAnalysis {
             analyzeImageIfAvailable(
@@ -74,7 +87,7 @@ struct NCImageZoomView: UIViewRepresentable {
         }
 
         scrollView.onLayoutSubviews = { [weak coordinator = context.coordinator] in
-            coordinator?.layoutImageViewResettingOnBoundsChange()
+            coordinator?.layoutImageViewPreservingOnBoundsChange()
         }
 
         let doubleTapGesture = UITapGestureRecognizer(
@@ -100,6 +113,7 @@ struct NCImageZoomView: UIViewRepresentable {
         context.coordinator.maximumZoomScale = maximumZoomScale
         context.coordinator.doubleTapZoomScale = doubleTapZoomScale
         context.coordinator.onZoomChanged = onZoomChanged
+        context.coordinator.onZoomStateChanged = onZoomStateChanged
 
         scrollView.backgroundColor = .ncViewerBackground(backgroundStyle)
         scrollView.minimumZoomScale = minimumZoomScale
@@ -109,7 +123,7 @@ struct NCImageZoomView: UIViewRepresentable {
         let imageChanged = context.coordinator.currentImage !== image
 
         if imageChanged {
-            let zoomState = context.coordinator.zoomState()
+            let zoomState = context.coordinator.zoomStateForRelayout()
 
             context.coordinator.currentImage = image
             context.coordinator.resetBoundsTracking()
@@ -127,7 +141,7 @@ struct NCImageZoomView: UIViewRepresentable {
                 removeImageAnalysisInteractions(from: imageView)
             }
         } else {
-            context.coordinator.layoutImageViewResettingOnBoundsChange()
+            context.coordinator.layoutImageViewPreservingOnBoundsChange()
         }
     }
 
@@ -138,6 +152,7 @@ struct NCImageZoomView: UIViewRepresentable {
     // MARK: - Scroll View
     final class NCZoomScrollView: UIScrollView {
         var onLayoutSubviews: (() -> Void)?
+
         override func layoutSubviews() {
             super.layoutSubviews()
             onLayoutSubviews?()
@@ -146,11 +161,6 @@ struct NCImageZoomView: UIViewRepresentable {
 
     // MARK: - Coordinator
     final class Coordinator: NSObject, UIScrollViewDelegate {
-        struct ZoomState: Equatable {
-            let zoomScale: CGFloat
-            let normalizedCenter: CGPoint
-        }
-
         weak var scrollView: UIScrollView?
         weak var imageView: UIImageView?
         var currentImage: UIImage?
@@ -160,9 +170,11 @@ struct NCImageZoomView: UIViewRepresentable {
         var maximumZoomScale: CGFloat = 5
         var doubleTapZoomScale: CGFloat = 2.5
         var onZoomChanged: (Bool) -> Void = { _ in }
+        var onZoomStateChanged: (ZoomState?) -> Void = { _ in }
 
         private var lastBoundsSize: CGSize = .zero
         private var isRestoringZoomState = false
+        private var lastZoomState: ZoomState?
 
         // MARK: - UIScrollViewDelegate
         func viewForZooming(in scrollView: UIScrollView) -> UIView? {
@@ -176,9 +188,27 @@ struct NCImageZoomView: UIViewRepresentable {
                 return
             }
 
+            if scrollView.pinchGestureRecognizer?.state == .began ||
+                scrollView.pinchGestureRecognizer?.state == .changed {
+                recordCurrentZoomState()
+            }
+
             onZoomChanged(
                 scrollView.zoomScale > scrollView.minimumZoomScale + 0.01
             )
+        }
+
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            let isUserDriven = scrollView.panGestureRecognizer.state == .began ||
+                scrollView.panGestureRecognizer.state == .changed ||
+                scrollView.isDecelerating
+
+            guard !isRestoringZoomState,
+                  isUserDriven else {
+                return
+            }
+
+            recordCurrentZoomState()
         }
 
         // MARK: - Layout
@@ -191,11 +221,13 @@ struct NCImageZoomView: UIViewRepresentable {
         }
 
         func zoomState() -> ZoomState? {
-            guard let scrollView,
-                  let imageView,
-                  scrollView.zoomScale > minimumZoomScale + 0.01,
-                  imageView.bounds.width > 0,
-                  imageView.bounds.height > 0 else {
+            guard let scrollView else {
+                return nil
+            }
+
+            guard scrollView.zoomScale > minimumZoomScale + 0.01,
+                  scrollView.contentSize.width > 0,
+                  scrollView.contentSize.height > 0 else {
                 return nil
             }
 
@@ -203,18 +235,23 @@ struct NCImageZoomView: UIViewRepresentable {
                 x: scrollView.bounds.midX,
                 y: scrollView.bounds.midY
             )
-            let imageCenter = imageView.convert(
-                visibleCenter,
-                from: scrollView
-            )
 
             return ZoomState(
                 zoomScale: scrollView.zoomScale,
                 normalizedCenter: CGPoint(
-                    x: min(max(imageCenter.x / imageView.bounds.width, 0), 1),
-                    y: min(max(imageCenter.y / imageView.bounds.height, 0), 1)
+                    x: min(max(visibleCenter.x / scrollView.contentSize.width, 0), 1),
+                    y: min(max(visibleCenter.y / scrollView.contentSize.height, 0), 1)
                 )
             )
+        }
+
+        func zoomStateForRelayout() -> ZoomState? {
+            guard let scrollView,
+                  scrollView.bounds.size != lastBoundsSize else {
+                return zoomState()
+            }
+
+            return lastZoomState
         }
 
         func layoutImageView(preserving zoomState: ZoomState?) {
@@ -236,6 +273,7 @@ struct NCImageZoomView: UIViewRepresentable {
             isRestoringZoomState = true
             defer {
                 isRestoringZoomState = false
+                updatePersistedZoomState(zoomState ?? self.zoomState())
                 onZoomChanged(
                     scrollView.zoomScale > scrollView.minimumZoomScale + 0.01
                 )
@@ -257,11 +295,10 @@ struct NCImageZoomView: UIViewRepresentable {
             scrollView.setZoomScale(restoredZoomScale, animated: false)
             centerImageView()
 
-            let imagePoint = CGPoint(
-                x: imageView.bounds.width * zoomState.normalizedCenter.x,
-                y: imageView.bounds.height * zoomState.normalizedCenter.y
+            let contentPoint = CGPoint(
+                x: scrollView.contentSize.width * zoomState.normalizedCenter.x,
+                y: scrollView.contentSize.height * zoomState.normalizedCenter.y
             )
-            let contentPoint = imageView.convert(imagePoint, to: scrollView)
             let proposedContentOffset = CGPoint(
                 x: contentPoint.x - boundsSize.width * 0.5,
                 y: contentPoint.y - boundsSize.height * 0.5
@@ -302,8 +339,7 @@ struct NCImageZoomView: UIViewRepresentable {
             centerImageView()
         }
 
-        // Reset zoom on size changes to avoid stale offsets.
-        func layoutImageViewResettingOnBoundsChange() {
+        func layoutImageViewPreservingOnBoundsChange() {
             guard let scrollView,
                   let imageView,
                   let image = imageView.image else {
@@ -324,7 +360,28 @@ struct NCImageZoomView: UIViewRepresentable {
                 return
             }
 
-            layoutImageViewResettingZoom()
+            layoutImageView(preserving: lastZoomState)
+        }
+
+        func recordCurrentZoomState() {
+            guard let scrollView else {
+                return
+            }
+
+            guard scrollView.bounds.size == lastBoundsSize else {
+                return
+            }
+
+            updatePersistedZoomState(zoomState())
+        }
+
+        func restorePersistedZoomState(_ zoomState: ZoomState?) {
+            lastZoomState = zoomState
+        }
+
+        private func updatePersistedZoomState(_ zoomState: ZoomState?) {
+            lastZoomState = zoomState
+            onZoomStateChanged(zoomState)
         }
 
         private func centerImageView() {
@@ -399,17 +456,30 @@ struct NCImageZoomView: UIViewRepresentable {
         // MARK: - Gestures
         @objc
         func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
+            guard let imageView else {
+                return
+            }
+
+            toggleZoom(
+                at: gesture.location(in: imageView),
+                animated: true
+            )
+        }
+
+        func toggleZoom(at point: CGPoint, animated: Bool) {
             guard let scrollView,
-                  let imageView else {
+                  let imageView,
+                  imageView.bounds.width > 0,
+                  imageView.bounds.height > 0 else {
                 return
             }
 
             if scrollView.zoomScale > minimumZoomScale + 0.01 {
-                scrollView.setZoomScale(minimumZoomScale, animated: true)
+                updatePersistedZoomState(nil)
+                scrollView.setZoomScale(minimumZoomScale, animated: animated)
                 return
             }
 
-            let point = gesture.location(in: imageView)
             let targetScale = min(doubleTapZoomScale, maximumZoomScale)
 
             let zoomSize = CGSize(
@@ -424,7 +494,14 @@ struct NCImageZoomView: UIViewRepresentable {
                 height: zoomSize.height
             )
 
-            scrollView.zoom(to: zoomRect, animated: true)
+            updatePersistedZoomState(ZoomState(
+                zoomScale: targetScale,
+                normalizedCenter: CGPoint(
+                    x: min(max(point.x / imageView.bounds.width, 0), 1),
+                    y: min(max(point.y / imageView.bounds.height, 0), 1)
+                )
+            ))
+            scrollView.zoom(to: zoomRect, animated: animated)
         }
     }
 

--- a/iOSClient/Viewer/NCViewerMedia/Content/Image/NCLivePhotoViewerContentView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Image/NCLivePhotoViewerContentView.swift
@@ -17,7 +17,9 @@ struct NCLivePhotoViewerContentView: View {
     let videoURL: URL?
     let backgroundStyle: NCViewerBackgroundStyle
     let topOverlayInset: CGFloat
+    let initialZoomState: NCImageZoomView.ZoomState?
     let onZoomChanged: (Bool) -> Void
+    let onZoomStateChanged: (NCImageZoomView.ZoomState?) -> Void
 
     @State private var livePhoto: PHLivePhoto?
     @State private var isPlayingLivePhoto = false
@@ -30,7 +32,9 @@ struct NCLivePhotoViewerContentView: View {
         videoURL: URL?,
         backgroundStyle: NCViewerBackgroundStyle = .system,
         topOverlayInset: CGFloat = 0,
-        onZoomChanged: @escaping (Bool) -> Void = { _ in }
+        initialZoomState: NCImageZoomView.ZoomState? = nil,
+        onZoomChanged: @escaping (Bool) -> Void = { _ in },
+        onZoomStateChanged: @escaping (NCImageZoomView.ZoomState?) -> Void = { _ in }
     ) {
         self.identifier = identifier
         self.previewURL = previewURL
@@ -38,7 +42,9 @@ struct NCLivePhotoViewerContentView: View {
         self.videoURL = videoURL
         self.backgroundStyle = backgroundStyle
         self.topOverlayInset = topOverlayInset
+        self.initialZoomState = initialZoomState
         self.onZoomChanged = onZoomChanged
+        self.onZoomStateChanged = onZoomStateChanged
     }
 
     var body: some View {
@@ -99,7 +105,9 @@ struct NCLivePhotoViewerContentView: View {
             fullURL: fullURL,
             backgroundStyle: backgroundStyle,
             allowsImageAnalysis: false,
-            onZoomChanged: onZoomChanged
+            initialZoomState: initialZoomState,
+            onZoomChanged: onZoomChanged,
+            onZoomStateChanged: onZoomStateChanged
         )
     }
 

--- a/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerModel.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerModel.swift
@@ -31,6 +31,7 @@ final class NCMediaViewerPageModel: ObservableObject, Identifiable {
 
     @Published var metadata: tableMetadata?
     @Published var state: NCMediaViewerPageState
+    var imageZoomState: NCImageZoomView.ZoomState?
 
     init(
         index: Int,

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
@@ -424,7 +424,9 @@ struct NCMediaViewerPageView: View {
                 videoURL: livePhotoURL,
                 backgroundStyle: backgroundStyle,
                 topOverlayInset: livePhotoTopOverlayInset,
-                onZoomChanged: onZoomChanged
+                initialZoomState: page.imageZoomState,
+                onZoomChanged: onZoomChanged,
+                onZoomStateChanged: { page.imageZoomState = $0 }
             )
             .background(Color.ncViewerBackground(backgroundStyle))
             .contentShape(Rectangle())
@@ -435,7 +437,9 @@ struct NCMediaViewerPageView: View {
                 previewURL: previewURL,
                 fullURL: localURL,
                 backgroundStyle: backgroundStyle,
-                onZoomChanged: onZoomChanged
+                initialZoomState: page.imageZoomState,
+                onZoomChanged: onZoomChanged,
+                onZoomStateChanged: { page.imageZoomState = $0 }
             )
             .contentShape(Rectangle())
             .gesture(chromeToggleGesture())
@@ -449,7 +453,9 @@ struct NCMediaViewerPageView: View {
             previewURL: previewURL,
             fullURL: nil,
             backgroundStyle: backgroundStyle,
-            onZoomChanged: onZoomChanged
+            initialZoomState: page.imageZoomState,
+            onZoomChanged: onZoomChanged,
+            onZoomStateChanged: { page.imageZoomState = $0 }
         )
         .contentShape(Rectangle())
         .gesture(chromeToggleGesture())


### PR DESCRIPTION
## Summary

Preserve the media viewer’s image zoom state when:

- the downloaded high-resolution image replaces its preview;
- the device orientation changes;
- the image view is recreated during rotation.

The zoom scale and focal point are stored per media page and updated only by user interactions, preventing automatic `UIScrollView` layout events from overwriting them.

## Testing

Added unit tests covering:

- preview-to-high-resolution image replacement;
- explicit zoom reset;
- repeated portrait–landscape round trips;
- double-tap zoom followed by view recreation and rotation.

Closes #4251

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
