### PR TITLE
fix: size the account settings avatar to the window, not the device screen

### DIFF
--- a/iOSClient/Account/Account Settings/NCAccountSettingsView.swift
+++ b/iOSClient/Account/Account Settings/NCAccountSettingsView.swift
@@ -36,7 +36,8 @@ struct NCAccountSettingsView: View {
                                 Image(uiImage: avatar)
                                     .resizable()
                                     .scaledToFit()
-                                    .frame(width: UIScreen.main.bounds.width, height: 65)
+                                    .frame(height: 65)
+                                    .frame(maxWidth: .infinity)
                                 if let statusImage = status.statusImage {
                                     ZStack {
                                         Circle()


### PR DESCRIPTION
### The problem

`NCAccountSettingsView` is presented as a page sheet from `NCFilesNavigationController`:

```swift
let accountSettingsController = UIHostingController(rootView: accountSettingsView)
self.present(accountSettingsController, animated: true, completion: nil)
```

The width available to the view is therefore the sheet's, not the display's. The avatar is framed at the display's width:

```swift
Image(uiImage: avatar)
    .resizable()
    .scaledToFit()
    .frame(width: UIScreen.main.bounds.width, height: 65)
```

So the row asks for a child wider than its container in every presentation narrower than the screen: a page sheet on iPad, where `UIScreen.main.bounds.width` is 1024pt or more against a sheet of roughly 700pt, and equally in Split View, Slide Over and Stage Manager. `.scaledToFit()` keeps the picture 65pt tall, but the frame that participates in the `Form` and `TabView` layout is still display-wide.

### The change

Constrain the height, then let the width fill what the parent offers:

```swift
.frame(height: 65)
.frame(maxWidth: .infinity)
```

Same intent, one line longer, and correct at any window size. `UIScreen.main` is also deprecated in iOS 27, where layout is expected to follow the scene rather than the device, so this removes one of the reads that will need revisiting anyway.

### What I verified, and what I did not

I could not build the app: it needs Xcode 26.1 and a `GoogleService-Info.plist`, and I have neither on this machine. So I have not photographed the symptom inside Nextcloud, and I am not claiming a specific visual defect.

What I did check is the layout behaviour the change relies on, rendered offscreen with `ImageRenderer` outside the project: a child frame fixed at 1024pt inside a 500pt container overflows it on both sides, while `maxWidth: .infinity` fits and stays centred. A reviewer can confirm the real thing in a second by opening account settings on an iPad or in Split View.

I found no existing issue about this, and I did not open one, because their bug report template asks for a reproduction and environment data I would have had to invent.

### 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

The commit carries an `Assisted-by` trailer as the organisation policy requires. The reasoning, the choice of fix and the sign-off are mine.
