### PR TITLE
feat: load media viewer originals on demand

### DIFF
--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -850,6 +850,7 @@
 		F7CDB5C32FA33CA300F72306 /* NCMediaViewerPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5B92FA33CA300F72306 /* NCMediaViewerPageView.swift */; };
 		F7CDB5C42FA33CA300F72306 /* NCImageViewerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5B62FA33CA300F72306 /* NCImageViewerContentView.swift */; };
 		F7CDB5C52FA33CA300F72306 /* NCMediaViewerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5B82FA33CA300F72306 /* NCMediaViewerModel.swift */; };
+		A1B2C3D430B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D330B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift */; };
 		F7CDB5C62FA33CA300F72306 /* NCMediaViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5BB2FA33CA300F72306 /* NCMediaViewerView.swift */; };
 		F7CDB5CC2FA33CA300F72306 /* NCNextcloudMediaViewerLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5BD2FA33CA300F72306 /* NCNextcloudMediaViewerLoader.swift */; };
 		F7CDB5D32FA3448B00F72306 /* NCAudioViewerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5D22FA3448A00F72306 /* NCAudioViewerContentView.swift */; };
@@ -1872,6 +1873,7 @@
 		F7CCAB502ECF315F00F8E68B /* NCCollectionViewCommon+SyncMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCCollectionViewCommon+SyncMetadata.swift"; sourceTree = "<group>"; };
 		F7CDB5B62FA33CA300F72306 /* NCImageViewerContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCImageViewerContentView.swift; sourceTree = "<group>"; };
 		F7CDB5B82FA33CA300F72306 /* NCMediaViewerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerModel.swift; sourceTree = "<group>"; };
+		A1B2C3D330B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerLoadingPolicy.swift; sourceTree = "<group>"; };
 		F7CDB5B92FA33CA300F72306 /* NCMediaViewerPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerPageView.swift; sourceTree = "<group>"; };
 		F7CDB5BB2FA33CA300F72306 /* NCMediaViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerView.swift; sourceTree = "<group>"; };
 		F7CDB5BD2FA33CA300F72306 /* NCNextcloudMediaViewerLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCNextcloudMediaViewerLoader.swift; sourceTree = "<group>"; };
@@ -2607,6 +2609,7 @@
 			isa = PBXGroup;
 			children = (
 				AABBCC0130A8000100F0A001 /* NCMediaPlaybackOptions.swift */,
+				A1B2C3D330B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift */,
 				AABBCC0530A8000100F0A001 /* NCVideoPlaybackPresentationContext.swift */,
 				F7CDB5BB2FA33CA300F72306 /* NCMediaViewerView.swift */,
 				F7CDB5B82FA33CA300F72306 /* NCMediaViewerModel.swift */,
@@ -4904,6 +4907,7 @@
 				F7CDB5C32FA33CA300F72306 /* NCMediaViewerPageView.swift in Sources */,
 				F7CDB5C42FA33CA300F72306 /* NCImageViewerContentView.swift in Sources */,
 				F7CDB5C52FA33CA300F72306 /* NCMediaViewerModel.swift in Sources */,
+				A1B2C3D430B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift in Sources */,
 				AABBCC0230A8000100F0A001 /* NCMediaPlaybackOptions.swift in Sources */,
 				AABBCC0630A8000100F0A001 /* NCVideoPlaybackPresentationContext.swift in Sources */,
 				F7CDB5C62FA33CA300F72306 /* NCMediaViewerView.swift in Sources */,

--- a/Tests/NextcloudUnitTests/NCMediaViewerModelTests.swift
+++ b/Tests/NextcloudUnitTests/NCMediaViewerModelTests.swift
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import Testing
+import NextcloudKit
 @testable import Nextcloud
 
 @Suite("Media viewer model")
@@ -115,6 +116,77 @@ struct NCMediaViewerModelTests {
         #expect(model.activePageIndex == 0)
     }
 
