### PR TITLE
fix: bound media search and backfill requests

### DIFF
--- a/Brand/Database.swift
+++ b/Brand/Database.swift
@@ -8,4 +8,4 @@ import Foundation
 //
 let databaseName                    = "nextcloud.realm"
 let tableAccountBackup              = "tableAccountBackup.json"
-let databaseSchemaVersion: UInt64   = 413
+let databaseSchemaVersion: UInt64   = 414

--- a/Nextcloud.xcodeproj/project.pbxproj
+++ b/Nextcloud.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2C33C48223E2C475005F963B /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C33C48123E2C475005F963B /* NotificationService.swift */; };
 		2C33C48623E2C475005F963B /* Notification Service Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 2C33C47F23E2C475005F963B /* Notification Service Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		370D26AF248A3D7A00121797 /* NCCellMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D26AE248A3D7A00121797 /* NCCellMain.swift */; };
+		A1B2C3D430B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D330B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift */; };
 		A5A87F9E4B0E4441A6A4BC20 /* NCContextMenuProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7697C94BA14450A0867940 /* NCContextMenuProfile.swift */; };
 		AA3C85E82D36B08C00F74F12 /* UITestBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3C85E72D36B08C00F74F12 /* UITestBackend.swift */; };
 		AA3C85EB2D36BBFB00F74F12 /* OCSResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3C85EA2D36BBF400F74F12 /* OCSResponse.swift */; };
@@ -850,7 +851,6 @@
 		F7CDB5C32FA33CA300F72306 /* NCMediaViewerPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5B92FA33CA300F72306 /* NCMediaViewerPageView.swift */; };
 		F7CDB5C42FA33CA300F72306 /* NCImageViewerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5B62FA33CA300F72306 /* NCImageViewerContentView.swift */; };
 		F7CDB5C52FA33CA300F72306 /* NCMediaViewerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5B82FA33CA300F72306 /* NCMediaViewerModel.swift */; };
-		A1B2C3D430B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D330B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift */; };
 		F7CDB5C62FA33CA300F72306 /* NCMediaViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5BB2FA33CA300F72306 /* NCMediaViewerView.swift */; };
 		F7CDB5CC2FA33CA300F72306 /* NCNextcloudMediaViewerLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5BD2FA33CA300F72306 /* NCNextcloudMediaViewerLoader.swift */; };
 		F7CDB5D32FA3448B00F72306 /* NCAudioViewerContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7CDB5D22FA3448A00F72306 /* NCAudioViewerContentView.swift */; };
