### PR TITLE
fix(auto-upload): reduce JPEG compression quality to 0.85

### DIFF
--- a/iOSClient/Utility/NCCameraRoll.swift
+++ b/iOSClient/Utility/NCCameraRoll.swift
@@ -345,7 +345,7 @@ final class NCCameraRoll: CameraRollExtractor {
                   let jpegData = CIContext().jpegRepresentation(
                     of: ciImage,
                     colorSpace: colorSpace,
-                    options: [compressionQuality: 1.0]
+                    options: [compressionQuality: 0.85]
                   )
             else {
                 throw NSError(domain: "ExtractAssetError", code: 3, userInfo: [NSLocalizedDescriptionKey: "JPEG conversion failed"])


### PR DESCRIPTION
Quality 1.0 forces an inefficient encode and re-encodes the source HEIC's compression artifacts, roughly tripling the resulting file size with no visible gain.

Fixes #4287



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

### Testing

Not built locally — no macOS machine available. Relying on CI.

The value 0.85 is a conservative pick; Apple's guidance suggests ~0.8 for
re-encodes of already-compressed sources:
https://developer.apple.com/forums/thread/793946

Scope: this is meant as a minimal fix so the regression stops shipping.
Happy to adjust the value if you'd prefer a different one. A user-facing
setting next to the compatibility-mode toggle would be a good follow-up,
but I'd rather leave that to a separate PR than expand this one.

### Note on the AI Usage

The one-line edit was made by hand. AI assistance was used for research —
locating the regression via `git blame` — and for drafting the issue and
commit text.