+    @Test("Regular image previews do not require the original file")
+    func regularImagePreviewDoesNotRequireOriginal() {
+        let metadata = imageMetadata(fileName: "photo.HEIC")
+        let policy = NCMediaViewerLoadingPolicy.standard
+
+        #expect(!policy.shouldDownloadOriginalImage(
+            for: metadata,
+            hasUsablePreview: true
+        ))
+    }
+
+    @Test("GIF and SVG images always require the original file")
+    func specialImageFormatsRequireOriginal() {
+        let policy = NCMediaViewerLoadingPolicy.standard
+
+        #expect(policy.shouldDownloadOriginalImage(
+            for: imageMetadata(fileName: "animation.GIF"),
+            hasUsablePreview: true
+        ))
+        #expect(policy.shouldDownloadOriginalImage(
+            for: imageMetadata(fileName: "drawing.svg"),
+            hasUsablePreview: true
+        ))
+    }
+
+    @Test("A missing preview falls back to the original file")
+    func missingPreviewRequiresOriginal() {
+        let metadata = imageMetadata(fileName: "photo.jpg")
+        let policy = NCMediaViewerLoadingPolicy.standard
+
+        #expect(policy.shouldDownloadOriginalImage(
+            for: metadata,
+            hasUsablePreview: false
+        ))
+    }
+
+    @Test("The internal switch restores automatic original downloads")
+    func internalSwitchEnablesOriginalDownloads() {
+        let metadata = imageMetadata(fileName: "photo.jpg")
+        let policy = NCMediaViewerLoadingPolicy(
+            automaticallyDownloadsOriginalImages: true,
+            automaticallyDownloadsLivePhotoResources: false
+        )
+
+        #expect(policy.shouldDownloadOriginalImage(
+            for: metadata,
+            hasUsablePreview: true
+        ))
+    }
+
+    @Test("Live Photo resources remain on demand unless their switch is enabled")
+    func livePhotoResourcesRespectInternalSwitch() {
+        let metadata = imageMetadata(fileName: "live-photo.heic")
+        metadata.livePhotoFile = "live-photo.mov"
+
+        #expect(!NCMediaViewerLoadingPolicy.standard.shouldDownloadLivePhotoResources(
+            for: metadata
+        ))
+
+        let automaticPolicy = NCMediaViewerLoadingPolicy(
+            automaticallyDownloadsOriginalImages: false,
+            automaticallyDownloadsLivePhotoResources: true
+        )
+
+        #expect(automaticPolicy.shouldDownloadLivePhotoResources(for: metadata))
+        #expect(automaticPolicy.shouldDownloadOriginalImage(
+            for: metadata,
+            hasUsablePreview: true
+        ))
+    }
+
     private func makeViewerModel() -> NCMediaViewerModel {
         let metadata = tableMetadata()
         metadata.ocId = "first"
@@ -125,5 +197,13 @@ struct NCMediaViewerModelTests {
             session: NCSession().getSession(account: ""),
             loader: NCMediaViewerLoader()
         )
+    }
+
+    private func imageMetadata(fileName: String) -> tableMetadata {
+        let metadata = tableMetadata()
+        metadata.classFile = NKTypeClassFile.image.rawValue
+        metadata.fileName = fileName
+        metadata.fileNameView = fileName
+        return metadata
     }
 }

