### PR TITLE
fix: open custom unified search file results

### DIFF
--- a/iOSClient/Main/Collection Common/NCCollectionViewCommon+Search.swift
+++ b/iOSClient/Main/Collection Common/NCCollectionViewCommon+Search.swift
@@ -283,6 +283,21 @@ extension NCCollectionViewCommon {
 
         default:
             for entry in searchResult.entries {
+                if let fileId = entry.fileId,
+                   let metadata = database.getMetadataFromFileId(String(fileId)) {
+                    metadata.section = provider.name
+                    metadatas.append(metadata)
+                    continue
+                }
+
+                if let filePath = entry.filePath,
+                   let metadata = await loadMetadata(session: session,
+                                                     provider: provider,
+                                                     filePath: filePath) {
+                    metadatas.append(metadata)
+                    continue
+                }
+
                 let metadata = await NCManageDatabaseCreateMetadata().createMetadataAsync(
                     fileName: entry.title,
                     ocId: NSUUID().uuidString,


### PR DESCRIPTION
## Summary

- Resolve custom unified search entries with `fileId` or `path` attributes to native Nextcloud file metadata.
- Keep the existing URL fallback for results that do not refer to a Nextcloud file.
- Preserve the existing behaviour of the built-in `files` and `fulltextsearch` providers.

## Reasoning

Nextcloud iOS currently creates temporary URL metadata for every result from a custom unified search provider, even when the entry exposes the standard `fileId` and `path` attributes. Selecting that temporary item exits silently because its random `ocId` is not present in Realm.

Resolving those attributes before creating the URL fallback makes file-backed results use the regular native file metadata and viewer. It also gives them their actual file type and preview instead of a generic URL icon.

Closes #4274.

## Testing

- Reproduced with Nextcloud iOS 34.1.4 against an isolated Nextcloud 33.0.8 instance and a minimal custom search provider.
- Confirmed that the provider response contains a readable file ID and user-relative path.
- Ran `git diff --check`.
- Parsed the changed Swift source with `xcrun swiftc -frontend -parse`.
- A full Xcode build was not available locally; the project CI will perform the supported simulator build and test suite.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