@@ -1217,6 +1217,7 @@
 		2C33C48A23E2CC26005F963B /* Notification_Service_Extension-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Notification_Service_Extension-Bridging-Header.h"; sourceTree = "<group>"; };
 		370D26AE248A3D7A00121797 /* NCCellMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCCellMain.swift; sourceTree = "<group>"; };
 		8932E90EC4278026D86CCCC9 /* NCContextMenuComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCContextMenuComment.swift; sourceTree = "<group>"; };
+		A1B2C3D330B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerLoadingPolicy.swift; sourceTree = "<group>"; };
 		AA3C85E72D36B08C00F74F12 /* UITestBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestBackend.swift; sourceTree = "<group>"; };
 		AA3C85EA2D36BBF400F74F12 /* OCSResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCSResponse.swift; sourceTree = "<group>"; };
 		AA3C85ED2D36BCCB00F74F12 /* SharesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharesResponse.swift; sourceTree = "<group>"; };
@@ -1873,7 +1874,6 @@
 		F7CCAB502ECF315F00F8E68B /* NCCollectionViewCommon+SyncMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NCCollectionViewCommon+SyncMetadata.swift"; sourceTree = "<group>"; };
 		F7CDB5B62FA33CA300F72306 /* NCImageViewerContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCImageViewerContentView.swift; sourceTree = "<group>"; };
 		F7CDB5B82FA33CA300F72306 /* NCMediaViewerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerModel.swift; sourceTree = "<group>"; };
-		A1B2C3D330B0000100ABCDEF /* NCMediaViewerLoadingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerLoadingPolicy.swift; sourceTree = "<group>"; };
 		F7CDB5B92FA33CA300F72306 /* NCMediaViewerPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerPageView.swift; sourceTree = "<group>"; };
 		F7CDB5BB2FA33CA300F72306 /* NCMediaViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCMediaViewerView.swift; sourceTree = "<group>"; };
 		F7CDB5BD2FA33CA300F72306 /* NCNextcloudMediaViewerLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NCNextcloudMediaViewerLoader.swift; sourceTree = "<group>"; };
@@ -6347,7 +6347,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = NKUJUXUJ3B;
@@ -6415,7 +6415,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = NKUJUXUJ3B;

--- a/iOSClient/Data/NCManageDatabase+MediaMetadataBackfill.swift
+++ b/iOSClient/Data/NCManageDatabase+MediaMetadataBackfill.swift
@@ -10,6 +10,7 @@ import NextcloudKit
 class tableMediaMetadataBackfill: Object {
     @Persisted(primaryKey: true) var account = ""
     @Persisted var offset = 0
+    @Persisted var cursorDate: Date?
     @Persisted var lastRunDate: Date?
     @Persisted var lastCompletedCycleDate: Date?
 
@@ -36,15 +37,18 @@ extension NCManageDatabase {
     // MARK: - Realm write
 
     func updateMediaMetadataBackfillAsync(account: String,
-                                          offset: Int) async {
+                                          offset: Int,
+                                          cursorDate: Date) async {
         await core.performRealmWriteAsync { realm in
             if let backfill = realm.object(ofType: tableMediaMetadataBackfill.self,
                                            forPrimaryKey: account) {
                 backfill.offset = offset
+                backfill.cursorDate = cursorDate
                 backfill.lastRunDate = Date()
             } else {
                 let backfill = tableMediaMetadataBackfill(account: account)
                 backfill.offset = offset
+                backfill.cursorDate = cursorDate
                 backfill.lastRunDate = Date()
                 realm.add(backfill)
             }
@@ -55,11 +59,13 @@ extension NCManageDatabase {
         await core.performRealmWriteAsync { realm in
             if let backfill = realm.object(ofType: tableMediaMetadataBackfill.self, forPrimaryKey: account) {
                 backfill.offset = 0
+                backfill.cursorDate = nil
                 backfill.lastRunDate = Date()
                 backfill.lastCompletedCycleDate = Date()
             } else {
                 let backfill = tableMediaMetadataBackfill(account: account)
                 backfill.offset = 0
+                backfill.cursorDate = nil
                 backfill.lastRunDate = Date()
                 backfill.lastCompletedCycleDate = Date()
                 realm.add(backfill)

--- a/iOSClient/Media/NCMediaDataSource.swift
+++ b/iOSClient/Media/NCMediaDataSource.swift
@@ -231,8 +231,9 @@ extension NCMedia {
 
         var firstDateNew = Date.distantFuture
         var lastDateNew = Date.distantPast
-        var firstDate: Date?
-        var lastDate: Date?
+        var firstVisibleCellDate: Date?
+        var lastVisibleCellDate: Date?
+        var visibleCellCount = 0
         var visibleCells: [NCMediaCell] = []
 
         await MainActor.run {
@@ -270,8 +271,9 @@ extension NCMedia {
                 return date1 > date2
             }
 
-            firstDate = visibleCells.first?.date
-            lastDate = visibleCells.last?.date
+            firstVisibleCellDate = visibleCells.first?.date
+            lastVisibleCellDate = visibleCells.last?.date
+            visibleCellCount = visibleCells.count
 
             if !visibleCells.isEmpty, !distant {
                 let firstCellDate = visibleCells.first?.date
@@ -324,17 +326,19 @@ extension NCMedia {
         guard !Task.isCancelled,
               self.isViewActived,
               self.session.account == account,
-              let firstDate,
-              let lastDate else {
+              let firstVisibleCellDate,
+              let lastVisibleCellDate else {
             return
         }
 
         // VERIFY MEDIA
         //
-        await self.verifyNetworkMedia(firstDate: firstDate,
-                                      lastDate: lastDate,
+        let verificationLimit = max(visibleCellCount * 3, 300)
+        await self.verifyNetworkMedia(firstDate: firstVisibleCellDate,
+                                      lastDate: lastVisibleCellDate,
                                       mediaPath: tblAccount.mediaPath,
-                                      account: account) {
+                                      account: account,
+                                      limit: verificationLimit) {
             Task { [weak self] in
                 guard let self else {
                     return
@@ -409,6 +413,7 @@ extension NCMedia {
                                      lastDate: Date,
                                      mediaPath: String,
                                      account: String,
+                                     limit: Int,
                                      update: @escaping () -> Void,
                                      finish: @escaping () -> Void) async {
         await NCMediaNetwork().searchMediaPage(
@@ -417,7 +422,7 @@ extension NCMedia {
             lastDate: lastDate,
             account: account,
             paginate: true,
-            limit: 1000000) { task in
+            limit: limit) { task in
                 Task {
                     let identifier = await NCNetworking.shared.networkingTasks.createIdentifier(
                         account: account,

--- a/iOSClient/Media/NCMediaDataSource.swift
+++ b/iOSClient/Media/NCMediaDataSource.swift
@@ -233,7 +233,6 @@ extension NCMedia {
         var lastDateNew = Date.distantPast
         var firstVisibleCellDate: Date?
         var lastVisibleCellDate: Date?
-        var visibleCellCount = 0
         var visibleCells: [NCMediaCell] = []
 
         await MainActor.run {
@@ -273,7 +272,6 @@ extension NCMedia {
 
             firstVisibleCellDate = visibleCells.first?.date
             lastVisibleCellDate = visibleCells.last?.date
-            visibleCellCount = visibleCells.count
 
             if !visibleCells.isEmpty, !distant {
                 let firstCellDate = visibleCells.first?.date
@@ -333,7 +331,8 @@ extension NCMedia {
 
         // VERIFY MEDIA
         //
-        let verificationLimit = max(visibleCellCount * 3, 300)
+        // Nextcloud cannot range-filter displayname, so same-date results are bounded by this cap.
+        let verificationLimit = 1000
         await self.verifyNetworkMedia(firstDate: firstVisibleCellDate,
                                       lastDate: lastVisibleCellDate,
                                       mediaPath: tblAccount.mediaPath,

--- a/iOSClient/Processor/NCMediaMetadataBackfillProcessor.swift
+++ b/iOSClient/Processor/NCMediaMetadataBackfillProcessor.swift
@@ -4,15 +4,19 @@
 
 import Foundation
 import NextcloudKit
+import os
 
 /// Incrementally scans the remote media archive and creates missing local metadata placeholders.
 ///
-/// The current offset is persisted so interrupted executions can resume later.
+/// The oldest date processed in a bounded result batch is persisted so later executions can resume.
 /// Once the archive has been fully processed, subsequent executions are skipped.
 final class NCMediaMetadataBackfillProcessor {
+    private let pagesPerBatch = 4
+
     /// Represents the result of a media metadata backfill execution.
     enum BackfillStatus {
         case skippedAlreadyCompleted(account: String)
+        case batchCompleted(account: String, processed: Int, inserted: Int, updated: Int, cursorDate: Date)
         case completed(account: String, processed: Int, inserted: Int, updated: Int)
         case failed(account: String, processed: Int, inserted: Int, updated: Int, errorCode: Int, errorDescription: String)
         case cancelled(account: String, processed: Int, inserted: Int, updated: Int)
@@ -20,7 +24,7 @@ final class NCMediaMetadataBackfillProcessor {
         /// Returns whether the backfill completed successfully or was already completed.
         var isSuccessful: Bool {
             switch self {
-            case .skippedAlreadyCompleted, .completed:
+            case .skippedAlreadyCompleted, .batchCompleted, .completed:
                 return true
             case .failed, .cancelled:
                 return false
@@ -32,6 +36,9 @@ final class NCMediaMetadataBackfillProcessor {
             switch self {
             case .skippedAlreadyCompleted(let account):
                 return "Media metadata backfill skipped for account \(account): cycle already completed"
+
+            case .batchCompleted(let account, let processed, let inserted, let updated, let cursorDate):
+                return "Media metadata backfill batch completed for account \(account): processed \(processed) - inserted \(inserted) - updated \(updated) - cursor date \(cursorDate)"
 
             case .completed(let account, let processed, let inserted, let updated):
                 return "Media metadata backfill completed for account \(account): processed \(processed) - inserted \(inserted) - updated \(updated)"
@@ -45,9 +52,11 @@ final class NCMediaMetadataBackfillProcessor {
         }
     }
 
-    /// Processes the remote media archive page by page and creates missing metadata placeholders.
+    /// Processes one bounded batch of the remote media archive and creates missing metadata placeholders.
     ///
-    /// An interrupted cycle resumes immediately from the stored offset.
+    /// Each completed page checkpoints its oldest date after placeholder synchronization.
+    /// An interrupted page is safely retried because placeholder synchronization is idempotent.
+    /// A full batch persists its oldest date so the next execution can continue from that boundary.
     /// A completed cycle starts again after the configured interval.
     func runBackfill(
         account: tableAccount,
@@ -57,25 +66,49 @@ final class NCMediaMetadataBackfillProcessor {
         let database = NCManageDatabase.shared
         let state = await database.getMediaMetadataBackfillAsync(account: account.account)
         let cycleInterval: TimeInterval = 7 * 24 * 60 * 60 // week
-        var offset = state?.offset ?? 0
+        let previousCursorDate = state?.cursorDate
+        let firstDate = previousCursorDate ?? .distantFuture
+        let previouslyProcessed = previousCursorDate == nil ? 0 : state?.offset ?? 0
+        var pageOffset = 0
         var token: String?
         var processed = 0
         var inserted = 0
         var updated = 0
+        var oldestProcessedDate: Date?
+
+        guard limit > 0 else {
+            return .failed(
+                account: account.account,
+                processed: 0,
+                inserted: 0,
+                updated: 0,
+                errorCode: NCGlobal.shared.errorPreconditionFailed,
+                errorDescription: "Invalid media metadata backfill page size: \(limit)"
+            )
+        }
+
+        let searchResultLimit = limit * pagesPerBatch
 
         if state?.offset == 0,
+           state?.cursorDate == nil,
            let lastCompletedCycleDate = state?.lastCompletedCycleDate,
            Date().timeIntervalSince(lastCompletedCycleDate) < cycleInterval {
             return .skippedAlreadyCompleted(account: account.account)
         }
 
-        while !Task.isCancelled {
+        for _ in 0..<pagesPerBatch {
+            guard !Task.isCancelled else {
+                return .cancelled(account: account.account, processed: processed, inserted: inserted, updated: updated)
+            }
+
             let result = await runSearch(
                 mediaPath: account.mediaPath,
                 account: account.account,
-                offset: offset,
+                firstDate: firstDate,
+                offset: pageOffset,
                 token: token,
-                count: limit
+                count: limit,
+                searchResultLimit: searchResultLimit
             )
 
             guard !Task.isCancelled else {
@@ -101,31 +134,49 @@ final class NCMediaMetadataBackfillProcessor {
                 return .completed(account: account.account, processed: processed, inserted: inserted, updated: updated)
             }
 
-            let ocIds = files.compactMap(\.ocId)
+            // Keep hidden files in the raw page count and cursor calculation because
+            // Nextcloud applies pagination before NextcloudKit filters them locally.
+            let visibleFiles = files.filter { !isHiddenFile($0) }
+            let ocIds = visibleFiles.map(\.ocId)
             let metadatas = await database.getMetadatasFromOcIdsAsync(ocIds)
 
             let resultPlaceholders = await database.syncPlaceholderMetadatasAsync(
-                files: files,
+                files: visibleFiles,
                 metadatas: metadatas
             )
 
             processed += files.count
             inserted += resultPlaceholders.inserted
             updated += resultPlaceholders.updated
-            offset += files.count
+            pageOffset += files.count
 
-            await update(offset, resultPlaceholders.inserted, resultPlaceholders.updated)
+            if let pageOldestDate = files.map(\.date).min() {
+                oldestProcessedDate = min(oldestProcessedDate ?? pageOldestDate, pageOldestDate)
+            }
+
+            if let checkpointDate = oldestProcessedDate,
+               previousCursorDate.map({ checkpointDate < $0 }) ?? true {
+                await database.updateMediaMetadataBackfillAsync(
+                    account: account.account,
+                    offset: previouslyProcessed + processed,
+                    cursorDate: checkpointDate
+                )
+            }
+
+            await update(previouslyProcessed + processed,
+                         resultPlaceholders.inserted,
+                         resultPlaceholders.updated)
 
             guard !Task.isCancelled else {
                 return .cancelled(account: account.account, processed: processed, inserted: inserted, updated: updated)
             }
 
-            await database.updateMediaMetadataBackfillAsync(
-                account: account.account,
-                offset: offset
-            )
+            if pageOffset >= searchResultLimit {
+                break
+            }
 
-            guard files.count == limit else {
+            if pageOffset < searchResultLimit,
+               (!result.paginate || files.count < limit) {
                 await database.completeMediaMetadataBackfillAsync(account: account.account)
                 return .completed(account: account.account, processed: processed, inserted: inserted, updated: updated)
             }
@@ -133,20 +184,59 @@ final class NCMediaMetadataBackfillProcessor {
             token = result.token
         }
 
-        return .cancelled(account: account.account, processed: processed, inserted: inserted, updated: updated)
+        guard let cursorDate = oldestProcessedDate else {
+            await database.completeMediaMetadataBackfillAsync(account: account.account)
+            return .completed(account: account.account, processed: processed, inserted: inserted, updated: updated)
+        }
+
+        if let previousCursorDate,
+           cursorDate >= previousCursorDate {
+            return .failed(
+                account: account.account,
+                processed: processed,
+                inserted: inserted,
+                updated: updated,
+                errorCode: NCGlobal.shared.errorPreconditionFailed,
+                errorDescription: "Media metadata backfill cursor did not advance beyond \(previousCursorDate)"
+            )
+        }
+
+        await database.updateMediaMetadataBackfillAsync(
+            account: account.account,
+            offset: previouslyProcessed + processed,
+            cursorDate: cursorDate
+        )
+
+        return .batchCompleted(
+            account: account.account,
+            processed: processed,
+            inserted: inserted,
+            updated: updated,
+            cursorDate: cursorDate
+        )
+    }
+
+    /// Mirrors NextcloudKit's hidden-path filtering without changing the raw paginated result count.
+    private func isHiddenFile(_ file: NKFile) -> Bool {
+        let pathComponents = (file.path as NSString).pathComponents + [file.fileName]
+        return pathComponents.contains { $0.hasPrefix(".") }
     }
 
     /// Executes a single paginated media search and handles task cancellation.
     private func runSearch(mediaPath: String,
                            account: String,
+                           firstDate: Date,
                            offset: Int,
                            token: String? = nil,
-                           count: Int) async -> (files: [NKFile]?, token: String?, paginate: Bool, error: NKError?) {
+                           count: Int,
+                           searchResultLimit: Int) async -> (files: [NKFile]?, token: String?, paginate: Bool, error: NKError?) {
         let result = await fetchMediaPage(path: mediaPath,
                                           account: account,
+                                          firstDate: firstDate,
                                           offset: offset,
                                           token: token,
-                                          count: count)
+                                          count: count,
+                                          searchResultLimit: searchResultLimit)
 
         guard !Task.isCancelled else {
             return (nil, nil, false, NKError(errorCode: NCGlobal.shared.errorTaskCancelled, errorDescription: "Task cancelled for account: \(account)"))
@@ -158,9 +248,11 @@ final class NCMediaMetadataBackfillProcessor {
     /// Fetches a page of media files from the server using offset and token pagination.
     private func fetchMediaPage(path: String,
                                 account: String,
+                                firstDate: Date,
                                 offset: Int,
                                 token: String? = nil,
-                                count: Int) async -> (files: [NKFile]?, token: String?, paginate: Bool, error: NKError) {
+                                count: Int,
+                                searchResultLimit: Int) async -> (files: [NKFile]?, token: String?, paginate: Bool, error: NKError) {
         guard let nkSession = NextcloudKit.shared.nkCommonInstance.nksessions.session(forAccount: account) else {
             return (nil, nil, false, NKError(errorCode: NCGlobal.shared.errorNCSessionNotFound, errorDescription: "Session not found for account: \(account)"))
         }
@@ -168,14 +260,14 @@ final class NCMediaMetadataBackfillProcessor {
         let href = "/files/" + nkSession.userId + path
 
         let elementDate = "d:" + NCGlobal.shared.mediaPropOrder
-        let lessDateString = Date.distantFuture.formatted(using: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
+        let lessDateString = firstDate.formatted(using: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
         let greaterDateString = Date.distantPast.formatted(using: "yyyy-MM-dd'T'HH:mm:ssZZZZZ")
         let httpBodyString = String(format: NCMediaNetwork().getRequestBodySearchMedia(
             href: href,
             elementDate: elementDate,
             lessDate: lessDateString,
             greaterDate: greaterDateString,
-            limit: String(1000000))
+            limit: String(searchResultLimit))
         )
 
         guard let httpBody = httpBodyString.data(using: .utf8) else {
@@ -189,7 +281,39 @@ final class NCMediaMetadataBackfillProcessor {
                                        paginateOffset: offset,
                                        paginateCount: count)
 
-        let results = await NextcloudKit.shared.searchAsync(serverUrl: nkSession.urlBase, httpBody: httpBody, showHiddenFiles: false, includeHiddenFiles: [], account: account, options: options)
+        let requestState = OSAllocatedUnfairLock(
+            initialState: (task: Optional<URLSessionTask>.none, isCancelled: false)
+        )
+        let results = await withTaskCancellationHandler {
+            await NextcloudKit.shared.searchAsync(
+                serverUrl: nkSession.urlBase,
+                httpBody: httpBody,
+                showHiddenFiles: true,
+                includeHiddenFiles: [],
+                account: account,
+                options: options
+            ) { task in
+                let shouldCancel = requestState.withLock { state in
+                    if state.isCancelled {
+                        return true
+                    }
+
+                    state.task = task
+                    return false
+                }
+
+                if shouldCancel {
+                    task.cancel()
+                }
+            }
+        } onCancel: {
+            let task = requestState.withLock { state in
+                state.isCancelled = true
+                return state.task
+            }
+            task?.cancel()
+        }
+
         if results.error == .success, let files = results.files {
             let allHeaderFields = results.responseData?.response?.allHeaderFields
             var token: String?


### PR DESCRIPTION
## Summary

Fixes #4255 by replacing effectively unbounded media WebDAV searches with bounded requests.

This PR introduces two changes:

- Media verification now uses a fixed search limit of 1,000 results.
- Media metadata backfill now processes bounded batches of up to 1,000 results, split into four pages of 250.

## Backfill behavior

- Persists the oldest successfully processed date as a Realm cursor.
- Checkpoints progress after every completed page.
- Resumes from the saved date during the next background task.
- Restarts safely from the beginning when migrating an incomplete legacy offset.
- Cancels the underlying HTTP request when the background task expires.
- Preserves correct pagination when hidden files are present.
- Detects a non-advancing date cursor and stops instead of looping indefinitely.
- Bumps the Realm schema version to 414.

## Known limitation

Nextcloud WebDAV SEARCH supports sorting by displayname, but does not support range comparisons such as lte for that field. Pagination therefore cannot use a composite date-and-filename cursor.

If at least 1,000 media items share the exact same cursor date, the backfill stops safely instead of entering an infinite loop. A future background task may encounter the same boundary again, but existing items remain protected by ocId deduplication.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