--- a/iOSClient/Viewer/NCViewerMedia/Content/Image/NCLivePhotoViewerContentView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Content/Image/NCLivePhotoViewerContentView.swift
@@ -20,9 +20,14 @@ struct NCLivePhotoViewerContentView: View {
     let initialZoomState: NCImageZoomView.ZoomState?
     let onZoomChanged: (Bool) -> Void
     let onZoomStateChanged: (NCImageZoomView.ZoomState?) -> Void
+    let requestResources: @MainActor () async -> (imageURL: URL, videoURL: URL)?
+    let cancelResourceDownload: @MainActor () -> Void
 
     @State private var livePhoto: PHLivePhoto?
     @State private var isPlayingLivePhoto = false
+    @State private var isPlaybackRequested = false
+    @State private var isLoadingResources = false
+    @State private var resourceLoadingTask: Task<Void, Never>?
     @State private var loadedTaskIdentifier: String?
     @State private var zoomState: NCImageZoomView.ZoomState?
 
@@ -35,7 +40,9 @@ struct NCLivePhotoViewerContentView: View {
         topOverlayInset: CGFloat = 0,
         initialZoomState: NCImageZoomView.ZoomState? = nil,
         onZoomChanged: @escaping (Bool) -> Void = { _ in },
-        onZoomStateChanged: @escaping (NCImageZoomView.ZoomState?) -> Void = { _ in }
+        onZoomStateChanged: @escaping (NCImageZoomView.ZoomState?) -> Void = { _ in },
+        requestResources: @escaping @MainActor () async -> (imageURL: URL, videoURL: URL)? = { nil },
+        cancelResourceDownload: @escaping @MainActor () -> Void = { }
     ) {
         self.identifier = identifier
         self.previewURL = previewURL
@@ -46,6 +53,8 @@ struct NCLivePhotoViewerContentView: View {
         self.initialZoomState = initialZoomState
         self.onZoomChanged = onZoomChanged
         self.onZoomStateChanged = onZoomStateChanged
+        self.requestResources = requestResources
+        self.cancelResourceDownload = cancelResourceDownload
         self._zoomState = State(initialValue: initialZoomState)
     }
 
@@ -92,11 +101,7 @@ struct NCLivePhotoViewerContentView: View {
         .highPriorityGesture(
             LongPressGesture(minimumDuration: 0.25)
                 .onEnded { _ in
-                    guard livePhoto != nil else {
-                        return
-                    }
-
-                    isPlayingLivePhoto = true
+                    requestLivePhotoPlayback()
                 }
         )
         // Stop Live Photo playback when the media viewer requests a global playback stop.
@@ -104,13 +109,15 @@ struct NCLivePhotoViewerContentView: View {
             stopLivePhotoPlayback()
         }
         .onChange(of: identifier) { _, _ in
+            cancelResourceLoadingIfNeeded()
             stopLivePhotoPlayback()
             zoomState = initialZoomState
         }
         .onChange(of: taskIdentifier) { _, _ in
-            stopLivePhotoPlayback()
+            isPlayingLivePhoto = false
         }
         .onDisappear {
+            cancelResourceLoadingIfNeeded()
             stopLivePhotoPlayback()
         }
     }
@@ -185,9 +192,15 @@ struct NCLivePhotoViewerContentView: View {
             VStack {
                 HStack {
                     HStack(spacing: 5) {
-                        Image(systemName: "livephoto")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(livePhotoBadgeForeground)
+                        if isLoadingResources {
+                            ProgressView()
+                                .controlSize(.small)
+                                .tint(livePhotoBadgeForeground)
+                        } else {
+                            Image(systemName: "livephoto")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(livePhotoBadgeForeground)
+                        }
 
                         Text("LIVE")
                             .font(.system(size: 13, weight: .semibold))
@@ -217,7 +230,10 @@ struct NCLivePhotoViewerContentView: View {
     // MARK: - Identifiers
 
     private var taskIdentifier: String {
-        "\(identifier)|\(fullURL?.absoluteString ?? "")|\(videoURL?.absoluteString ?? "")"
+        resourceIdentifier(
+            imageURL: fullURL,
+            videoURL: videoURL
+        )
     }
 
     private var playbackViewIdentifier: String {
@@ -229,6 +245,10 @@ struct NCLivePhotoViewerContentView: View {
     // Keep the still image visible when Live Photo resources are missing.
     @MainActor
     private func loadLivePhotoIfNeeded() async {
+        guard !isLoadingResources else {
+            return
+        }
+
         if loadedTaskIdentifier != taskIdentifier {
             livePhoto = nil
             isPlayingLivePhoto = false
@@ -244,13 +264,93 @@ struct NCLivePhotoViewerContentView: View {
             return
         }
 
-        guard FileManager.default.fileExists(atPath: fullURL.path),
+        isLoadingResources = true
+        defer {
+            isLoadingResources = false
+        }
+
+        await loadLivePhoto(
+            imageURL: fullURL,
+            videoURL: videoURL
+        )
+    }
+
+    @MainActor
+    private func requestLivePhotoPlayback() {
+        isPlaybackRequested = true
+
+        if livePhoto != nil {
+            isPlaybackRequested = false
+            isPlayingLivePhoto = true
+            return
+        }
+
+        guard !isLoadingResources else {
+            return
+        }
+
+        isLoadingResources = true
+
+        resourceLoadingTask = Task { @MainActor in
+            defer {
+                isLoadingResources = false
+                resourceLoadingTask = nil
+            }
+
+            let resourceURLs: (imageURL: URL, videoURL: URL)?
+
+            if let fullURL,
+               let videoURL {
+                resourceURLs = (fullURL, videoURL)
+            } else {
+                resourceURLs = await requestResources()
+            }
+
+            guard !Task.isCancelled,
+                  let resourceURLs else {
+                isPlaybackRequested = false
+                return
+            }
+
+            await loadLivePhoto(
+                imageURL: resourceURLs.imageURL,
+                videoURL: resourceURLs.videoURL
+            )
+        }
+    }
+
+    @MainActor
+    private func loadLivePhoto(
+        imageURL: URL,
+        videoURL: URL
+    ) async {
+        let expectedIdentifier = resourceIdentifier(
+            imageURL: imageURL,
+            videoURL: videoURL
+        )
+
+        if loadedTaskIdentifier != expectedIdentifier {
+            livePhoto = nil
+            isPlayingLivePhoto = false
+            loadedTaskIdentifier = expectedIdentifier
+        }
+
+        guard livePhoto == nil else {
+            if isPlaybackRequested {
+                isPlaybackRequested = false
+                isPlayingLivePhoto = true
+            }
+            return
+        }
+
+        guard FileManager.default.fileExists(atPath: imageURL.path),
               FileManager.default.fileExists(atPath: videoURL.path) else {
+            isPlaybackRequested = false
             return
         }
 
         let resourceURLs = [
-            fullURL,
+            imageURL,
             videoURL
         ]
 
@@ -260,19 +360,46 @@ struct NCLivePhotoViewerContentView: View {
             return
         }
 
-        guard loadedTaskIdentifier == taskIdentifier else {
+        guard loadedTaskIdentifier == expectedIdentifier else {
             return
         }
 
         guard let loadedLivePhoto else {
+            isPlaybackRequested = false
             return
         }
 
         livePhoto = loadedLivePhoto
+
+        if isPlaybackRequested {
+            isPlaybackRequested = false
+            isPlayingLivePhoto = true
+        }
+    }
+
+    private func resourceIdentifier(
+        imageURL: URL?,
+        videoURL: URL?
+    ) -> String {
+        "\(identifier)|\(imageURL?.absoluteString ?? "")|\(videoURL?.absoluteString ?? "")"
+    }
+
+    @MainActor
+    private func cancelResourceLoadingIfNeeded() {
+        guard let resourceLoadingTask else {
+            return
+        }
+
+        resourceLoadingTask.cancel()
+        self.resourceLoadingTask = nil
+        isLoadingResources = false
+        isPlaybackRequested = false
+        cancelResourceDownload()
     }
 
     @MainActor
     private func stopLivePhotoPlayback() {
+        isPlaybackRequested = false
         isPlayingLivePhoto = false
     }
 

--- a/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerLoadingPolicy.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerLoadingPolicy.swift
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import Foundation
+
+struct NCMediaViewerLoadingPolicy: Sendable {
+    static let standard = NCMediaViewerLoadingPolicy(
+        automaticallyDownloadsOriginalImages: false,
+        automaticallyDownloadsLivePhotoResources: false
+    )
+
+    let automaticallyDownloadsOriginalImages: Bool
+    let automaticallyDownloadsLivePhotoResources: Bool
+
+    func shouldDownloadOriginalImage(
+        for metadata: tableMetadata,
+        hasUsablePreview: Bool
+    ) -> Bool {
+        if Self.originalRequiredExtensions.contains(metadata.fileExtension.lowercased()) {
+            return true
+        }
+
+        if !hasUsablePreview {
+            return true
+        }
+
+        if metadata.isLivePhoto,
+           automaticallyDownloadsLivePhotoResources {
+            return true
+        }
+
+        return automaticallyDownloadsOriginalImages
+    }
+
+    func shouldDownloadLivePhotoResources(for metadata: tableMetadata) -> Bool {
+        metadata.isLivePhoto && automaticallyDownloadsLivePhotoResources
+    }
+
+    private static let originalRequiredExtensions: Set<String> = [
+        "gif",
+        "svg"
+    ]
+}

--- a/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerModel.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerModel.swift
@@ -544,12 +544,23 @@ final class NCMediaViewerModel: ObservableObject {
     }
 
     func downloadVideoForPlayback(_ metadata: tableMetadata) async throws -> URL {
-        try await loader.downloadMedia(for: metadata)
+        try await loader.downloadMedia(
+            for: metadata,
+            onDownloadStarted: nil
+        )
     }
 
     @discardableResult
-    func downloadOriginalImage(for metadata: tableMetadata) async throws -> URL {
-        let localURL = try await loader.downloadMedia(for: metadata)
+    func downloadOriginalImage(
+        for metadata: tableMetadata,
+        onDownloadStarted: (@MainActor @Sendable () -> Void)? = nil
+    ) async throws -> URL {
+        let localURL = try await loader.downloadMedia(
+            for: metadata,
+            onDownloadStarted: {
+                await onDownloadStarted?()
+            }
+        )
 
         guard !Task.isCancelled else {
             throw CancellationError()
@@ -934,7 +945,8 @@ final class NCMediaViewerModel: ObservableObject {
 
         do {
             let downloadedURL = try await loader.downloadMedia(
-                for: metadata
+                for: metadata,
+                onDownloadStarted: nil
             )
 
             guard !Task.isCancelled else {

--- a/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerModel.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Core/NCMediaViewerModel.swift
@@ -133,6 +133,7 @@ final class NCMediaViewerModel: ObservableObject {
     // MARK: - Dependencies
 
     private let loader: NCMediaViewerLoading
+    private let loadingPolicy: NCMediaViewerLoadingPolicy
     private let utilityFileSystem = NCUtilityFileSystem()
 
     // MARK: - Source Context
@@ -294,9 +295,11 @@ final class NCMediaViewerModel: ObservableObject {
     init(
         initialModel: NCMediaViewerInitialModel,
         session: NCSession.Session,
-        loader: NCMediaViewerLoading
+        loader: NCMediaViewerLoading,
+        loadingPolicy: NCMediaViewerLoadingPolicy = .standard
     ) {
         self.loader = loader
+        self.loadingPolicy = loadingPolicy
         self.session = session
         self.ocIds = initialModel.normalizedOcIds
         self.selectedIndex = initialModel.currentSelectedIndex
@@ -315,7 +318,8 @@ final class NCMediaViewerModel: ObservableObject {
         currentMetadata: tableMetadata,
         ocIds: [String],
         session: NCSession.Session,
-        loader: NCMediaViewerLoading
+        loader: NCMediaViewerLoading,
+        loadingPolicy: NCMediaViewerLoadingPolicy = .standard
     ) {
         let initialModel = NCMediaViewerInitialModel(
             currentMetadata: currentMetadata,
@@ -325,7 +329,8 @@ final class NCMediaViewerModel: ObservableObject {
         self.init(
             initialModel: initialModel,
             session: session,
-            loader: loader
+            loader: loader,
+            loadingPolicy: loadingPolicy
         )
     }
 
@@ -365,7 +370,7 @@ final class NCMediaViewerModel: ObservableObject {
         }
 
         if let ocId = ocId(at: index),
-           !pageState(for: ocId).needsSelectedPageLoading {
+           !pageNeedsSelectedPageLoading(for: ocId) {
             return
         }
 
@@ -459,7 +464,7 @@ final class NCMediaViewerModel: ObservableObject {
 
         let ocId = ocIds[index]
 
-        guard pageState(for: ocId).needsSelectedPageLoading else {
+        guard pageNeedsSelectedPageLoading(for: ocId) else {
             return
         }
 
@@ -540,6 +545,74 @@ final class NCMediaViewerModel: ObservableObject {
 
     func downloadVideoForPlayback(_ metadata: tableMetadata) async throws -> URL {
         try await loader.downloadMedia(for: metadata)
+    }
+
+    @discardableResult
+    func downloadOriginalImage(for metadata: tableMetadata) async throws -> URL {
+        let localURL = try await loader.downloadMedia(for: metadata)
+
+        guard !Task.isCancelled else {
+            throw CancellationError()
+        }
+
+        let livePhotoURL: URL?
+
+        if metadata.isLivePhoto {
+            livePhotoURL = await loader.localLivePhotoURL(for: metadata)
+        } else {
+            livePhotoURL = nil
+        }
+
+        setState(
+            .image(
+                previewURL: currentPreviewURL(for: metadata.ocId),
+                localURL: localURL,
+                livePhotoURL: livePhotoURL,
+                progress: nil
+            ),
+            for: metadata.ocId
+        )
+
+        return localURL
+    }
+
+    func downloadLivePhotoResources(
+        for metadata: tableMetadata
+    ) async -> (imageURL: URL, videoURL: URL)? {
+        guard metadata.isLivePhoto else {
+            return nil
+        }
+
+        do {
+            let imageURL = try await downloadOriginalImage(for: metadata)
+
+            guard !Task.isCancelled,
+                  let videoURL = await loader.downloadLivePhotoMedia(for: metadata),
+                  !Task.isCancelled else {
+                return nil
+            }
+
+            setState(
+                .image(
+                    previewURL: currentPreviewURL(for: metadata.ocId),
+                    localURL: imageURL,
+                    livePhotoURL: videoURL,
+                    progress: nil
+                ),
+                for: metadata.ocId
+            )
+
+            return (imageURL, videoURL)
+        } catch {
+            return nil
+        }
+    }
+
+    func cancelLivePhotoResourceDownload(for metadata: tableMetadata) {
+        Task {
+            await loader.cancelDownload(for: metadata.ocId)
+            await loader.cancelLivePhotoMediaDownload(for: metadata)
+        }
     }
 
     func cancelVideoDownload(for ocId: String) async {
@@ -839,6 +912,13 @@ final class NCMediaViewerModel: ObservableObject {
                 )
             }
 
+            guard loadingPolicy.shouldDownloadOriginalImage(
+                for: metadata,
+                hasUsablePreview: previewURL != nil
+            ) else {
+                return
+            }
+
         case NKTypeClassFile.audio.rawValue:
             setState(
                 .downloading(
@@ -1092,6 +1172,40 @@ final class NCMediaViewerModel: ObservableObject {
         cachedPagesByOcId[ocId]?.state ?? .idle
     }
 
+    private func pageNeedsSelectedPageLoading(for ocId: String) -> Bool {
+        let state = pageState(for: ocId)
+
+        switch state {
+        case .idle,
+             .downloading:
+            return true
+
+        case .image(let previewURL, nil, _, _):
+            guard let metadata = cachedPagesByOcId[ocId]?.metadata else {
+                return true
+            }
+
+            return loadingPolicy.shouldDownloadOriginalImage(
+                for: metadata,
+                hasUsablePreview: previewURL != nil
+            )
+
+        case .video(nil, nil):
+            return true
+
+        case .image(_, .some, _, _),
+             .audio,
+             .video,
+             .loadingMetadata,
+             .metadataMissing,
+             .checkingLocalFile,
+             .ready,
+             .deleted,
+             .failed:
+            return false
+        }
+    }
+
     private func currentPreviewURL(for ocId: String) -> URL? {
         guard let page = cachedPagesByOcId[ocId] else {
             return nil
@@ -1159,12 +1273,17 @@ final class NCMediaViewerModel: ObservableObject {
         index: Int
     ) async {
         if metadata.classFile == NKTypeClassFile.image.rawValue {
-            let livePhotoURL: URL?
+            var livePhotoURL: URL?
 
             if metadata.isLivePhoto {
-                livePhotoURL = await loader.downloadLivePhotoMedia(
-                    for: metadata
-                )
+                livePhotoURL = await loader.localLivePhotoURL(for: metadata)
+
+                if livePhotoURL == nil,
+                   loadingPolicy.shouldDownloadLivePhotoResources(for: metadata) {
+                    livePhotoURL = await loader.downloadLivePhotoMedia(
+                        for: metadata
+                    )
+                }
             } else {
                 livePhotoURL = nil
             }
@@ -1317,32 +1436,4 @@ private extension NCMediaViewerPageState {
         }
     }
 
-    var needsSelectedPageLoading: Bool {
-        switch self {
-        case .idle:
-            return true
-
-        case .downloading:
-            return true
-
-        case .image(_, nil, _, _):
-            return true
-
-        case .video(nil, nil):
-            return true
-
-        case .audio:
-            return false
-
-        case .image(_, .some, _, _),
-             .video,
-             .loadingMetadata,
-             .metadataMissing,
-             .checkingLocalFile,
-             .ready,
-             .deleted,
-             .failed:
-            return false
-        }
-    }
 }

--- a/iOSClient/Viewer/NCViewerMedia/Loading/NCNextcloudMediaViewerLoader.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Loading/NCNextcloudMediaViewerLoader.swift
@@ -245,6 +245,14 @@ final class NCMediaViewerLoader: NCMediaViewerLoading, @unchecked Sendable {
         await downloadTaskRegistry.cancelTask(for: ocId)
     }
 
+    func cancelLivePhotoMediaDownload(for metadata: tableMetadata) async {
+        guard let livePhotoMetadata = database.getMetadataLivePhoto(metadata: metadata) else {
+            return
+        }
+
+        await downloadTaskRegistry.cancelTask(for: livePhotoMetadata.ocId)
+    }
+
     func cancelAllDownloads() async {
         await downloadTaskRegistry.cancelAllTasks()
     }
@@ -308,6 +316,8 @@ protocol NCMediaViewerLoading: Sendable {
     func downloadLivePhotoMedia(for metadata: tableMetadata) async -> URL?
 
     func cancelDownload(for ocId: String) async
+
+    func cancelLivePhotoMediaDownload(for metadata: tableMetadata) async
 
     func cancelAllDownloads() async
 }

--- a/iOSClient/Viewer/NCViewerMedia/Loading/NCNextcloudMediaViewerLoader.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Loading/NCNextcloudMediaViewerLoader.swift
@@ -127,10 +127,15 @@ final class NCMediaViewerLoader: NCMediaViewerLoading, @unchecked Sendable {
         return URL(fileURLWithPath: localPath)
     }
 
-    func downloadMedia(for metadata: tableMetadata) async throws -> URL {
+    func downloadMedia(
+        for metadata: tableMetadata,
+        onDownloadStarted: (@Sendable () async -> Void)? = nil
+    ) async throws -> URL {
         if let localURL = await localMediaURL(for: metadata) {
             return localURL
         }
+
+        await onDownloadStarted?()
 
         guard let downloadMetadata = await database.setMetadataSessionInWaitDownloadAsync(
             ocId: metadata.ocId,
@@ -309,7 +314,10 @@ protocol NCMediaViewerLoading: Sendable {
 
     func previewURL(for metadata: tableMetadata, ext: String) async -> URL?
 
-    func downloadMedia(for metadata: tableMetadata) async throws -> URL
+    func downloadMedia(
+        for metadata: tableMetadata,
+        onDownloadStarted: (@Sendable () async -> Void)?
+    ) async throws -> URL
 
     func localLivePhotoURL(for metadata: tableMetadata) async -> URL?
 

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaViewerHostingController.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaViewerHostingController.swift
@@ -18,6 +18,7 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
     private weak var contextMenuController: NCMainTabBarController?
 
     private var detailHostingController: UIHostingController<NCMediaViewerDetailView>?
+    private var detailLoadingTask: Task<Void, Never>?
     private var isShowingDetail = false
     private var cancellables = Set<AnyCancellable>()
     private var transferDelegate: NCMediaViewerTransferDelegate?
@@ -84,6 +85,12 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
         target: self,
         action: #selector(mediaDetailButtonTapped)
     )
+
+    private lazy var mediaDetailActivityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.color = NCBrandColor.shared.iconImageColor
+        return indicator
+    }()
 
     // MARK: - Video Player Menu
 
@@ -287,6 +294,10 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
 
     /// Stops media playback before the viewer is closed.
     private func stop() {
+        detailLoadingTask?.cancel()
+        detailLoadingTask = nil
+        setMediaDetailLoading(false)
+
         // Stop any remaining media playback before releasing the viewer hierarchy.
         // This notification is intentionally global and should only be used for
         // viewer-wide teardown, not for normal page-to-page navigation.
@@ -432,22 +443,52 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
 
     /// Opens or closes the media detail panel.
     private func openDetail(animated: Bool = true) {
-        Task {
-            guard !isShowingDetail else {
-                closeDetail(animated: animated)
+        guard !isShowingDetail else {
+            closeDetail(animated: animated)
+            return
+        }
+
+        guard detailLoadingTask == nil,
+              let selectedMetadata = model.selectedMetadata else {
+            return
+        }
+
+        let selectedOcId = selectedMetadata.ocId
+        let index = model.selectedIndex
+
+        isShowingDetail = true
+        setMediaDetailLoading(true)
+
+        detailLoadingTask = Task { [weak self] in
+            guard let self else {
                 return
             }
 
-            guard var metadata = model.selectedMetadata else {
+            var metadata = await NCNetworking.shared.updateMetadataPlaceholder(
+                selectedMetadata
+            )
+
+            if metadata.classFile == NKTypeClassFile.image.rawValue {
+                _ = try? await self.model.downloadOriginalImage(for: metadata)
+            }
+
+            guard !Task.isCancelled,
+                  self.model.selectedMetadata?.ocId == selectedOcId else {
+                self.finishDetailLoadingWithoutPresentation()
                 return
             }
-            metadata = await NCNetworking.shared.updateMetadataPlaceholder(metadata)
 
-            let index = model.selectedIndex
-            isShowingDetail = true
+            self.detailLoadingTask = nil
+            self.setMediaDetailLoading(false)
 
             NCUtility().getExif(metadata: metadata) { exif in
                 Task { @MainActor in
+                    guard self.isShowingDetail,
+                          self.detailHostingController == nil,
+                          self.model.selectedMetadata?.ocId == selectedOcId else {
+                        return
+                    }
+
                     self.presentDetailView(
                         metadata: metadata,
                         index: index,
@@ -456,6 +497,24 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
                     )
                 }
             }
+        }
+    }
+
+    private func finishDetailLoadingWithoutPresentation() {
+        detailLoadingTask = nil
+        isShowingDetail = false
+        setMediaDetailLoading(false)
+    }
+
+    private func setMediaDetailLoading(_ isLoading: Bool) {
+        if isLoading {
+            mediaDetailActivityIndicator.startAnimating()
+            mediaDetailNavigationItem.customView = mediaDetailActivityIndicator
+            mediaDetailNavigationItem.isEnabled = false
+        } else {
+            mediaDetailActivityIndicator.stopAnimating()
+            mediaDetailNavigationItem.customView = nil
+            mediaDetailNavigationItem.isEnabled = true
         }
     }
 
@@ -490,6 +549,10 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
 
     /// Closes the media detail panel.
     private func closeDetail(animated: Bool = true) {
+        detailLoadingTask?.cancel()
+        detailLoadingTask = nil
+        setMediaDetailLoading(false)
+
         guard let detailHostingController else {
             isShowingDetail = false
             return

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaViewerHostingController.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaViewerHostingController.swift
@@ -455,20 +455,21 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
 
         let selectedOcId = selectedMetadata.ocId
         let index = model.selectedIndex
+        let downloadsOriginal = selectedMetadata.classFile == NKTypeClassFile.image.rawValue
 
         isShowingDetail = true
-        setMediaDetailLoading(true)
+        setMediaDetailLoading(downloadsOriginal)
 
         detailLoadingTask = Task { [weak self] in
             guard let self else {
                 return
             }
 
-            var metadata = await NCNetworking.shared.updateMetadataPlaceholder(
+            let metadata = await NCNetworking.shared.updateMetadataPlaceholder(
                 selectedMetadata
             )
 
-            if metadata.classFile == NKTypeClassFile.image.rawValue {
+            if downloadsOriginal {
                 _ = try? await self.model.downloadOriginalImage(for: metadata)
             }
 

--- a/iOSClient/Viewer/NCViewerMedia/NCMediaViewerHostingController.swift
+++ b/iOSClient/Viewer/NCViewerMedia/NCMediaViewerHostingController.swift
@@ -458,7 +458,6 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
         let downloadsOriginal = selectedMetadata.classFile == NKTypeClassFile.image.rawValue
 
         isShowingDetail = true
-        setMediaDetailLoading(downloadsOriginal)
 
         detailLoadingTask = Task { [weak self] in
             guard let self else {
@@ -470,7 +469,12 @@ final class NCMediaViewerHostingController: UIHostingController<NCMediaViewerVie
             )
 
             if downloadsOriginal {
-                _ = try? await self.model.downloadOriginalImage(for: metadata)
+                _ = try? await self.model.downloadOriginalImage(
+                    for: metadata,
+                    onDownloadStarted: { [weak self] in
+                        self?.setMediaDetailLoading(true)
+                    }
+                )
             }
 
             guard !Task.isCancelled,

--- a/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
+++ b/iOSClient/Viewer/NCViewerMedia/Views/NCMediaViewerPageView.swift
@@ -426,7 +426,23 @@ struct NCMediaViewerPageView: View {
                 topOverlayInset: livePhotoTopOverlayInset,
                 initialZoomState: page.imageZoomState,
                 onZoomChanged: onZoomChanged,
-                onZoomStateChanged: { page.imageZoomState = $0 }
+                onZoomStateChanged: { page.imageZoomState = $0 },
+                requestResources: {
+                    guard let metadata = page.metadata else {
+                        return nil
+                    }
+
+                    return await model.downloadLivePhotoResources(
+                        for: metadata
+                    )
+                },
+                cancelResourceDownload: {
+                    guard let metadata = page.metadata else {
+                        return
+                    }
+
+                    model.cancelLivePhotoResourceDownload(for: metadata)
+                }
             )
             .background(Color.ncViewerBackground(backgroundStyle))
             .contentShape(Rectangle())


### PR DESCRIPTION
Defer original image and Live Photo resource downloads until required, while preserving automatic loading for GIFs, SVGs, and missing previews.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
